### PR TITLE
Implement lowering fix for #1000

### DIFF
--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -798,7 +798,7 @@ function CourseTurn:onPathfindingDone(path)
 		self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
 		-- and once again, if there is an ending course, keep adjusting the tight turn offset
 		self.turnContext:appendEndingTurnCourse(self.turnCourse, nil, true)
-		TurnManeuver.setTurnControlForLastWaypoints(self.turnCourse, 5, TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END, true)
+		TurnManeuver.setLowerImplements(self.turnCourse, self.turnContext.frontMarkerDistance, self.steeringLength)
 	else
 		self:debug('No path found in %d ms, falling back to normal turn course generator', g_currentMission.time - (self.pathfindingStartedAt or 0))
 		self:generateCalculatedTurn()
@@ -961,7 +961,7 @@ StartRowOnly = CpObject(CourseTurn)
 function StartRowOnly:init(vehicle, driveStrategy, ppc, turnContext, startRowCourse, fieldWorkCourse, workWidth)
 	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, 'AlignmentTurn')
 	self.turnCourse = startRowCourse
-	TurnManeuver.setTurnControlForLastWaypoints(self.turnCourse, 5, TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END, true)
+	TurnManeuver.setLowerImplements(self.turnCourse, turnContext.frontMarkerDistance, self.steeringLength)
 	self.ppc:setCourse(self.turnCourse)
 	self.ppc:initialize(1)
 	self.state = self.states.TURNING

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -226,6 +226,13 @@ function TurnManeuver.setTurnControlForLastWaypoints(course, d, control, value)
 	end)
 end
 
+--- Set implement lowering control for the end of the turn
+function TurnManeuver.setLowerImplements(course, frontMarkerDistance, steeringLength)
+	TurnManeuver.setTurnControlForLastWaypoints(course,
+			math.max(steeringLength, math.abs(frontMarkerDistance), 3) + 2,
+			TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END, true)
+end
+
 ---@param course Course
 ---@param dBack number distance in meters to move the course back (positive moves it backwards!)
 function TurnManeuver:moveCourseBack(course, dBack)
@@ -277,8 +284,7 @@ function AnalyticTurnManeuver:init(vehicle, turnContext, vehicleDirectionNode, t
 	if distanceToFieldEdge < spaceNeededOnFieldForTurn then
 		self.course = self:moveCourseBack(self.course, spaceNeededOnFieldForTurn - distanceToFieldEdge)
 	end
-	TurnManeuver.setTurnControlForLastWaypoints(self.course, math.max(turnContext.frontMarkerDistance + 2, 5),
-			TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END, true)
+	TurnManeuver.setLowerImplements(self.course, turnContext.frontMarkerDistance, steeringLength)
 end
 
 ---@class DubinsTurnManeuver : AnalyticTurnManeuver
@@ -373,7 +379,7 @@ function TurnEndingManeuver:init(vehicle, turnContext, vehicleDirectionNode, tur
 	myCorner:delete()
 	self.course = Course(vehicle, self.waypoints, true)
 	self.course:setUseTightTurnOffsetForLastWaypoints(20)
-	TurnManeuver.setTurnControlForLastWaypoints(self.course, 5, TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END, true)
+	TurnManeuver.setLowerImplements(self.course, turnContext.frontMarkerDistance, steeringLength)
 end
 
 ---@class HeadlandCornerTurnManeuver : TurnManeuver


### PR DESCRIPTION
Start checking for lowering earlier at the end
of a turn. Use the absolute value of the front marker
distance as it is negative for towed implements :)