### PR TITLE
Setting value are now saved, instead of the current ix. #908

### DIFF
--- a/scripts/CpGlobalSettings.lua
+++ b/scripts/CpGlobalSettings.lua
@@ -10,8 +10,10 @@ function CpGlobalSettings:init()
 end
 
 function CpGlobalSettings:registerXmlSchema(schema,baseKey)
-	schema:register(XMLValueType.INT,baseKey..CpGlobalSettings.KEY.."(?)#value","Setting value")
-    schema:register(XMLValueType.STRING,baseKey..CpGlobalSettings.KEY.."(?)#name","Setting name")
+    local key = baseKey..CpGlobalSettings.KEY.."(?)"
+	schema:register(XMLValueType.INT, key.."#value", "Old setting save format.")
+    schema:register(XMLValueType.STRING, key.."#currentValue", "Setting value")
+    schema:register(XMLValueType.STRING, key.."#name", "Setting name")
 end
 
 --- Loads settings setup form an xmlFile.

--- a/scripts/ai/parameters/AIParameterBooleanSetting.lua
+++ b/scripts/ai/parameters/AIParameterBooleanSetting.lua
@@ -33,3 +33,12 @@ end
 function AIParameterBooleanSetting:getClosestSetupIx()
 	return self.current
 end
+
+function AIParameterBooleanSetting:loadFromXMLFile(xmlFile, key)
+	local rawValue = xmlFile:getString(key .. "#currentValue")
+	if rawValue ~= nil then 
+		self:setValue(rawValue == "true" or false)
+	else 
+		self:loadFromXMLFileLegacy(xmlFile, key)
+	end
+end

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -219,12 +219,24 @@ function AIParameterSettingList:getDebugString()
 	-- replace % as this string goes through multiple formats (%% does not seem to work and I have no time to figure it out
 	return string.format('%s: %s', self.name, string.gsub(self.texts[self.current], '%%', 'percent'))
 end
+
 function AIParameterSettingList:saveToXMLFile(xmlFile, key, usedModNames)
-	xmlFile:setInt(key .. "#value", self.current)
+	xmlFile:setString(key .. "#currentValue", tostring(self:getValue()))
+end
+
+--- Old load function.
+function AIParameterSettingList:loadFromXMLFileLegacy(xmlFile, key)
+	self:setToIx(xmlFile:getInt(key .. "#value", self.current))
 end
 
 function AIParameterSettingList:loadFromXMLFile(xmlFile, key)
-	self:setToIx(xmlFile:getInt(key .. "#value", self.current))
+	local rawValue = xmlFile:getString(key .. "#currentValue")
+	local value = rawValue and tonumber(rawValue) 
+	if value then 
+		self:setFloatValue(value)
+	else 
+		self:loadFromXMLFileLegacy(xmlFile, key)
+	end
 end
 
 function AIParameterSettingList:readStream(streamId, connection)

--- a/scripts/specializations/CpCourseGeneratorSettings.lua
+++ b/scripts/specializations/CpCourseGeneratorSettings.lua
@@ -9,8 +9,10 @@ CpCourseGeneratorSettings.MOD_NAME = g_currentModName
 CpCourseGeneratorSettings.KEY = "."..CpCourseGeneratorSettings.MOD_NAME..".cpCourseGeneratorSettings"
 function CpCourseGeneratorSettings.initSpecialization()
 	local schema = Vehicle.xmlSchemaSavegame
-    schema:register(XMLValueType.INT,"vehicles.vehicle(?)"..CpCourseGeneratorSettings.KEY.."(?)#value","Setting value")
-    schema:register(XMLValueType.STRING,"vehicles.vehicle(?)"..CpCourseGeneratorSettings.KEY.."(?)#name","Setting name")
+    local key = "vehicles.vehicle(?)"..CpCourseGeneratorSettings.KEY.."(?)"
+    schema:register(XMLValueType.INT, key.."#value", "Old setting save format.")
+    schema:register(XMLValueType.STRING, key.."#currentValue", "Setting value")
+    schema:register(XMLValueType.STRING, key.."#name", "Setting name")
 end
 
 

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -9,8 +9,10 @@ CpVehicleSettings.MOD_NAME = g_currentModName
 CpVehicleSettings.KEY = "."..CpVehicleSettings.MOD_NAME..".cpVehicleSettings"
 function CpVehicleSettings.initSpecialization()
 	local schema = Vehicle.xmlSchemaSavegame
-    schema:register(XMLValueType.INT,"vehicles.vehicle(?)"..CpVehicleSettings.KEY.."(?)#value","Setting value")
-    schema:register(XMLValueType.STRING,"vehicles.vehicle(?)"..CpVehicleSettings.KEY.."(?)#name","Setting name")
+    local key = "vehicles.vehicle(?)"..CpVehicleSettings.KEY.."(?)"
+    schema:register(XMLValueType.INT, key.."#value", "Old setting save format.")
+    schema:register(XMLValueType.STRING, key.."#currentValue", "Setting value")
+    schema:register(XMLValueType.STRING, key.."#name", "Setting name")
 end
 
 


### PR DESCRIPTION
Should prevent similiar issues as #908 in the future.
Needs testing: 
- Backwards compatibility to main savegames.
- Saving/Loading of vehicle/course generator and global settings.