### PR TITLE
Turn ending fix

### DIFF
--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -192,13 +192,6 @@ function AIUtil.getTurningRadius(vehicle)
 		CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  turnRadius set from config file to %.1f', radius)
 	end
 
-	-- TODO_22
-	--local turnDiameterSetting = vehicle.cp.settings.turnDiameter
-	--if not turnDiameterSetting:isAutomaticActive() then
-	--	radius = turnDiameterSetting:get() / 2
-	--	CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  turnRadius manually set to %.1f', radius)
-	--end
-
 	if vehicle:getAIMinTurningRadius() ~= nil then
 		CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  AIMinTurningRadius by Giants is %.1f', vehicle:getAIMinTurningRadius())
 		radius = math.max(radius, vehicle:getAIMinTurningRadius())
@@ -222,8 +215,7 @@ function AIUtil.getTurningRadius(vehicle)
 			end
 		end
 		if turnRadius == 0 then
-			local towed, _ = AIUtil.getSteeringParameters(vehicle)
-			if towed then
+			if AIUtil.isImplementTowed(vehicle, implement.object) then
 				turnRadius = 6
 				CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  %s: no Giants turn radius, towed implement, we use a default %.1f',
 						implement.object:getName(), turnRadius)
@@ -240,13 +232,24 @@ function AIUtil.getTurningRadius(vehicle)
 	return radius
 end
 
+---@param vehicle table
+---@param implementObject table
+function AIUtil.isImplementTowed(vehicle, implementObject)
+	if AIUtil.isObjectAttachedOnTheBack(vehicle, implementObject) then
+		if ImplementUtil.isWheeledImplement(implementObject) then
+			return true
+		end
+	end
+	return false
+end
+
 ---@return table implement object
 function AIUtil.getFirstReversingImplementWithWheels(vehicle)
 	-- since some weird things like Seed Bigbag are also vehicles, check this first
 	if not vehicle.getAttachedImplements then return nil end
 	-- Check all attached implements if we are a wheeled workTool behind the tractor
 	for _, imp in ipairs(vehicle:getAttachedImplements()) do
-		-- Check if the implement is behind
+		-- Check if the implement is behind the tractor
 		if AIUtil.isObjectAttachedOnTheBack(vehicle, imp.object) then
 			if ImplementUtil.isWheeledImplement(imp.object) then
 				-- If the implement is a wheeled workTool, then return the object

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -637,7 +637,7 @@ end
 
 ---@return boolean true if it is ok the continue driving, false when the vehicle should stop
 function CourseTurn:endTurn(dt)
--- keep driving on the turn course until we need to lower our implements
+	-- keep driving on the turn course until we need to lower our implements
 	local shouldLower, dz = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode, self.ppc:isReversing())
 	if shouldLower then
 		if not self.implementsLowered then
@@ -650,8 +650,10 @@ function CourseTurn:endTurn(dt)
 				self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
 			end
 		else
-			-- implements already lowering
-			if dz and dz > -1 and not self.vehicle:getCanAIFieldWorkerContinueWork() then
+			-- implements already lowering, making sure we check if they are lowered, the faster we go, the earlier,
+			-- for those people who set insanely high turn speeds...
+			local implementCheckDistance = math.max(1, 0.1 * self.vehicle:getLastSpeed())
+			if dz and dz > - implementCheckDistance and not self.vehicle:getCanAIFieldWorkerContinueWork() then
 				self:debug('waiting for lower at dz=%.1f', dz)
 				-- we are almost at the start of the row but still not lowered everything,
 				-- hold.

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -392,7 +392,9 @@ function TurnContext:appendEndingTurnCourse(course, extraLength, useTightTurnOff
 	-- extra length at the end to allow for alignment
 	extraLength = extraLength and (extraLength + 3) or 3
     -- +1 so the first waypoint of the appended line won't overlap with the last wp of course
-    for d = math.min(dzFrontMarker, dzWorkStart) + 1, math.max(dzFrontMarker, dzWorkStart) + extraLength, 1 do
+    CpUtil.debugFormat(CpDebug.DBG_TURN, 'appendEndingTurnCourse: dzVehicleAtTurnEnd: %.1f, dzWorkStart: %.1f, extra %.1f)',
+            dzFrontMarker, dzWorkStart, extraLength)
+    for d = math.min(dzFrontMarker, dzWorkStart) + 1, extraLength, 1 do
         local x, y, z = localToWorld(startNode, 0, 0, d)
         table.insert(waypoints, {x = x, y = y, z = z, useTightTurnOffset = useTightTurnOffset or nil})
     end

--- a/scripts/courseGenerator/CourseGenerator.lua
+++ b/scripts/courseGenerator/CourseGenerator.lua
@@ -242,15 +242,6 @@ function CourseGenerator.pointsToXyInPlace(points)
 	return points
 end
 
-
-function CourseGenerator.pointsToCxCz( points )
-	local result = {}
-	for _, point in ipairs( points) do
-		table.insert( result, { cx = point.x, cz = -point.y })
-	end
-	return result
-end
-
 function CourseGenerator.pointToXy( point )
 	return({ x = point.x or point.cx, y = - ( point.z or point.cz )})
 end

--- a/scripts/field/CpFieldUtil.lua
+++ b/scripts/field/CpFieldUtil.lua
@@ -89,6 +89,11 @@ function CpFieldUtil.saveAllFields()
                 for i,point in ipairs(points) do
                     setXMLString(xmlFile, key .. (".point%d#pos"):format(i), ("%.2f %.2f %.2f"):format(point.x, point.y, point.z))
                 end
+                local islandNodes = Island.findIslands( Polygon:new(CourseGenerator.pointsToXy(points)))
+                CourseGenerator.pointsToXzInPlace(islandNodes)
+                for i, islandNode in ipairs(islandNodes) do
+                    setXMLString(xmlFile, key .. ( ".islandNode%d#pos"):format( i ), ("%.2f %2.f"):format( islandNode.x, islandNode.z ))
+                end
                 CpUtil.info('Field %d saved', field.fieldId)
             else
                 CpUtil.info('Field %d could not be saved', field.fieldId)


### PR DESCRIPTION
The turn ending straight piece leading into the
next row was not calculated correctly, was too short,
causing the vehicle to switch back to the up/down
rows well before the implement reached the work
start position, which bypassed the last check for
lowered implements.

#571