### PR TITLE
Drive to fieldwork

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -125,6 +125,7 @@ Funktionen:
 		<sourceFile filename="scripts/ai/jobs/CpAIJobBaleFinder.lua"/>
 		<sourceFile filename="scripts/ai/tasks/CpAITaskFieldWork.lua"/>
 		<sourceFile filename="scripts/ai/tasks/CpAITaskBaleFinder.lua"/>
+		<sourceFile filename="scripts/ai/tasks/CpAITaskDriveTo.lua"/>
 		<sourceFile filename="scripts/CpSettingsUtil.lua"/>
 		<sourceFile filename="scripts/CpGlobalSettings.lua"/>
 		<sourceFile filename="scripts/config/VehicleConfigurations.lua"/>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -91,6 +91,7 @@ Funktionen:
 		<sourceFile filename="scripts/ai/turns/TurnContext.lua"/>
 		<sourceFile filename="scripts/ai/AIReverseDriver.lua"/>
 		<sourceFile filename="scripts/ai/AIDriveStrategyCourse.lua"/>
+		<sourceFile filename="scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua"/>
 		<sourceFile filename="scripts/ai/AIDriveStrategyFieldWorkCourse.lua"/>
 		<sourceFile filename="scripts/ai/AIDriveStrategyCombineCourse.lua"/>
 		<sourceFile filename="scripts/ai/AIDriveStrategyPlowCourse.lua"/>

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -892,8 +892,8 @@ function Course:append(other)
 end
 
 --- Return a copy of the course
-function Course:copy(vehicle)
-	return Course(vehicle or self.vehicle, self.waypoints)
+function Course:copy(vehicle, first, last)
+	return Course(vehicle or self.vehicle, self.waypoints, self:isTemporary(), first, last)
 end
 
 --- Append a single waypoint to the course

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -1337,6 +1337,24 @@ function Course:markAsHeadland(waypoints, passNumber)
 	end
 end
 
+--- @param nVehicles number of vehicles working together
+--- @param position number an integer defining the position of this vehicle within the group, negative numbers are to
+--- the left, positives to the right. For example, a -2 means that this is the second vehicle to the left (and thus,
+--- there are at least 4 vehicles in the group), a 0 means the vehicle in the middle, for which obviously no offset
+--- headland is required as it it driving on the original headland.
+--- @param width number working width of one vehicle
+function Course.calculateOffsetForMultitools(nVehicles, position, width)
+	local offset
+	if nVehicles % 2 == 0 then
+		-- even number of vehicles
+		offset = math.abs(position) * width - width / 2
+	else
+		offset = math.abs(position) * width
+	end
+	-- correct for side
+	return position >= 0 and offset or -offset
+end
+
 --- Calculate an offset course from an existing course. This is used when multiple vehicles working on
 --- the same field. In this case we only generate one course with the total implement width of all vehicles and use
 --- the same course for all vehicles, only with different offsets (multitool).
@@ -1361,16 +1379,7 @@ end
 --- @return Course the course with the appropriate offset applied.
 function Course:calculateOffsetCourse(nVehicles, position, width, useSameTurnWidth)
 	-- find out the absolute offset in meters first
-	local offset
-	if nVehicles % 2 == 0 then
-		-- even number of vehicles
-		offset = math.abs(position) * width - width / 2
-	else
-		offset = math.abs(position) * width
-	end
-	-- correct for side
-	offset = position >= 0 and offset or -offset
-
+	local offset = Course.calculateOffsetForMultitools(nVehicles, position, width)
 	local offsetCourse = Course(self.vehicle, {})
 	offsetCourse.multiTools = nVehicles
 	offsetCourse.name = self.name

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -46,7 +46,7 @@ function CpUtil.printVariableToXML(variableName, maxDepth, printToSeparateXmlFil
 	local xmlFile = createXMLFile("xmlFile", filePath, baseKey);
 	local xmlFileValid = xmlFile and xmlFile ~= 0 or false
 	if not xmlFileValid then
-		CpUtil.error("xmlFile(%s) not valid!", filePath)
+		CpUtil.info("xmlFile(%s) not valid!", filePath)
 		return 
 	end
 	setXMLString(xmlFile, baseKey .. '#maxDepth', tostring(maxDepth))
@@ -220,7 +220,7 @@ function CpUtil.try(func, ...)
 	local data = {xpcall(func, function(err) printCallstack(); return err end, ...)}
 	local status = data[1]
 	if not status then 
-		CpUtil.error(data[2])
+		CpUtil.info(data[2])
 		return status, tostring(data[2])
 	end
 	return unpack(data)

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -130,7 +130,7 @@ function AIDriveStrategyCourse:getStartingPointWaypointIx(course, startAt)
         self:debug('Starting course at the closest waypoint in the right direction %d', ixClosestRightDirection)
         return ixClosestRightDirection
     elseif startAt == CpJobParameters.START_AT_LAST_POINT then
-        local lastWpIx = self.vehicle:getCpLastRememberedWaypointIx()()
+        local lastWpIx = self.vehicle:getCpLastRememberedWaypointIx()
         if lastWpIx then
             self:debug('Starting course at the last waypoint %d', lastWpIx)
             return lastWpIx

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -111,7 +111,7 @@ function AIDriveStrategyCourse:setAIVehicle(vehicle, jobParameters)
     if course then
         self:debug('Vehicle has a fieldwork course, figure out where to start')
         local startIx = self:getStartingPointWaypointIx(course, jobParameters.startAt:getValue())
-        self:start(course, startIx)
+        self:start(course, startIx, jobParameters)
     else
         -- some strategies do not need a recorded or generated course to work, they
         -- will create the courses on the fly.
@@ -140,7 +140,7 @@ function AIDriveStrategyCourse:getStartingPointWaypointIx(course, startAt)
     return 1
 end
 
-function AIDriveStrategyCourse:start(course, startIx)
+function AIDriveStrategyCourse:start(course, startIx, jobParameters)
     self:startCourse(course, startIx)
     self.state = self.states.INITIAL
 end

--- a/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -1,0 +1,196 @@
+--[[
+This file is part of Courseplay (https://github.com/Courseplay/Courseplay_FS22)
+Copyright (C) 2022 Peter Vaiko
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Drive strategy for driving to the waypoint where we want to start the fieldwork.
+
+- Make sure everything is raised (maybe folded?)
+- Find a path to the start waypoint (first or last worked on), avoiding fruit
+- When getting close to the end of the course (to the work start waypoint), give control
+  to the field work strategy, which will then drive the last few meters making sure the
+  implements are in a working position when reaching the work start waypoint.
+
+]]--
+
+---@class AIDriveStrategyDriveToFieldWorkStart : AIDriveStrategyCourse
+AIDriveStrategyDriveToFieldWorkStart = {}
+local AIDriveStrategyDriveToFieldWorkStart_mt = Class(AIDriveStrategyDriveToFieldWorkStart, AIDriveStrategyCourse)
+
+AIDriveStrategyDriveToFieldWorkStart.myStates = {
+    PREPARE_TO_DRIVE = {},
+    WORK_START_REACHED = {},
+}
+
+-- minimum distance to the target when this strategy is even used
+AIDriveStrategyDriveToFieldWorkStart.minDistanceToDrive = 20
+
+AIDriveStrategyDriveToFieldWorkStart.normalFillLevelFullPercentage = 99.5
+
+function AIDriveStrategyDriveToFieldWorkStart.new(customMt)
+    if customMt == nil then
+        customMt = AIDriveStrategyDriveToFieldWorkStart_mt
+    end
+    local self = AIDriveStrategyCourse.new(customMt)
+    AIDriveStrategyCourse.initStates(self, AIDriveStrategyDriveToFieldWorkStart.myStates)
+    self.state = self.states.INITIAL
+    self.debugChannel = CpDebug.DBG_FIELDWORK
+    self.prepareTimeout = 0
+    self.emergencyBrake = CpTemporaryObject(true)
+    return self
+end
+
+function AIDriveStrategyDriveToFieldWorkStart:delete()
+    AIDriveStrategyDriveToFieldWorkStart:superClass().delete(self)
+end
+
+function AIDriveStrategyDriveToFieldWorkStart:initializeImplementControllers(vehicle)
+    -- these can't handle the standard Giants AI events to raise, so we need to have the controllers for them
+    self:addImplementController(vehicle, PickupController, Pickup, {})
+    self:addImplementController(vehicle, CutterController, Cutter, {})
+end
+
+function AIDriveStrategyDriveToFieldWorkStart:start(course, startIx)
+    local distance = course:getDistanceBetweenVehicleAndWaypoint(self.vehicle, startIx)
+    if distance < AIDriveStrategyDriveToFieldWorkStart.minDistanceToDrive then
+        self:debug('Closer than %.0f m to start waypoint (%d), start fieldwork directly',
+                AIDriveStrategyDriveToFieldWorkStart.minDistanceToDrive, startIx)
+        self.state = self.states.WORK_START_REACHED
+    else
+        self:debug('Start driving to work start waypoint')
+        self.vehicle:prepareForAIDriving()
+        self:startCourseWithPathfinding(course, startIx)
+    end
+end
+
+function AIDriveStrategyDriveToFieldWorkStart:update()
+    AIDriveStrategyDriveToFieldWorkStart:superClass().update(self)
+    self:updateImplementControllers()
+    if self.ppc:getCourse():isTemporary() then
+        self.ppc:getCourse():draw()
+    end
+end
+
+function AIDriveStrategyDriveToFieldWorkStart:isWorkStartReached()
+    return self.state == self.states.WORK_START_REACHED
+end
+
+function AIDriveStrategyDriveToFieldWorkStart:getDriveData(dt, vX, vY, vZ)
+    local moveForwards = not self.ppc:isReversing()
+    local gx, gz
+
+    if not moveForwards then
+        local maxSpeed
+        gx, gz, maxSpeed = self:getReverseDriveData()
+        self:setMaxSpeed(maxSpeed)
+    else
+        gx, _, gz = self.ppc:getGoalPointPosition()
+    end
+
+    if self.state == self.states.WAITING_FOR_PATHFINDER then
+        self:setMaxSpeed(0)
+    elseif self.state == self.states.PREPARE_TO_DRIVE then
+        self:setMaxSpeed(0)
+        local isReadyToDrive, blockingVehicle = self.vehicle:getIsAIReadyToDrive()
+        if isReadyToDrive then
+            self.state = self.states.DRIVING_TO_WORK_START_WAYPOINT
+            self:debug('Ready to drive to work start')
+        else
+            self:debugSparse('Not ready to drive because of %s, preparing ...', CpUtil.getName(blockingVehicle))
+            if not self.vehicle:getIsAIPreparingToDrive() then
+                self.prepareTimeout = self.prepareTimeout + dt
+                if 2000 < self.prepareTimeout then
+                    self:debug('Timeout preparing, continue anyway')
+                    self.state = self.states.DRIVING_TO_WORK_START_WAYPOINT
+                end
+            end
+        end
+    elseif self.state == self.states.DRIVING_TO_WORK_START_WAYPOINT then
+        self:setMaxSpeed(self.settings.fieldSpeed:getValue())
+    elseif self.state == self.states.WORK_START_REACHED then
+        if self.emergencyBrake:get() then
+            self:debugSparse('Work start reached but field work did not start...')
+            self:setMaxSpeed(0)
+        else
+            self:setMaxSpeed(self.settings.turnSpeed:getValue())
+        end
+    end
+    return gx, gz, moveForwards, self.maxSpeed, 100
+end
+
+------------------------------------------------------------------------------------------------------------------------
+--- Pathfinding
+---------------------------------------------------------------------------------------------------------------------------
+---@param course Course
+---@param ix number
+function AIDriveStrategyDriveToFieldWorkStart:startCourseWithPathfinding(course, ix)
+    if not self.pathfinder or not self.pathfinder:isActive() then
+        -- set a course so the PPC is able to do its updates.
+        self.course = course
+        self.ppc:setCourse(self.course)
+        self.ppc:initialize(ix)
+        self:rememberCourse(course, ix)
+        self:setFrontAndBackMarkers()
+        local x, _, z = course:getWaypointPosition(ix)
+        self.state = self.states.WAITING_FOR_PATHFINDER
+        local fieldNum = CpFieldUtil.getFieldIdAtWorldPosition(x, z)
+        -- if there is fruit at the target, create an area around it where the pathfinder ignores the fruit
+        -- so there's no penalty driving there. This is to speed up pathfinding when start harvesting for instance
+        local fruitAtTarget = PathfinderUtil.hasFruit(x, z, self.workWidth, self.workWidth)
+        self.pathfindingStartedAt = g_currentMission.time
+        local done, path
+        self.pathfinder, done, path = PathfinderUtil.startPathfindingFromVehicleToWaypoint(self.vehicle, course:getWaypoint(ix),
+                0, math.min(-self.frontMarkerDistance, 0), self:getAllowReversePathfinding(), fieldNum, nil, ix < 3 and math.huge, nil, nil,
+                fruitAtTarget and PathfinderUtil.Area(x, z, 2 * self.workWidth))
+        if done then
+            return self:onPathfindingDoneToCourseStart(path)
+        else
+            self:setPathfindingDoneCallback(self, self.onPathfindingDoneToCourseStart)
+            return true
+        end
+    else
+        self:info('Pathfinder already active')
+        self.state = self.states.PREPARE_TO_DRIVE
+        return false
+    end
+end
+
+function AIDriveStrategyDriveToFieldWorkStart:onPathfindingDoneToCourseStart(path)
+    local fieldWorkCourse, ix = self:getRememberedCourseAndIx()
+    local courseToStart
+    if path and #path > 2 then
+        self:debug('Pathfinding to start fieldwork finished with %d waypoints (%d ms)',
+                #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
+        courseToStart = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
+    else
+        self:debug('Pathfinding to start fieldwork failed, using alignment course instead')
+        courseToStart = self:createAlignmentCourse(fieldWorkCourse, ix)
+    end
+    self.state = self.states.PREPARE_TO_DRIVE
+    self:startCourse(courseToStart, 1)
+end
+
+-----------------------------------------------------------------------------------------------------------------------
+--- Event listeners
+-----------------------------------------------------------------------------------------------------------------------
+---@param course Course
+function AIDriveStrategyDriveToFieldWorkStart:onWaypointChange(ix, course)
+    if course:isCloseToLastWaypoint(10) then
+        self.state = self.states.WORK_START_REACHED
+        -- just in case no one takes the wheel in a few seconds
+        self.emergencyBrake:set(false, 2000)
+        self:debug('Almost at the work start waypoint, preparing for work')
+    end
+end

--- a/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -187,10 +187,12 @@ end
 -----------------------------------------------------------------------------------------------------------------------
 ---@param course Course
 function AIDriveStrategyDriveToFieldWorkStart:onWaypointChange(ix, course)
-    if course:isCloseToLastWaypoint(10) then
+    if course:isCloseToLastWaypoint(15) then
         self.state = self.states.WORK_START_REACHED
         -- just in case no one takes the wheel in a few seconds
         self.emergencyBrake:set(false, 2000)
         self:debug('Almost at the work start waypoint, preparing for work')
+        -- let the field work strategy know where to continue
+        self.vehicle:getJob():setStartFieldWorkCourse(course, ix)
     end
 end

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -81,7 +81,7 @@ end
 
 --- Start a fieldwork course. We expect that something else dropped us off close enough to startIx so
 --- the most we need is an alignment course to lower the implements
-function AIDriveStrategyFieldWorkCourse:start(course, startIx)
+function AIDriveStrategyFieldWorkCourse:start(course, startIx, jobParameters)
     self:showAllInfo('Starting field work at waypoint %d', startIx)
     self.fieldWorkCourse = course
     -- remember at which waypoint we started, especially for the convoy

--- a/scripts/ai/FieldWorkerProximityController.lua
+++ b/scripts/ai/FieldWorkerProximityController.lua
@@ -113,8 +113,8 @@ function FieldWorkerProximityController:getMaxSpeed(distanceLimit, currentMaxSpe
         if otherVehicle ~= self.vehicle and self:hasSameCourse(otherVehicle) and
                 otherVehicle.getIsCpFieldWorkActive and otherVehicle:getIsCpFieldWorkActive() then
             local otherStrategy = otherVehicle:getCpDriveStrategy()
-            local otherIsDone = otherStrategy:isDone()
-            if not otherIsDone then
+            local otherIsDone = otherStrategy and otherStrategy:isDone()
+            if otherStrategy and not otherIsDone then
                 local otherConvoyDistance = otherVehicle:getCpSettings().convoyDistance:getValue()
                 maxConvoyDistance = math.max(maxConvoyDistance, otherConvoyDistance)
                 local distanceFromOther = otherStrategy:getFieldWorkProximity(self.vehicle.rootNode)

--- a/scripts/ai/jobs/CpAIJob.lua
+++ b/scripts/ai/jobs/CpAIJob.lua
@@ -60,10 +60,12 @@ end
 
 --- Gets the first task to start with.
 function CpAIJob:getStartTaskIndex()
-	if self.isDirectStart then
+	if self.isDirectStart or self:isTargetReached() then
+		-- skip Giants driveTo
+		-- TODO: this isn't very nice as we rely here on the derived classes to add more tasks
 		return 2
 	end
-	return self:isTargetReached() and 2 or 1 
+	return 1
 end
 
 --- Should the giants path finder job be skipped?

--- a/scripts/ai/jobs/CpAIJobFieldWork.lua
+++ b/scripts/ai/jobs/CpAIJobFieldWork.lua
@@ -21,7 +21,12 @@ function CpAIJobFieldWork.new(isServer, customMt)
 end
 
 function CpAIJobFieldWork:setupTasks(isServer)
+	-- this will add a standard driveTo task to drive to the target position selected by the user
 	CpAIJobFieldWork:superClass().setupTasks(self, isServer)
+	-- then we add our own driveTo task to drive from the target position to the waypoint where the
+	-- fieldwork starts (first waypoint or the one we worked on last)
+	self.driveToFieldWorkStartTask = CpAITaskDriveTo.new(isServer, self)
+	self:addTask(self.driveToFieldWorkStartTask)
 	self.fieldWorkTask = CpAITaskFieldWork.new(isServer, self)
 	self:addTask(self.fieldWorkTask)
 end
@@ -104,6 +109,8 @@ end
 function CpAIJobFieldWork:setValues()
 	CpAIJobFieldWork:superClass().setValues(self)
 	local vehicle = self.vehicleParameter:getVehicle()
+	self.driveToFieldWorkStartTask:reset()
+	self.driveToFieldWorkStartTask:setVehicle(vehicle)
 	self.fieldWorkTask:setVehicle(vehicle)
 end
 

--- a/scripts/ai/jobs/CpAIJobFieldWork.lua
+++ b/scripts/ai/jobs/CpAIJobFieldWork.lua
@@ -153,6 +153,17 @@ function CpAIJobFieldWork:getCanGenerateFieldWorkCourse()
 	return self.hasValidPosition
 end
 
+-- To pass an alignment course from the drive to fieldwork start to the fieldwork, so the
+-- fieldwork strategy can continue the alignment course set up by the drive to fieldwork start strategy.
+function CpAIJobFieldWork:setStartFieldWorkCourse(course, ix)
+	self.startFieldWorkCourse = course
+	self.startFieldWorkCourseIx = ix
+end
+
+function CpAIJobFieldWork:getStartFieldWorkCourse()
+	return self.startFieldWorkCourse, self.startFieldWorkCourseIx
+end
+
 --- Is course generation allowed ?
 function CpAIJobFieldWork:isCourseGenerationAllowed()
 	return self:getCanGenerateFieldWorkCourse()

--- a/scripts/ai/tasks/CpAITaskDriveTo.lua
+++ b/scripts/ai/tasks/CpAITaskDriveTo.lua
@@ -12,12 +12,10 @@ end
 
 function CpAITaskDriveTo:start()
     CpUtil.infoVehicle(self.vehicle, 'CP drive to task started')
-    self.vehicle:startCpDriveTo(self.job:getCpJobParameters())
+    self.vehicle:startCpDriveTo(self, self.job:getCpJobParameters())
 end
 
 function CpAITaskDriveTo:update()
-    --- Test only
-    self.isFinished = true
 end
 
 function CpAITaskDriveTo:stop()

--- a/scripts/ai/tasks/CpAITaskDriveTo.lua
+++ b/scripts/ai/tasks/CpAITaskDriveTo.lua
@@ -1,0 +1,33 @@
+CpAITaskDriveTo = {}
+local AITaskDriveToCp_mt = Class(CpAITaskDriveTo, AITaskDriveTo)
+
+function CpAITaskDriveTo.new(isServer, job, customMt)
+    local self = AITaskDriveTo.new(isServer, job, customMt or AITaskDriveToCp_mt)
+    return self
+end
+
+function CpAITaskDriveTo:setVehicle(vehicle)
+    self.vehicle = vehicle
+end
+
+function CpAITaskDriveTo:start()
+    CpUtil.infoVehicle(self.vehicle, 'CP drive to task started')
+    self.vehicle:startCpDriveTo(self.job:getCpJobParameters())
+end
+
+function CpAITaskDriveTo:update()
+    --- Test only
+    self.isFinished = true
+end
+
+function CpAITaskDriveTo:stop()
+    if self.isServer then
+        CpUtil.infoVehicle(self.vehicle, 'CP drive to task stopped')
+        self.vehicle:stopCpDriveTo()
+    end
+    AITask.stop(self)
+end
+
+function CpAITaskDriveTo:onTargetReached()
+    self.isFinished = true
+end

--- a/scripts/ai/tasks/CpAITaskFieldWork.lua
+++ b/scripts/ai/tasks/CpAITaskFieldWork.lua
@@ -10,7 +10,7 @@ end
 --- Makes sure the cp fieldworker gets started.
 function CpAITaskFieldWork:start()
 	if self.isServer then
-		self.vehicle:cpStartFieldWorker(self.job:getCpJobParameters())
+		self.vehicle:startCpFieldWorker(self.job:getCpJobParameters())
 	end
 	AITask.start(self)
 	

--- a/scripts/field/CpFieldUtil.lua
+++ b/scripts/field/CpFieldUtil.lua
@@ -86,7 +86,7 @@ function CpFieldUtil.saveAllFields()
                 local key = ("CPFields.field(%d)"):format(field.fieldId);
                 setXMLInt(xmlFile, key .. '#fieldNum',	field.fieldId);
                 setXMLInt(xmlFile, key .. '#numPoints', #points);
-                for i,point in ipairs(points) do
+                for i, point in ipairs(points) do
                     setXMLString(xmlFile, key .. (".point%d#pos"):format(i), ("%.2f %.2f %.2f"):format(point.x, point.y, point.z))
                 end
                 local islandNodes = Island.findIslands( Polygon:new(CourseGenerator.pointsToXy(points)))

--- a/scripts/reloadAI.bat
+++ b/scripts/reloadAI.bat
@@ -6,5 +6,6 @@ type ai\AIDriveStrategyCourse.lua >> %outfile%
 type ai\AIDriveStrategyFieldWorkCourse.lua >> %outfile%
 type ai\AIDriveStrategyCombineCourse.lua >> %outfile%
 type ai\AIDriveStrategyPlowCourse.lua >> %outfile%
+type ai\AIDriveStrategyDriveToFieldWorkStart.lua >> %outfile%
 echo ]]^> >> %outfile%
 echo ^</code^> >> %outfile%

--- a/scripts/specializations/CpAIFieldWorker.lua
+++ b/scripts/specializations/CpAIFieldWorker.lua
@@ -51,7 +51,7 @@ function CpAIFieldWorker.registerFunctions(vehicleType)
             CpAIFieldWorker.getIsCpHarvesterWaitingForUnloadAfterPulledBack)
     SpecializationUtil.registerFunction(vehicleType, "getIsCpHarvesterManeuvering", CpAIFieldWorker.getIsCpHarvesterManeuvering)
     SpecializationUtil.registerFunction(vehicleType, "holdCpHarvesterTemporarily", CpAIFieldWorker.holdCpHarvesterTemporarily)
-    SpecializationUtil.registerFunction(vehicleType, "cpStartFieldWorker", CpAIFieldWorker.startFieldWorker)
+    SpecializationUtil.registerFunction(vehicleType, "startCpFieldWorker", CpAIFieldWorker.startCpFieldWorker)
     SpecializationUtil.registerFunction(vehicleType, "getCanStartCpFieldWork", CpAIFieldWorker.getCanStartCpFieldWork)
 
     SpecializationUtil.registerFunction(vehicleType, "startCpAtFirstWp", CpAIFieldWorker.startCpAtFirstWp)
@@ -182,7 +182,7 @@ function CpAIFieldWorker:startCpAtFirstWp()
     self:updateAIFieldWorkerImplementData()
     if self:hasCpCourse() and self:getCanStartCpFieldWork() then
         spec.cpJobStartAtFirstWp:applyCurrentState(self, g_currentMission, g_currentMission.player.farmId, true)
-        
+
         --- Applies the lane offset set in the hud, so ad can start with the correct lane offset.
         spec.cpJobStartAtFirstWp:getCpJobParameters().laneOffset:setValue(spec.cpJob:getCpJobParameters().laneOffset:getValue())
         spec.cpJobStartAtFirstWp:setValues()
@@ -249,7 +249,7 @@ end
 
 
 --- Custom version of AIFieldWorker:startFieldWorker()
-function CpAIFieldWorker:startFieldWorker(jobParameters)
+function CpAIFieldWorker:startCpFieldWorker(jobParameters)
     --- Calls the giants startFieldWorker function.
     self:startFieldWorker()
     if self.isServer then 

--- a/scripts/specializations/CpAIWorker.lua
+++ b/scripts/specializations/CpAIWorker.lua
@@ -32,6 +32,7 @@ end
 function CpAIWorker.registerEventListeners(vehicleType)
 	SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", CpAIWorker)
 	SpecializationUtil.registerEventListener(vehicleType, "onLoad", CpAIWorker)
+    SpecializationUtil.registerEventListener(vehicleType, "onUpdate", CpAIWorker)
     SpecializationUtil.registerEventListener(vehicleType, "onUpdateTick", CpAIWorker)
 end
 
@@ -206,10 +207,47 @@ function CpAIWorker:getCpStartText()
 	return ""
 end
 
-function CpAIWorker:startCpDriveTo()
-
+function CpAIWorker:startCpDriveTo(task, jobParameters)
+    self.driveToTask = task
+    ---@type AIDriveStrategyDriveToFieldWorkStart
+    self.driveToFieldWorkStartStrategy = AIDriveStrategyDriveToFieldWorkStart.new()
+    -- this also starts the strategy
+    self.driveToFieldWorkStartStrategy:setAIVehicle(self, jobParameters)
 end
 
 function CpAIWorker:stopCpDriveTo()
+    self.driveToFieldWorkStartStrategy:delete()
+    self.driveToFieldWorkStartStrategy = nil
+end
 
+function CpAIWorker:onUpdate(dt)
+    if self.driveToFieldWorkStartStrategy then
+        if self.driveToFieldWorkStartStrategy:isWorkStartReached() then
+            CpUtil.debugVehicle(CpDebug.DBG_FIELDWORK, self, 'Work start location reached')
+            self.driveToTask:onTargetReached()
+        else
+            self.driveToFieldWorkStartStrategy:update(dt)
+            if g_updateLoopIndex % 4 == 0 then
+                local tX, tZ, moveForwards, maxSpeed = self.driveToFieldWorkStartStrategy:getDriveData(dt)
+
+                -- same as AIFieldWorker:updateAIFieldWorker(), do the actual driving
+                local tY = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, tX, 0, tZ)
+                local pX, _, pZ = worldToLocal(self:getAISteeringNode(), tX, tY, tZ)
+
+                if not moveForwards and self.spec_articulatedAxis ~= nil and
+                        self.spec_articulatedAxis.aiRevereserNode ~= nil then
+                    pX, _, pZ = worldToLocal(self.spec_articulatedAxis.aiRevereserNode, tX, tY, tZ)
+                end
+
+                if not moveForwards and self:getAIReverserNode() ~= nil then
+                    pX, _, pZ = worldToLocal(self:getAIReverserNode(), tX, tY, tZ)
+                end
+
+                local acceleration = 1
+                local isAllowedToDrive = maxSpeed ~= 0
+
+                AIVehicleUtil.driveToPoint(self, dt, acceleration, isAllowedToDrive, moveForwards, pX, pZ, maxSpeed)
+            end
+        end
+    end
 end

--- a/scripts/specializations/CpAIWorker.lua
+++ b/scripts/specializations/CpAIWorker.lua
@@ -41,6 +41,8 @@ function CpAIWorker.registerFunctions(vehicleType)
 	SpecializationUtil.registerFunction(vehicleType, "getCpStartText", CpAIWorker.getCpStartText)
     SpecializationUtil.registerFunction(vehicleType, "cpStartStopDriver", CpAIWorker.startStopDriver)
     SpecializationUtil.registerFunction(vehicleType, "getCanStartCp", CpAIWorker.getCanStartCp)
+    SpecializationUtil.registerFunction(vehicleType, "startCpDriveTo", CpAIWorker.startCpDriveTo)
+    SpecializationUtil.registerFunction(vehicleType, "stopCpDriveTo", CpAIWorker.stopCpDriveTo)
 end
 
 function CpAIWorker.registerOverwrittenFunctions(vehicleType)
@@ -204,3 +206,10 @@ function CpAIWorker:getCpStartText()
 	return ""
 end
 
+function CpAIWorker:startCpDriveTo()
+
+end
+
+function CpAIWorker:stopCpDriveTo()
+
+end


### PR DESCRIPTION
Added separate task and strategy to drive from where Giants or AutoDrive leaves the vehicle to the point where it starts the fieldwork. This is to make all implements are in the driving position until just before the fieldwork starts.