### PR TITLE
mini gui update

### DIFF
--- a/config/GlobalSettingsSetup.xml
+++ b/config/GlobalSettingsSetup.xml
@@ -36,6 +36,7 @@
 	<!-- TODO: save the user settings in the game settings and not the save game dir.-->
 	<SettingSubTitle prefix="true" title="userSettings">
 		<Setting classType="AIParameterBooleanSetting" name="controllerHudSelected" defaultBool="false" onChangeCallback="onHudSelectionChanged" isUserSetting="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="openHudWithMouse" defaultBool="false" onChangeCallback="onHudSelectionChanged" isUserSetting="true"/>
 	</SettingSubTitle>
 	<SettingSubTitle prefix="true" title="pathfinder">
 		<Setting classType="AIParameterSettingList" name="maxDeltaAngleAtGoal" min="5" max="90" incremental="5" default="45"/>

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -21,9 +21,6 @@
 			</Texts>
 		</Setting>
 		<!--Stop At End-->
-		<Setting classType="AIParameterBooleanSetting" name="openHudWithMouse" defaultBool="true" onChangeCallback="cpUpdateMouseAction"/>
-
-		<!--Stop At End-->
 		<Setting classType="AIParameterBooleanSetting" name="stopAtEnd" defaultBool="true"/>
 		<!--Turn on Field-->
 		<Setting classType="AIParameterBooleanSetting" name="turnOnField" defaultBool="true"/>
@@ -96,9 +93,9 @@
 		<!--Convoy (still needed? even if on on single course, will have no effect)-->
 		<Setting classType="AIParameterBooleanSetting" name="convoyActive"/>
 		<!--Min Distance-->
-		<Setting classType="AIParameterSettingList" name="convoyMinDistance" min="20" max="200" unit="2"/>
+		<Setting classType="AIParameterSettingList" name="convoyMinDistance" min="10" max="200" unit="2"/>
 		<!--Max Distance-->
-		<Setting classType="AIParameterSettingList" name="convoyMaxDistance" min="100" max="300" unit="2"/>
+		<Setting classType="AIParameterSettingList" name="convoyMaxDistance" min="40" max="300" unit="2"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="speed">


### PR DESCRIPTION
Short Summary what I changed

Moved: 'openHudWithMouse' to global settings, as imo this is a global setting and not vehicle depended.


CpHud.lua:
CpHud:onRegisterActionEvents:
	removed: 'if g_Courseplay.globalSettings.controllerHudSelected:getValue() then return end', 
		you still want to use the mouse if mini hud is active in settings.
	Used the global openHudWithMouse setting to register events


Split CpHud:actionEventMouse() into 2 funcs (openCpHud) to use it even when CP_TOGGLE_MOUSE never fires due other mods


getCpHud()
	Added check if active, prevents mouse actions when not active

onUpdateTick()
	Added opening hud when mouse is active and global settings==true (when CP_TOGGLE_MOUSE never fires due other mods)


Changed: Vehicle depended isHudActive instead of on/off for every vehicle


*This changes are all working with and without AD, I did it all by my knowledge as I am no programmer and still learning ;)