### PR TITLE
Issue 1060

### DIFF
--- a/Courseplay.lua
+++ b/Courseplay.lua
@@ -117,13 +117,13 @@ function Courseplay:setupGui()
 		return aiPage.currentHotspot ~= nil or aiPage.controlledVehicle ~= nil 
 	end
 	
-	CpGuiUtil.fixInGameMenu(vehicleSettingsFrame,"pageCpVehicleSettings",
+	CpGuiUtil.fixInGameMenuPage(vehicleSettingsFrame,"pageCpVehicleSettings",
 			{896, 0, 128, 128},3, predicateFunc)
-	CpGuiUtil.fixInGameMenu(globalSettingsFrame,"pageCpGlobalSettings",
+	CpGuiUtil.fixInGameMenuPage(globalSettingsFrame,"pageCpGlobalSettings",
 			{768, 0, 128, 128},4,function () return true end)
-	CpGuiUtil.fixInGameMenu(courseManagerFrame,"pageCpCourseManager",
+	CpGuiUtil.fixInGameMenuPage(courseManagerFrame,"pageCpCourseManager",
 			{256,0,128,128},5, predicateFunc)
-	
+	CpGuiUtil.fixInGameMenu()
 end
 
 --- Adds cp help info to the in game help menu.

--- a/config/GlobalSettingsSetup.xml
+++ b/config/GlobalSettingsSetup.xml
@@ -32,10 +32,10 @@
 		</Setting>
 
 	</SettingSubTitle>
-	<!-- TODO: save the user settings in the game settings and not the save game dir.-->
 	<SettingSubTitle prefix="true" title="userSettings">
 		<Setting classType="AIParameterBooleanSetting" name="controllerHudSelected" defaultBool="false" onChangeCallback="onHudSelectionChanged" isUserSetting="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="showsAllActiveCourses" isUserSetting="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="showActionEventHelp" isUserSetting="true" defaultBool="true" onChangeCallback="onActionEventTextVisibilityChanged"/>
 	</SettingSubTitle>
 	<SettingSubTitle prefix="true" title="pathfinder">
 		<Setting classType="AIParameterSettingList" name="maxDeltaAngleAtGoal" min="5" max="90" incremental="5" default="45"/>

--- a/scripts/CpGlobalSettings.lua
+++ b/scripts/CpGlobalSettings.lua
@@ -92,6 +92,14 @@ function CpGlobalSettings:onHudSelectionChanged()
     end
 end
 
+function CpGlobalSettings:onActionEventTextVisibilityChanged()
+    local vehicle = g_currentMission.controlledVehicle
+    if vehicle then 
+        vehicle:requestActionEventUpdate()
+    end
+    CpDebug:updateActionEventTextVisibility()
+end
+
 function CpGlobalSettings:onUnitChanged()
     for i,setting in ipairs(self.settings) do 
         setting:validateTexts()

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -572,6 +572,7 @@ function AIParameterSettingList:resetGuiElement()
 	if self.guiElement then
 		if self.oldMouseEvent then
 			self.guiElement.mouseEvent = self.oldMouseEvent
+			self.oldMouseEvent = nil
 		end
 	end
 

--- a/scripts/debug/CpDebug.lua
+++ b/scripts/debug/CpDebug.lua
@@ -130,6 +130,14 @@ function CpDebug:deactivateEvents()
 	end
 end
 
+function CpDebug:updateActionEventTextVisibility()
+	local textVisible = g_Courseplay.globalSettings.showActionEventHelp:getValue()
+	for _,id in pairs(CpDebug.eventIds) do 
+		g_inputBinding:setActionEventTextVisibility(id, textVisible)
+	end
+	g_inputBinding:setActionEventTextVisibility(CpDebug.menuEventId, textVisible)
+end
+
 function CpDebug:toggleMenuVisibility()
 	if self.menuVisible then 
 		self:deactivateEvents()
@@ -170,6 +178,6 @@ function CpDebug.addEvents(mission)
 	local _, eventId = mission.inputManager:registerActionEvent(InputAction.CP_DBG_CHANNEL_TOGGLE_CURRENT, CpDebug, CpDebug.toggleCurrentChannel, false, true, false, CpDebug:isMenuVisible())
 	table.insert(CpDebug.eventIds,eventId)
 	local _, eventId = mission.inputManager:registerActionEvent(InputAction.CP_DBG_CHANNEL_MENU_VISIBILITY, CpDebug, CpDebug.toggleMenuVisibility, false, true, false, CpDebug.isEnabled)
-
+	CpDebug.menuEventId = eventId
 end
 FSBaseMission.registerActionEvents = Utils.appendedFunction(FSBaseMission.registerActionEvents,CpDebug.addEvents)

--- a/scripts/gui/CpAIFrameExtended.lua
+++ b/scripts/gui/CpAIFrameExtended.lua
@@ -237,11 +237,7 @@ function CpInGameMenuAIFrameExtended:updateCourseGeneratorSettings()
 end
 
 function CpInGameMenuAIFrameExtended:unbindCourseGeneratorSettings()
-	local vehicle = InGameMenuMapUtil.getHotspotVehicle(self.currentHotspot)
-	if self.settings then
-		CpUtil.debugVehicle( CpUtil.DBG_HUD,vehicle, "unbinding course generator settings." )
-		CpSettingsUtil.unlinkGuiElementsAndSettings(self.settings,self.courseGeneratorLayoutElements)
-	end
+	CpSettingsUtil.unlinkGuiElementsAndSettings(self.settings,self.courseGeneratorLayoutElements)
 	self.courseGeneratorLayoutElements:invalidateLayout()
 end
 

--- a/scripts/gui/CpAIFrameExtended.lua
+++ b/scripts/gui/CpAIFrameExtended.lua
@@ -237,8 +237,10 @@ function CpInGameMenuAIFrameExtended:updateCourseGeneratorSettings()
 end
 
 function CpInGameMenuAIFrameExtended:unbindCourseGeneratorSettings()
-	CpSettingsUtil.unlinkGuiElementsAndSettings(self.settings,self.courseGeneratorLayoutElements)
-	self.courseGeneratorLayoutElements:invalidateLayout()
+	if self.settings then
+		CpSettingsUtil.unlinkGuiElementsAndSettings(self.settings,self.courseGeneratorLayoutElements)
+		self.courseGeneratorLayoutElements:invalidateLayout()
+	end
 end
 
 

--- a/scripts/gui/CpAIFrameExtended.lua
+++ b/scripts/gui/CpAIFrameExtended.lua
@@ -293,6 +293,7 @@ function CpInGameMenuAIFrameExtended:onAIFrameClose()
 	self.contextBox:setVisible(true)
 	self.lastHotspot = self.currentHotspot
 	g_currentMission:removeMapHotspot(self.secondAiTargetMapHotspot)
+	CpInGameMenuAIFrameExtended.unbindCourseGeneratorSettings(self)
 end
 InGameMenuAIFrame.onFrameClose = Utils.appendedFunction(InGameMenuAIFrame.onFrameClose,CpInGameMenuAIFrameExtended.onAIFrameClose)
 

--- a/scripts/gui/CpGuiUtil.lua
+++ b/scripts/gui/CpGuiUtil.lua
@@ -2,7 +2,8 @@
 ---@class CpGuiUtil
 CpGuiUtil = {}
 
-function CpGuiUtil.fixInGameMenu(frame,pageName,uvs,position,predicateFunc)
+--- Adds a new page to the in game menu.
+function CpGuiUtil.fixInGameMenuPage(frame, pageName, uvs, position, predicateFunc)
 	local inGameMenu = g_gui.screenControllers[InGameMenu]
 
 	-- remove all to avoid warnings
@@ -11,8 +12,6 @@ function CpGuiUtil.fixInGameMenu(frame,pageName,uvs,position,predicateFunc)
 	end
 
 	inGameMenu:registerControls({pageName})
-
-	
 	inGameMenu[pageName] = frame
 	inGameMenu.pagingElement:addElement(inGameMenu[pageName])
 
@@ -56,6 +55,42 @@ function CpGuiUtil.fixInGameMenu(frame,pageName,uvs,position,predicateFunc)
 
 	inGameMenu:rebuildTabList()
 end
+
+--- Fixes the top/bottom icons in the in game menu.
+function CpGuiUtil.fixInGameMenu()
+	local inGameMenu = g_gui.screenControllers[InGameMenu]
+	local function fixImageFile(self)
+		if self.pagingTabPrevious ~= nil then
+			local isFirstItemVisible = self.pagingTabList.firstVisibleItem == 1
+			if not isFirstItemVisible then
+				local itemToShow = self.pagingTabList.firstVisibleItem - 1
+				local prevElement = self.pagingTabList.listItems[itemToShow].elements[1]
+	
+
+				if prevElement then
+					self.pagingTabPrevious.elements[1]:setImageFilename(prevElement.icon.filename)
+				end
+			end
+		end
+	
+		if self.pagingTabNext ~= nil then
+			local isLastItemVisible = self.pagingTabList.firstVisibleItem + self.pagingTabList.visibleItems - 1 >= #self.pagingTabList.listItems
+			if not isLastItemVisible then
+				local itemToShow = self.pagingTabList.firstVisibleItem + self.pagingTabList.visibleItems
+				local nextElement = self.pagingTabList.listItems[itemToShow].elements[1]
+	
+				if nextElement then
+					self.pagingTabNext.elements[1]:setImageFilename(nextElement.icon.filename)
+				end
+			end
+		end
+	end
+
+	inGameMenu.updateTabDisplay = Utils.appendedFunction(
+		inGameMenu.updateTabDisplay, fixImageFile
+	)
+end
+
 
 --- Clones a child element with a given profile name.
 ---@param rootElement GuiElement Searches in this element children elements.

--- a/scripts/specializations/CpAIWorker.lua
+++ b/scripts/specializations/CpAIWorker.lua
@@ -67,6 +67,7 @@ function CpAIWorker:onRegisterActionEvents(isActiveForInput, isActiveForInputIgn
         if self.spec_aiJobVehicle.supportsAIJobs and self:getIsActiveForInput(true, true) then
 			local _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.CP_START_STOP, self, CpAIWorker.startStopDriver, false, true, false, true, nil)
             g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_HIGH)
+            g_inputBinding:setActionEventTextVisibility(actionEventId, g_Courseplay.globalSettings.showActionEventHelp:getValue())
             CpAIWorker.updateActionEvents(self)
 		end
 	end

--- a/scripts/specializations/CpHud.lua
+++ b/scripts/specializations/CpHud.lua
@@ -96,6 +96,7 @@ function CpHud:onRegisterActionEvents(isActiveForInput, isActiveForInputIgnoreSe
                         CpHud.actionEventMouse, false, true, false, true,nil,nil,true)
                 g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_NORMAL)
                 g_inputBinding:setActionEventText(actionEventId, spec.openCloseText)
+                g_inputBinding:setActionEventTextVisibility(actionEventId, g_Courseplay.globalSettings.showActionEventHelp:getValue())
             end
         end
     end

--- a/scripts/specializations/CpVehicleSettingDisplay.lua
+++ b/scripts/specializations/CpVehicleSettingDisplay.lua
@@ -115,12 +115,14 @@ function CpVehicleSettingDisplay:onRegisterActionEvents(isActiveForInput, isActi
 				local _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.CP_OPEN_CLOSE_VEHICLE_SETTING_DISPLAY, self, CpHud.openClose, false, true, false, true, nil)
 				g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_HIGH)
 				g_inputBinding:setActionEventText(actionEventId, spec.hudText)
+				g_inputBinding:setActionEventTextVisibility(actionEventId, g_Courseplay.globalSettings.showActionEventHelp:getValue())
 			end
 		else
 			if self.isActiveForInputIgnoreSelectionIgnoreAI then
 				local _, actionEventId = self:addActionEvent(spec.actionEvents, InputAction.CP_OPEN_CLOSE_VEHICLE_SETTING_DISPLAY, self, CpVehicleSettingDisplay.actionEventOpenCloseDisplay, false, true, false, true, nil)
 				g_inputBinding:setActionEventTextPriority(actionEventId, GS_PRIO_HIGH)
 				g_inputBinding:setActionEventText(actionEventId, spec.text)
+				g_inputBinding:setActionEventTextVisibility(actionEventId, g_Courseplay.globalSettings.showActionEventHelp:getValue())
 			end
 		end
 	end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -225,6 +225,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Hud compatível com gamepad"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Use o Hud, que pode ser controlado com um Gamepad."/>
 
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Configurações Pathfinder"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Meta diferença angular"/>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="手柄控制HUB"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="HUD（游戏内CP界面）可搭配游戏手柄使用。"/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="路径生成设置"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="目标的角度差"/>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -226,6 +226,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Gamepad friendly Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Use the Hud, wich can be controlled with a Gamepad."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Pathfinder settings"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Angle difference at goal"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -227,6 +227,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Hud nastavený pro Gamepad"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Použijte Hud, který lze ovládat pomocí Gamepadu."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Nastavení generování trasy"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Rozdíl úhlů v cíli"/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Controller venling Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Benyt Hud, som kan betjenes via controlleren."/>
 
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Pathfinder Indstillinger"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Ankomstvinkel ved mål"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -228,6 +228,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Controller freundliches Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Benutze das Hud, welches sich über den Controller bedienen lässt."/>
 
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Pathfinder Einstellungen"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Ankunftswinkel am Ziel"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -228,8 +228,8 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Controller freundliches Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Benutze das Hud, welches sich über den Controller bedienen lässt."/>
 
-		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
-		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Zeige Tastenbelegung"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Schaltet die Anzeige der Tastenbelegung an und aus."/>
 
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Pathfinder Einstellungen"/>
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -226,6 +226,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Gamepad friendly Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Use the Hud, wich can be controlled with a Gamepad."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Pathfinder settings"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Angle difference at goal"/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -227,6 +227,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Hud compatible con gamepad"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Usa el Hud, que se puede controlar con un Gamepad. Si está activado, no se mostrará el Mini-Hud"/>
 
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Ajustes del generador de rutas"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Ángulo máximo a usar"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="ATH compatible manette"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="L'ATH (interface du CP en jeu) est utilisable avec une manette."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Réglages du Pathfinder"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Différence d'angle à l'objectif"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -225,6 +225,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Gamepad friendly Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Use the Hud, wich can be controlled with a Gamepad."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Úttörő beállításai"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Célszög különbség"/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -227,6 +227,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Hud compatibile con il gamepad"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="La Hud, può essere controllata con un Gamepad."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Ricerca percorso"/>
 		
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Differenza angolare obiettivo"/>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="ゲームパッド用HUD"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="ゲームパッドが接続されている場合、パッドに対応したHUDを表示できます（有効にするとマウスでHUD表示が無効になります）"/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="経路探索設定"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="ゴール時の角度差"/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Gamepad vriendelijke Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Gebruik de Hud, die kan worden bestuurd met een Gamepad."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Padvinder instellingen"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Hoekverschil op doel"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="HUD przyjazny kontrolerom"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Używa HUDa, który może być ustawiany przez kontrolery gier."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Ustawienia szukania ścieżki"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Różnica kątów na bramce"/>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Gamepad friendly Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Use the Hud, wich can be controlled with a Gamepad."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Pathfinder settings"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Angle difference at goal"/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -229,6 +229,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Дружелюбный к геймпаду HUD"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Использовать HUD, которым можно управлять с помощью геймпада."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Настройки поиска пути"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Разница углов у цели"/>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -232,6 +232,9 @@
 		<text name="CP_global_setting_controllerHudSelected_title"										text="Handkontroll vänlig Hud"/>
 		<text name="CP_global_setting_controllerHudSelected_tooltip"									text="Använd HUD, som kan styras med en handkontroll."/>
 		
+		<text name="CP_global_setting_showActionEventHelp_title" 										text="Action event help"/>
+		<text name="CP_global_setting_showActionEventHelp_tooltip" 										text="Shows action event help texts."/>
+
 		<text name="CP_global_setting_subTitle_pathfinder"												text="Pathfinder inställningar"/>
 
 		<text name="CP_global_setting_maxDeltaAngleAtGoal_title" 										text="Vinkelskillnad vid mål"/>


### PR DESCRIPTION
- Fixes setting input text bug. #983 
- Fixes top/bottom icon bug, where the page icon was not correct.
- Added user setting to disable action event texts.
- Needs testing:
  - Direct setting input in the course generator settings between turning headlands off(0) or on(>0).
  - Action event text turn on/off with the setting.
  - German translation.