### PR TITLE
Moves the turn slightly outwards from the vine rows.

### DIFF
--- a/scripts/ai/AIDriveStrategyVineFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyVineFieldWorkCourse.lua
@@ -48,3 +48,8 @@ end
 function AIDriveStrategyVineFieldWorkCourse:getImplementLowerEarly()
     return true
 end
+
+--- Creates a little space between the vine rows and the turn.
+function AIDriveStrategyVineFieldWorkCourse:getTurnEndForwardOffset()
+    return -4
+end

--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -133,7 +133,7 @@ function WorkWidthUtil.getAIMarkers(object, logPrefix, suppressLog)
                 if not suppressLog then
                     WorkWidthUtil.debug(object, logPrefix, 'has no work areas, configured to use front/back markers')
                 end
-                return Markers.getFrontMarkerNode(object), Markers.getFrontMarkerNode(object), Markers.getBackMarkerNode(object)
+                return Markers.getFrontMarkerNode(object.rootVehicle), Markers.getFrontMarkerNode(object.rootVehicle), Markers.getBackMarkerNode(object.rootVehicle)
             else
                 if not suppressLog then
                     WorkWidthUtil.debug(object, logPrefix, 'has no work areas, giving up')


### PR DESCRIPTION
TODO: 
- disable pathfinder turns, as they get stuck on the vine rows(collision).
- vine tool at the front of the vehicle needs the ai markers for the complete vehicle combo ('useVehicleSizeForMarkers') #1295 