### PR TITLE
Headland -> up/down transition fix

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -624,7 +624,8 @@ end
 
 --- How far are we from the waypoint marked as the beginning of the up/down rows?
 ---@param ix number start searching from this index. Will stop searching after 100 m
----@return number of meters or math.huge if no start up/down row waypoint found within 100 meters and the index of the first up/down waypoint
+---@return number, number of meters or math.huge if no start up/down row waypoint found within 100 meters and the
+--- index of the first up/down waypoint
 function Course:getDistanceToFirstUpDownRowWaypoint(ix)
 	local d = 0
 	local isConnectingTrack = false

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -391,6 +391,11 @@ function AIDriveStrategyFieldWorkCourse:onWaypointChange(ix, course)
             self:debug('connecting track ended, back to work, first lowering implements.')
             self.state = self.states.WORKING
             self:lowerImplements()
+        elseif self.course:isTurnStartAtIx(ix) and
+                not self.course:isOnConnectingTrack(ix + 1) and
+                not self.course:isOnHeadland(ix + 1)then
+            self:debug('ending connecting track with a turn into the up/down rows')
+            self:startTurn(ix)
         end
     elseif self.state == self.states.WORKING then
         -- towards the end of the field course make sure the implement reaches the last waypoint


### PR DESCRIPTION
Do not skip a turn on connecting track if the turn starts
at the end of the connecting track leading into the
first up/down row.