### PR TITLE
Field scanner improvements #837

### DIFF
--- a/scripts/DevHelper.lua
+++ b/scripts/DevHelper.lua
@@ -160,11 +160,11 @@ function DevHelper:keyEvent(unicode, sym, modifier, isDown)
         DevHelper.restoreVehiclePosition(g_currentMission.controlledVehicle)
     elseif bitAND(modifier, Input.MOD_LALT) ~= 0 and isDown and sym == Input.KEY_c then
         self:debug('Finding contour of current field')
-        local points = g_fieldScanner:findContour(self.data.x, self.data.z)
         local fieldId = CpFieldUtil.getFieldIdAtWorldPosition(self.data.x, self.data.z)
     elseif bitAND(modifier, Input.MOD_LALT) ~= 0 and isDown and sym == Input.KEY_g then
+        local valid, points = g_fieldScanner:findContour(self.data.x, self.data.z)
         self:debug('Generate course')
-        local status, ok, course = CourseGeneratorInterface.generate(g_fieldScanner:findContour(self.data.x, self.data.z),
+        local status, ok, course = CourseGeneratorInterface.generate(points,
                 {x = self.data.x, z = self.data.z},
                 0, 6, 6, 1, true)
         if ok then

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1424,13 +1424,13 @@ function AIDriveStrategyCombineCourse:findBestTrailer()
 end
 
 function AIDriveStrategyCombineCourse:getClosestDistanceToFieldEdge(x, z)
-	local closestDistance = math.huge
+	local closestDistance= math.huge
 	local fieldPolygon = self.course:getFieldPolygon()
 	-- TODO: this should either be saved with the field or regenerated when the course is loaded...
 	if fieldPolygon == nil then
 		self:debug('Field polygon not found, regenerating it.')
 		local vx, _, vz = getWorldTranslation(self.vehicle.rootNode)
-		fieldPolygon = g_fieldScanner:findContour(vx, vz)
+		_, fieldPolygon = g_fieldScanner:findContour(vx, vz)
 		self.course:setFieldPolygon(fieldPolygon)
 	end
 	for _, p in ipairs(fieldPolygon) do

--- a/scripts/ai/jobs/AIJobFieldWorkCp.lua
+++ b/scripts/ai/jobs/AIJobFieldWorkCp.lua
@@ -92,16 +92,14 @@ function AIJobFieldWorkCp:validate(farmId)
 		return isValid, errorMessage
 	else
 		self.lastPositionX, self.lastPositionZ = tx, tz
-		self.hasValidPosition = true
 	end
 	self.customField = nil
 	local fieldNum = CpFieldUtil.getFieldIdAtWorldPosition(tx, tz)
 	CpUtil.infoVehicle(vehicle,'Scanning field %d on %s', fieldNum, g_currentMission.missionInfo.mapTitle)
-	self.fieldPolygon = g_fieldScanner:findContour(tx, tz)
-	if not self.fieldPolygon then
+	self.hasValidPosition, self.fieldPolygon = g_fieldScanner:findContour(tx, tz)
+	if not self.hasValidPosition then
 		local customField = g_customFieldManager:getCustomField(tx, tz)
 		if not customField then
-			self.hasValidPosition = false
 			self.selectedFieldPlot:setVisible(false)
 			return false, g_i18n:getText("CP_error_not_on_field")
 		else
@@ -109,6 +107,7 @@ function AIJobFieldWorkCp:validate(farmId)
 			self.fieldPolygon = customField:getVertices()
 			self.customField = customField
 			vehicle:getCourseGeneratorSettings().islandBypassMode:setValue(Island.BYPASS_MODE_NONE)
+			self.hasValidPosition = true
 		end
 	end
 	if self.fieldPolygon then

--- a/scripts/field/CpFieldUtil.lua
+++ b/scripts/field/CpFieldUtil.lua
@@ -81,20 +81,24 @@ function CpFieldUtil.saveAllFields()
     local xmlFile = createXMLFile("cpFields", fileName, "CPFields");
     if xmlFile and xmlFile ~= 0 then
         for _, field in pairs(g_fieldManager:getFields()) do
-            local key = ("CPFields.field(%d)"):format(field.fieldId);
-            setXMLInt(xmlFile, key .. '#fieldNum',	field.fieldId);
-            local points = g_fieldScanner:findContour(field.posX, field.posZ)
-            setXMLInt(xmlFile, key .. '#numPoints', #points);
-            for i,point in ipairs(points) do
-                setXMLString(xmlFile, key .. (".point%d#pos"):format(i), ("%.2f %.2f %.2f"):format(point.x, point.y, point.z))
-            end;
-
+            local valid, points = g_fieldScanner:findContour(field.posX, field.posZ)
+            if valid then
+                local key = ("CPFields.field(%d)"):format(field.fieldId);
+                setXMLInt(xmlFile, key .. '#fieldNum',	field.fieldId);
+                setXMLInt(xmlFile, key .. '#numPoints', #points);
+                for i,point in ipairs(points) do
+                    setXMLString(xmlFile, key .. (".point%d#pos"):format(i), ("%.2f %.2f %.2f"):format(point.x, point.y, point.z))
+                end
+                CpUtil.info('Field %d saved', field.fieldId)
+            else
+                CpUtil.info('Field %d could not be saved', field.fieldId)
+            end
         end
         saveXMLFile(xmlFile);
         delete(xmlFile);
         print(string.format('Saved all fields to %s', fileName))
     else
-        print("Error: Courseplay's custom fields could not be saved to " .. CpManager.cpCoursesFolderPath);
+        print("Error: field could not be saved to " .. CpManager.cpCoursesFolderPath);
     end;
 end
 


### PR DESCRIPTION
Should more gracefully handle maps with fields too close together
- scanner detects if it is lost and handles it gracefully
- if lost, retries scanning with field ID limited to the field ID at
the start position selected
- even if lost, can still save all fields with console command cpSaveAllFields (#812)