### PR TITLE
Last row width

### DIFF
--- a/scripts/courseGenerator/Island.lua
+++ b/scripts/courseGenerator/Island.lua
@@ -82,7 +82,7 @@ local function generateGridForPolygon( polygon, gridSpacingHint )
 	-- for this limit, use a fraction to reduce the chance of ending up right on the field edge (assuming fields
 	-- are drawn using integer sizes) as that may result in a row or two missing in the grid
 	local gridSpacing = gridSpacingHint or math.max( 4.071, math.sqrt( polygon.area ) / 64 )
-	local horizontalLines = generateParallelTracks( polygon, {}, gridSpacing, gridSpacing / 2 )
+	local horizontalLines = CourseGenerator.generateParallelTracks( polygon, {}, gridSpacing, gridSpacing / 2 )
 	if not horizontalLines then return grid end
 	-- we'll need this when trying to find the array index from the
 	-- grid coordinates. All of these lines are the same length and start

--- a/scripts/courseGenerator/geo.lua
+++ b/scripts/courseGenerator/geo.lua
@@ -38,7 +38,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 --                  length of edges pointing in that range
 
 -- TODO: make point a real class
-function pointToString(p)
+local function pointToString(p)
 	local fromAngle, toAngle = 'N/A', 'N/A'
 	if p.nextEdge then
 		toAngle = string.format('%.1f', math.deg(p.nextEdge.angle))

--- a/scripts/courseGenerator/headland.lua
+++ b/scripts/courseGenerator/headland.lua
@@ -502,7 +502,7 @@ function generateTwoSideHeadlands( polygon, islands, implementWidth, headlandSet
 
 	local bestAngle, nTracks, nBlocks, resultIsOk
 	-- Now, determine the angle where the number of tracks is the minimum
-	bestAngle, nTracks, nBlocks, resultIsOk = findBestTrackAngle( boundary, translatedIslands, implementWidth, 0, centerSettings )
+	bestAngle, nTracks, nBlocks, resultIsOk = CourseGenerator.findBestTrackAngle( boundary, translatedIslands, implementWidth, 0, centerSettings )
 	if nBlocks < 1 then
 		CourseGenerator.debug( "No room for up/down rows." )
 		return nil, 0, 0, nil, true
@@ -518,7 +518,7 @@ function generateTwoSideHeadlands( polygon, islands, implementWidth, headlandSet
 	local rotatedIslands = Island.rotateAll( translatedIslands, math.rad( bestAngle ))
 	-- use a distanceFromBoundary > 0 to avoid problems with rectangular fields with not
 	-- perfectly straight sides
-	local parallelTracks = generateParallelTracks( boundary, rotatedIslands, implementWidth, implementWidth / 2 )
+	local parallelTracks = CourseGenerator.generateParallelTracks( boundary, rotatedIslands, implementWidth, implementWidth / 2 )
 
 	local startTrack, endTrack = 1, #parallelTracks
 

--- a/scripts/courseGenerator/track.lua
+++ b/scripts/courseGenerator/track.lua
@@ -145,8 +145,8 @@ function generateCourseForField( field, implementWidth, headlandSettings,
 
 		linkHeadlandTracks( field, implementWidth, headlandSettings.isClockwise, headlandSettings.startLocation, doSmooth, minSmoothAngle, maxSmoothAngle )
 
-		field.track, field.bestAngle, field.nTracks, field.blocks, resultIsOk = generateTracks( field.headlandTracks, field.bigIslands,
-			implementWidth, headlandSettings.nPasses, centerSettings )
+		field.track, field.bestAngle, field.nTracks, field.blocks, resultIsOk = CourseGenerator.generateFieldCenter(
+			field.headlandTracks, field.bigIslands, implementWidth, headlandSettings, centerSettings )
 	elseif headlandSettings.mode == CourseGenerator.HEADLAND_MODE_NONE then
 		-- no headland pass wanted, still generate a dummy one on the field boundary so
 		-- we have something to work with when generating the up/down tracks
@@ -154,8 +154,8 @@ function generateCourseForField( field, implementWidth, headlandSettings,
 				field.boundary.isClockwise, 0, minDistanceBetweenPoints, minSmoothAngle, maxSmoothAngle,
 				0, doSmooth, not fromInside, nil, nil)
 		linkHeadlandTracks( field, implementWidth, headlandSettings.isClockwise, headlandSettings.startLocation, doSmooth, minSmoothAngle, maxSmoothAngle )
-		field.track, field.bestAngle, field.nTracks, field.blocks, resultIsOk = generateTracks( field.headlandTracks, field.bigIslands,
-			implementWidth, 0, centerSettings )
+		field.track, field.bestAngle, field.nTracks, field.blocks, resultIsOk = CourseGenerator.generateFieldCenter(
+			field.headlandTracks, field.bigIslands, implementWidth, headlandSettings, centerSettings )
 	elseif headlandSettings.mode == CourseGenerator.HEADLAND_MODE_TWO_SIDE then
 		-- force headland corners
 		headlandSettings.minHeadlandTurnAngleDeg = 60
@@ -163,8 +163,8 @@ function generateCourseForField( field, implementWidth, headlandSettings,
 		local boundary
 		field.headlandPath, boundary = generateTwoSideHeadlands( field.boundary, field.bigIslands,
 			implementWidth, headlandSettings, centerSettings, minDistanceBetweenPoints, minSmoothAngle, maxSmoothAngle)
-		field.track, field.bestAngle, field.nTracks, field.blocks, resultIsOk = generateTracks({ boundary }, field.bigIslands,
-			implementWidth, 0, centerSettings )
+		field.track, field.bestAngle, field.nTracks, field.blocks, resultIsOk = CourseGenerator.generateFieldCenter(
+			{ boundary }, field.bigIslands, implementWidth, headlandSettings, centerSettings )
 	end
 	CourseGenerator.debug("####### COURSE GENERATOR END ###########################################################")
 


### PR DESCRIPTION
If there are headlands, make the last row overlap with the
headland, and not as before, overlapping the second last row.

This hopefully will prevent collisions in this case when there
are multiple vehicles on the course, there's little chance that
one is working on the last row while another on the headland.