### PR TITLE
Issue #1041

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -1250,9 +1250,12 @@ end
 --- Run a function for all waypoints of the course within the last d meters
 ---@param d number
 ---@param lambda function (waypoint)
-function Course:executeFunctionForLastWaypoints(d, lambda)
+---@param stopAtDirectionChange boolean if we reach a direction change, stop there, the last waypoint the function
+--- is called for is the one before the direction change
+function Course:executeFunctionForLastWaypoints(d, lambda, stopAtDirectionChange)
 	local i = self:getNumberOfWaypoints()
-	while i > 1 and self:getDistanceToLastWaypoint(i) < d do
+	while i > 1 and self:getDistanceToLastWaypoint(i) < d and
+			((stopAtDirectionChange and not self:switchingDirectionAt(i)) or not stopAtDirectionChange) do
 		lambda(self.waypoints[i])
 		i = i - 1
 	end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -796,9 +796,8 @@ function CourseTurn:onPathfindingDone(path)
 		end
 		-- make sure we use tight turn offset towards the end of the course so a towed implement is aligned with the new row
 		self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
-		-- and once again, if there is an ending course, keep adjusting the tight turn offset
-		self.turnContext:appendEndingTurnCourse(self.turnCourse, nil, true)
-		TurnManeuver.setLowerImplements(self.turnCourse, self.turnContext.frontMarkerDistance, self.steeringLength)
+		local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, nil, true)
+		TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
 	else
 		self:debug('No path found in %d ms, falling back to normal turn course generator', g_currentMission.time - (self.pathfindingStartedAt or 0))
 		self:generateCalculatedTurn()
@@ -961,7 +960,7 @@ StartRowOnly = CpObject(CourseTurn)
 function StartRowOnly:init(vehicle, driveStrategy, ppc, turnContext, startRowCourse, fieldWorkCourse, workWidth)
 	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, 'AlignmentTurn')
 	self.turnCourse = startRowCourse
-	TurnManeuver.setLowerImplements(self.turnCourse, turnContext.frontMarkerDistance, self.steeringLength)
+	TurnManeuver.setLowerImplements(self.turnCourse, math.max(math.abs(turnContext.frontMarkerDistance), self.steeringLength))
 	self.ppc:setCourse(self.turnCourse)
 	self.ppc:initialize(1)
 	self.state = self.states.TURNING

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -382,6 +382,7 @@ end
 ---@param course Course pathfinding course to append the ending course to
 ---@param extraLength number add so many meters to the calculated course (for example to allow towed implements to align
 --- before reversing)
+---@return number length added to the course in meters
 function TurnContext:appendEndingTurnCourse(course, extraLength, useTightTurnOffset)
     -- make sure course reaches the front marker node so end it well behind that node
     local _, _, dzFrontMarker = course:getWaypointLocalPosition(self.vehicleAtTurnEndNode, course:getNumberOfWaypoints())
@@ -398,7 +399,9 @@ function TurnContext:appendEndingTurnCourse(course, extraLength, useTightTurnOff
         local x, y, z = localToWorld(startNode, 0, 0, d)
         table.insert(waypoints, {x = x, y = y, z = z, useTightTurnOffset = useTightTurnOffset or nil})
     end
+    local oldLength = course:getLength()
     course:appendWaypoints(waypoints)
+    return course:getLength() - oldLength
 end
 
 

--- a/scripts/pathfinder/HybridAStar.lua
+++ b/scripts/pathfinder/HybridAStar.lua
@@ -417,9 +417,9 @@ function HybridAStar:findPath(start, goal, turnRadius, allowReverse, constraints
 	---@type HybridAStar.NodeList closedList
 	self.nodes = HybridAStar.NodeList(self.deltaPos, self.deltaThetaDeg)
 	if allowReverse then
-		self.analyticSolver = ReedsSheppSolver()
+		self.analyticSolver = self.analyticSolver or ReedsSheppSolver()
 	else
-		self.analyticSolver = DubinsSolver()
+		self.analyticSolver = self.analyticSolver or DubinsSolver()
 	end
 
 	-- ignore trailer for the first check, we don't know its heading anyway
@@ -652,7 +652,8 @@ HybridAStarWithAStarInTheMiddle = CpObject(PathfinderInterface)
 ---@param hybridRange number range in meters around start/goal to use hybrid A *
 ---@param yieldAfter number coroutine yield after so many iterations (number of iterations in one update loop)
 ---@param mustBeAccurate boolean must be accurately find the goal position/angle (optional)
-function HybridAStarWithAStarInTheMiddle:init(hybridRange, yieldAfter, maxIterations, mustBeAccurate)
+---@param analyticSolver AnalyticSolver the analytic solver the use (optional)
+function HybridAStarWithAStarInTheMiddle:init(hybridRange, yieldAfter, maxIterations, mustBeAccurate, analyticSolver)
 	-- path generation phases
 	self.START_TO_MIDDLE = 1
 	self.MIDDLE = 2
@@ -662,6 +663,7 @@ function HybridAStarWithAStarInTheMiddle:init(hybridRange, yieldAfter, maxIterat
 	self.yieldAfter = yieldAfter or 100
 	self.hybridAStarPathfinder = HybridAStar(self.yieldAfter, maxIterations, mustBeAccurate)
 	self.aStarPathfinder = self:getAStar()
+	self.analyticSolver = analyticSolver
 end
 
 function HybridAStarWithAStarInTheMiddle:getAStar()
@@ -863,10 +865,11 @@ HybridAStarWithPathInTheMiddle = CpObject(HybridAStarWithAStarInTheMiddle)
 ---@param yieldAfter number coroutine yield after so many iterations (number of iterations in one update loop)
 ---@param path State3D[] path to use in the middle part
 ---@param mustBeAccurate boolean must be accurately find the goal position/angle (optional)
-function HybridAStarWithPathInTheMiddle:init(hybridRange, yieldAfter, path, mustBeAccurate)
+---@param analyticSolver AnalyticSolver the analytic solver the use (optional)
+function HybridAStarWithPathInTheMiddle:init(hybridRange, yieldAfter, path, mustBeAccurate, analyticSolver)
 	self.path = path
 	self:debug('Start pathfinding on headland, hybrid A* range is %.1f, %d points on headland', hybridRange, #path)
-	HybridAStarWithAStarInTheMiddle.init(self, hybridRange, yieldAfter, 10000, mustBeAccurate)
+	HybridAStarWithAStarInTheMiddle.init(self, hybridRange, yieldAfter, 10000, mustBeAccurate, analyticSolver)
 end
 
 function HybridAStarWithPathInTheMiddle:getAStar()

--- a/scripts/pathfinder/ReedsShepp.lua
+++ b/scripts/pathfinder/ReedsShepp.lua
@@ -90,6 +90,14 @@ ReedsShepp.PathWords =
     RbLfpi2SfRfpi2Lb = {}
 }
 
+--- The paths ending in forward gear
+ReedsShepp.ForwardEndingPathWords = {}
+for key, word in pairs(ReedsShepp.PathWords) do
+    if string.sub(key, -1) == 'f' then
+        ReedsShepp.ForwardEndingPathWords[key] = word
+    end
+end
+
 -- The ReedsSheppAction class represents a single steering and motion action over some length.
 ---@class ReedsShepp.Action
 ReedsShepp.Action = CpObject()

--- a/scripts/pathfinder/ReedsSheppSolver.lua
+++ b/scripts/pathfinder/ReedsSheppSolver.lua
@@ -27,7 +27,8 @@ https://github.com/mattbradley/AutonomousCar
 --- @class ReedsSheppSolver
 ReedsSheppSolver = CpObject(AnalyticSolver)
 
-function ReedsSheppSolver:init()
+function ReedsSheppSolver:init(enabledPathWords)
+    self.enabledPathWords = enabledPathWords or ReedsShepp.PathWords
 end
 
 local sin, cos, asin, acos, atan2, abs, sqrt, floor, huge, pi =
@@ -48,7 +49,7 @@ function ReedsSheppSolver:solve(start, goal, turnRadius, enabledPathWords)
     local bestPathLength = huge
     local bestWord, bestKey
     local bestT, bestU, bestV = 0, 0, 0
-    for key, word in pairs(enabledPathWords or ReedsShepp.PathWords) do
+    for key, word in pairs(enabledPathWords or self.enabledPathWords) do
         local potentialLength, t, u, v = self:calculatePathLength(newGoal, word)
         if potentialLength < huge then
            --   print(key, potentialLength)


### PR DESCRIPTION
Turn fixes for #1041

- pathfinder turns with reverse now will not 
lower implements too early
- pathfinder and analytic turns should start lowering 
implements earlier now to reduce waiting for lowering 
at the start of the row
- should test: pathfinder/non-pathfinder turns with 
towed and mounted implements (both front and back)