### PR TITLE
Fix for 180 turn offset multitool

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,3 +29,4 @@ jobs:
           lua CourseManagerTest.lua
           lua CpMathUtilTest.lua
           lua MovingAverageTest.lua
+          lua PolygonTest.lua

--- a/scripts/courseGenerator/geo.lua
+++ b/scripts/courseGenerator/geo.lua
@@ -639,12 +639,14 @@ function Polyline:add(p)
 	table.insert(self, p)
 end
 
-function Polyline:getClosestPointIndex(p)
+---@param delta number threshold for comparison, any difference less than delta is ignored
+function Polyline:getClosestPointIndex(p, delta)
+	delta = delta or 0
 	local minDistance = math.huge
 	local ix
 	for i, vertex in self:iterator() do
 		local d = getDistanceBetweenPoints(vertex, p)
-		if d < minDistance then
+		if d < minDistance and minDistance - d >= delta then
 			minDistance = d
 			ix = i
 		end
@@ -783,9 +785,17 @@ function Polyline:replacePointsWithArc( fromIx, toIx, r )
 end
 
 --- Return the section of self starting at the vertex closest to point a and ending at the vertex closest to b
-function Polyline:getSectionBetweenPoints(a, b)
-	local startIx = self:getClosestPointIndex(a)
-	local endIx = self:getClosestPointIndex(b)
+---@param delta number when searching for the polyline points closest to a and b, use delta as a threshold
+--- this is to solve the issue when working on overlapping headlands (where the connection track overlaps with
+--- the first part of the headland) in a multitool situation, where the headland is calculated as an offset course
+--- and the overlapping part will not have the exact same coordinates (like the vanilla generated course would have).
+--- In this case it is possible that one of startIx or endIx are on the overlap, the other on the non-overlap part,
+--- resulting in a section going through the first point.
+--- Alternatively, we could write getClosestPointIndex() so that it detects overlaps and stops the loop after a full
+--- circle, but it is part of Polyline that should not know about overlaps...
+function Polyline:getSectionBetweenPoints(a, b, delta)
+	local startIx = self:getClosestPointIndex(a, delta)
+	local endIx = self:getClosestPointIndex(b, delta)
 	local section = Polyline:new()
 	local i = 1
 	for _, p in self:iteratorClosestDistance(startIx, endIx) do

--- a/scripts/pathfinder/PathfinderUtil.lua
+++ b/scripts/pathfinder/PathfinderUtil.lua
@@ -655,8 +655,8 @@ local function findShortestPathOnHeadland(start, goal, course, turnRadius)
     local headland = getOutermostHeadland(course)
     headland:calculateData()
     local path = {}
-    for _, p in ipairs(headland:getSectionBetweenPoints(start, goal)) do
-        --CourseGenerator.debug('%.1f %.1f', p.x, p.y)
+    for _, p in ipairs(headland:getSectionBetweenPoints(start, goal, 2)) do
+        CourseGenerator.debug('%.1f %.1f', p.x, p.y)
         table.insert(path, State3D(p.x, p.y, 0))
     end
     return path

--- a/scripts/test/PolygonTest.lua
+++ b/scripts/test/PolygonTest.lua
@@ -1,0 +1,89 @@
+lu = require("luaunit")
+package.path = package.path .. ";../?.lua;../courseGenerator/?.lua;../pathfinder/?.lua"
+require('CpObject')
+require('geo')
+require('State3D')
+require('AnalyticSolution')
+
+local function p(x, y)
+    return {x = x, y = y}
+end
+
+local function assertPointsEqual(a, b)
+    lu.assertEquals(#a, #b)
+    for i = 1, #a do
+        lu.assertEquals(a[i].x, b[i].x, string.format('at index %d', i))
+        lu.assertEquals(a[i].y, b[i].y, string.format('at index %d', i))
+    end
+end
+
+local vertices = {
+    p(10, 0),
+    p(15, 0),
+    p(20, 0),
+    p(20, 5),
+    p(20, 10),
+    p(20, 15),
+    p(20, 20),
+    p(15, 20),
+    p(10, 20),
+    p(5, 20),
+    p(0, 20),
+    p(0, 15),
+    p(0, 10),
+    p(0, 5),
+    p(0, 0),
+    p(5, 0),
+    -- overlap with the first few waypoints to simulate a connecting track on the headland
+    p(10, 0),
+    -- not exactly the same coordinates as it could be a calculated offset course
+    p(15.01, 0),
+    p(20, 0),
+    p(20, 5),
+}
+
+local headland = Polygon:new(vertices)
+
+local s = headland:getSectionBetweenPoints(State3D(11, 0, 0), State3D(12, 0, 0))
+assertPointsEqual(s, {p(10, 0)})
+s = headland:getSectionBetweenPoints(State3D(12, 0, 0), State3D(11, 0, 0))
+assertPointsEqual(s, {p(10, 0)})
+
+s = headland:getSectionBetweenPoints(State3D(12, 0, 0), State3D(9, 0, 0))
+assertPointsEqual(s, {p(10, 0)})
+s = headland:getSectionBetweenPoints(State3D(9, 0, 0), State3D(12, 0, 0))
+assertPointsEqual(s, {p(10, 0)})
+
+-- offset course test
+s = headland:getSectionBetweenPoints(State3D(9, 0, 0), State3D(17, 0, 0), 0.1)
+assertPointsEqual(s, {p(10, 0), p(15, 0)})
+s = headland:getSectionBetweenPoints(State3D(17, 0, 0), State3D(9, 0, 0), 0.1)
+assertPointsEqual(s, {p(15, 0), p(10, 0)})
+
+s = headland:getSectionBetweenPoints(State3D(8, 0, 0), State3D(9, 0, 0))
+assertPointsEqual(s, {p(10, 0)})
+s = headland:getSectionBetweenPoints(State3D(9, 0, 0), State3D(8, 0, 0))
+assertPointsEqual(s, {p(10, 0)})
+
+s = headland:getSectionBetweenPoints(State3D(8, 1, 0), State3D(9, 2, 0))
+assertPointsEqual(s, {p(10, 0)})
+
+s = headland:getSectionBetweenPoints(State3D(19, 0, 0), State3D(20, 6, 0))
+assertPointsEqual(s, {p(20, 0), p(20, 5)})
+
+-- another offset with overlap test
+s = headland:getSectionBetweenPoints(State3D(20, 11, 0), State3D(16, 0, 0), 0.1)
+assertPointsEqual(s, {p(20, 10), p(20, 5), p(20, 0), p(15, 0)})
+
+-- another offset with overlap test
+s = headland:getSectionBetweenPoints(
+        State3D(16, 0, 0),
+        State3D(20, 11, 0),
+        0.1
+)
+assertPointsEqual(s, {
+    p(15, 0),
+    p(20, 0),
+    p(20, 5),
+    p(20, 10),
+})


### PR DESCRIPTION
When there is a connecting track (which overlaps a part
of the headland) we sometimes select the wrong waypoint
to start/end the section of the turn following the headland.

Made sure no points on the overlapping headland part are used
in a wide turn.

Note that this does not fix the missing connecting track labels
on the left/right offset courses.