### PR TITLE
Should fix mp info texts #1220 and added debug channel event.

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -148,11 +148,12 @@ Funktionen:
 		<sourceFile filename="scripts/gui/VehicleSettingDisplayDialog.lua"/>
 		<sourceFile filename="scripts/gui/hud/HudElements.lua"/>
 		<sourceFile filename="scripts/gui/hud/CpBaseHud.lua"/>
+		<sourceFile filename="scripts/gui/hud/CpHudInfoTexts.lua"/>
 		<sourceFile filename="scripts/events/CoursesEvent.lua"/>
 		<sourceFile filename="scripts/events/CpJoinEvent.lua"/>
 		<sourceFile filename="scripts/events/GlobalSettingsEvent.lua"/>
 		<sourceFile filename="scripts/events/VehicleSettingsEvent.lua"/>
-		<sourceFile filename="scripts/gui/hud/CpHudInfoTexts.lua"/>
+		<sourceFile filename="scripts/events/DebugChannelEvent.lua"/>
 	</extraSourceFiles>
 
 	<specializations>

--- a/scripts/ai/InfoTextsManager.lua
+++ b/scripts/ai/InfoTextsManager.lua
@@ -97,25 +97,26 @@ function InfoTextManager:getActiveInfoTexts()
 	local validInfoText
 	for _,infoText in ipairs(self.infoTexts) do 
 		for _,vehicle in pairs(self.vehicles) do 
-			
-			--- dev functionally for testing.
-			if self.numActiveTexts > 0 then 
-				validInfoText = true 
-				if i == 0 then 
-					break
+			if g_currentMission.accessHandler:canPlayerAccess(vehicle) then
+				--- dev functionally for testing.
+				if self.numActiveTexts > 0 then 
+					validInfoText = true 
+					if i == 0 then 
+						break
+					end
+					i = i - 1 
+				else 
+					validInfoText = vehicle:getIsCpInfoTextActive(infoText)
 				end
-				i = i - 1 
-			else 
-				validInfoText = vehicle:getIsCpInfoTextActive(infoText)
+			
+				if validInfoText then 
+					local info = {
+						text = infoText.text,
+						vehicle = vehicle
+					}
+					table.insert(infos,info)
+				end	
 			end
-		
-			if validInfoText then 
-				local info = {
-					text = infoText.text,
-					vehicle = vehicle
-				}
-				table.insert(infos,info)
-			end	
 		end
 	end
 	return infos

--- a/scripts/debug/CpDebug.lua
+++ b/scripts/debug/CpDebug.lua
@@ -67,6 +67,10 @@ function CpDebug:isChannelActive(ix, vehicle)
 	end
 end
 
+function CpDebug:setChannelActive(ix, active)
+	self.channels[ix].active = active
+end
+
 ---Sets the next select channel.
 function CpDebug:setNext()
 	if not self:isMenuVisible() then return end
@@ -89,6 +93,7 @@ end
 function CpDebug:toggleCurrentChannel()
 	if not self:isMenuVisible() then return end
 	self.channels[self.currentIx].active = not self.channels[self.currentIx].active
+	DebugChannelEvent.sendEvent(self.currentIx, self.channels[self.currentIx].active)
 end
 
 ---Draws the channels at the bottom if it's enabled.

--- a/scripts/events/CpJoinEvent.lua
+++ b/scripts/events/CpJoinEvent.lua
@@ -24,6 +24,10 @@ function CpJoinEvent:readStream(streamId, connection) -- wird aufgerufen wenn mi
 	for i = 1, #settings do 
 		settings[i]:readStream(streamId, connection)
 	end
+
+	for i = 1, #CpDebug.channels do 
+		CpDebug:setChannelActive(i, streamReadBool(streamId))
+	end
 	
 	self:run(connection);
 end
@@ -35,6 +39,11 @@ function CpJoinEvent:writeStream(streamId, connection)  -- Wird aufgrufen wenn i
 	for i = 1, #settings do 
 		settings[i]:writeStream(streamId, connection)
 	end
+
+	for i = 1, #CpDebug.channels do 
+		streamWriteBool(streamId, CpDebug:isChannelActive(i))
+	end
+
 end
 
 --- Runs the event on the receiving end of the event.

--- a/scripts/events/DebugChannelEvent.lua
+++ b/scripts/events/DebugChannelEvent.lua
@@ -1,0 +1,44 @@
+---@class DebugChannelEvent
+DebugChannelEvent = {}
+local DebugChannelEvent_mt = Class(DebugChannelEvent, Event)
+
+InitEventClass(DebugChannelEvent, "DebugChannelEvent")
+
+function DebugChannelEvent.emptyNew()
+	return Event.new(DebugChannelEvent_mt)
+end
+
+function DebugChannelEvent.new(channel, value)
+	local self = DebugChannelEvent.emptyNew()
+	self.channel = channel
+	self.value = value
+	return self
+end
+
+function DebugChannelEvent:readStream(streamId, connection)
+	self.channel = streamReadUInt8(streamId)
+	self.value = streamReadBool(streamId)
+	self:run(connection)
+end
+
+function DebugChannelEvent:writeStream(streamId, connection)
+	streamWriteUInt8(streamId, self.channel)
+	streamWriteBool(streamId, self.value or false)
+end
+
+-- Process the received event
+function DebugChannelEvent:run(connection)
+	CpDebug:setChannelActive(self.channel, self.value)
+	if not connection:getIsServer() then
+		-- event was received from a client, so we, the server broadcast it to all other clients now
+		g_server:broadcastEvent(DebugChannelEvent.new(self.channel, self.value))
+	end
+end
+
+function DebugChannelEvent.sendEvent(channel, value)
+	if g_server ~= nil then
+		g_server:broadcastEvent(DebugChannelEvent.new(channel, value))
+	else
+		g_client:getServerConnection():sendEvent(DebugChannelEvent.new(channel, value))
+	end
+end

--- a/scripts/specializations/CpInfoTexts.lua
+++ b/scripts/specializations/CpInfoTexts.lua
@@ -76,10 +76,10 @@ function CpInfoTexts:onWriteStream(streamId)
 	streamWriteInt32(streamId, CpInfoTexts.getBitMask(self))
 end
 
-function CpInfoTexts:onEnterVehicle()
-	if self.isServer and not self:getIsCpActive() then 
-		local spec = self.spec_cpInfoTexts
-		if next(spec.activeInfoTexts) ~= nil then
+function CpInfoTexts:onEnterVehicle(isControlling)
+	local spec = self.spec_cpInfoTexts
+	if not self:getIsCpActive() and next(spec.activeInfoTexts) ~= nil then
+		if self.isServer then
 			self:resetCpAllActiveInfoTexts()
 		end
 	end
@@ -129,6 +129,7 @@ function CpInfoTexts:resetCpAllActiveInfoTexts()
 	local spec = self.spec_cpInfoTexts
 	spec.activeInfoTexts = {}
 	CpInfoTexts.raiseDirtyFlag(self)
+	CpUtil.debugVehicle(CpDebug.DBG_HUD, self, "All info texts were cleared.")
 end
 
 function CpInfoTexts:getCpActiveInfoTexts()
@@ -160,12 +161,11 @@ function CpInfoTexts:setFromBitMask(bitMask)
 	local spec = self.spec_cpInfoTexts
 	local bits = MathUtil.getBinary(bitMask)
 	local id
+	spec.activeInfoTexts = {}
 	for ix, bit in ipairs(bits) do 
 		id = bitShiftLeft(1, ix-1)
 		if bit == 1 then
 			spec.activeInfoTexts[id] = g_infoTextManager:getInfoTextById(id)
-		else 
-			spec.activeInfoTexts[id] = nil
 		end
 	end
 end


### PR DESCRIPTION
Test mp:
  - info texts are reseted when entered and the driver has finished.
  - only info texts from vehicles that can be entered should be displayed.
  - check if the debug channels are synchron with the server.