### PR TITLE
Turn fix for #1272

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -76,9 +76,15 @@ You can define the following custom settings:
 
 - lowerEarly: boolean
     Similar to the above, the default behavior when starting to work is lower the implement when the back of the
-    work area reaches to row start/field edge. Setting this to true will make Courseplay lowere the implement as
+    work area reaches to row start/field edge. Setting this to true will make Courseplay lower the implement as
     soon as the the front reaches the row start/field edge, avoiding unworked patches with irregular implement
     work areas such as a plow.
+
+- useVehicleSizeForMarkers: boolean
+    Some vehicles and implements, mostly used for grape harvest have no AI markers and not even a work area.
+    In order for these to perform turn maneuvers correctly we still need a front and back marker, which usually
+    are derived from the AI markers or from the work areas. If useVehicleSizeForMarkers is true, we simply place
+    the front marker on the front of the vehicle, the back marker on the back if there is no AI marker or work area.
 
 - modName: Name of the .zip file (without '.zip')
     In case a Mod has the same .xml filename for the vehicle/implement, as a default giants vehicle/implement,

--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -102,11 +102,13 @@ You can define the following custom settings:
              raiseLate="true"
              lowerEarly="true"
              turnRadius="5"
+             useVehicleSizeForMarkers="true"
     />
     <Vehicle name="braud9090X.xml"
              raiseLate="true"
              lowerEarly="true"
              turnRadius="5"
+             useVehicleSizeForMarkers="true"
     />
     <!-- Implements -->
 
@@ -234,6 +236,7 @@ You can define the following custom settings:
              raiseLate="true"
              lowerEarly="true"
              turnRadius="5"
+             useVehicleSizeForMarkers="true"
     />
 
     <!--Tractors-->

--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -129,7 +129,7 @@ function WorkWidthUtil.getAIMarkers(object, logPrefix, suppressLog)
         end
         aiLeftMarker, aiRightMarker, aiBackMarker = WorkWidthUtil.getAIMarkersFromWorkAreas(object)
         if not aiLeftMarker or not aiRightMarker or not aiLeftMarker then
-            if g_vehicleConfigurations.get(object, 'useVehicleSizeForMarkers') then
+            if g_vehicleConfigurations:get(object, 'useVehicleSizeForMarkers') then
                 if not suppressLog then
                     WorkWidthUtil.debug(object, logPrefix, 'has no work areas, configured to use front/back markers')
                 end

--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -129,10 +129,17 @@ function WorkWidthUtil.getAIMarkers(object, logPrefix, suppressLog)
         end
         aiLeftMarker, aiRightMarker, aiBackMarker = WorkWidthUtil.getAIMarkersFromWorkAreas(object)
         if not aiLeftMarker or not aiRightMarker or not aiLeftMarker then
-            if not suppressLog then
-                WorkWidthUtil.debug(object, logPrefix, 'has no work areas, giving up, will use front/back markers')
+            if g_vehicleConfigurations.get(object, 'useVehicleSizeForMarkers') then
+                if not suppressLog then
+                    WorkWidthUtil.debug(object, logPrefix, 'has no work areas, configured to use front/back markers')
+                end
+                return Markers.getFrontMarkerNode(object), Markers.getFrontMarkerNode(object), Markers.getBackMarkerNode(object)
+            else
+                if not suppressLog then
+                    WorkWidthUtil.debug(object, logPrefix, 'has no work areas, giving up')
+                end
+                return nil, nil, nil
             end
-            return Markers.getFrontMarkerNode(object), Markers.getFrontMarkerNode(object), Markers.getBackMarkerNode(object)
         else
             if not suppressLog then WorkWidthUtil.debug(object, logPrefix, 'AI markers from work area set') end
             return aiLeftMarker, aiRightMarker, aiBackMarker

--- a/scripts/config/VehicleConfigurations.lua
+++ b/scripts/config/VehicleConfigurations.lua
@@ -43,6 +43,7 @@ VehicleConfigurations.attributes = {
     baleCollectorOffset = XMLValueType.FLOAT,
     raiseLate = XMLValueType.BOOL,
     lowerEarly = XMLValueType.BOOL,
+    useVehicleSizeForMarkers = XMLValueType.BOOL,
 }
 
 


### PR DESCRIPTION
Introduce useVehicleSizeForMarkers for those weird
grape tools/vehicles which have no work area or
AI markers.

These will need to be added to the VehicleConfigurations.xml,
this is not part of this commit.