### PR TITLE
User redirect in Contributors.md is not working

### DIFF
--- a/.github/scripts/update-contributors/index.js
+++ b/.github/scripts/update-contributors/index.js
@@ -2,7 +2,7 @@ const { readFileSync, writeFileSync } = require("fs");
 const translationFileNameRegexp = /translation_(.{2})\.xml/;
 
 function getUserTag(name) {
-    return `[${name}](/${name})`;
+    return `[${name}](https://github.com/${name})`;
 }
 
 function readContributors() {


### PR DESCRIPTION
If you want to redirect to a user page you actually need to provide the FQDN, otherwise a link is assumed to be relative within the repository