### PR TITLE
noReverse config activated

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -174,6 +174,7 @@ You can define the following custom settings:
              implementWheelAlwaysOnGround = "true"
 	/>
     <Vehicle name="titan18.xml"
+             noReverse="true"
              turnRadius = "9"
              implementWheelAlwaysOnGround = "true"
              raiseLate = "true"
@@ -265,6 +266,7 @@ You can define the following custom settings:
              baleCollectorOffset="1.5"
     />
     <Vehicle name="pw10012.xml"
+             noReverse="true"
              implementWheelAlwaysOnGround = "true"
              turnRadius="14"
              raiseLate="true"

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -605,3 +605,16 @@ function AIUtil.getWidth(vehicle)
 		return vehicle.size.width
 	end
 end
+
+--- Can we reverse with whatever is attached to the vehicle?
+function AIUtil.canReverse(vehicle)
+	if AIVehicleUtil.getAttachedImplementsBlockTurnBackward(vehicle) then
+		-- Giants says no reverse
+		return false
+	elseif g_vehicleConfigurations:getRecursively(vehicle, 'noReverse') then
+		-- our configuration disabled reverse
+		return false
+	else
+		return true
+	end
+end

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -291,9 +291,10 @@ function AnalyticTurnManeuver:init(vehicle, turnContext, vehicleDirectionNode, t
 	local dzMax = self:getDzMax(self.course)
 	local spaceNeededOnFieldForTurn = dzMax + workWidth / 2
 	distanceToFieldEdge = distanceToFieldEdge or 500  -- if not given, assume we have a lot of space
-	self:debug('dzMax=%.1f, workWidth=%.1f, spaceNeeded=%.1f, distanceToFieldEdge=%.1f, ixBeforeEndingTurnSection=%d',
-		dzMax, workWidth, spaceNeededOnFieldForTurn, distanceToFieldEdge, ixBeforeEndingTurnSection)
-	if distanceToFieldEdge < spaceNeededOnFieldForTurn then
+	local canReverse = AIUtil.canReverse(vehicle)
+	self:debug('dzMax=%.1f, workWidth=%.1f, spaceNeeded=%.1f, distanceToFieldEdge=%.1f, ixBeforeEndingTurnSection=%d, canReverse=%s',
+		dzMax, workWidth, spaceNeededOnFieldForTurn, distanceToFieldEdge, ixBeforeEndingTurnSection, canReverse)
+	if distanceToFieldEdge < spaceNeededOnFieldForTurn and canReverse then
 		self.course = self:moveCourseBack(self.course, spaceNeededOnFieldForTurn - distanceToFieldEdge,
 			ixBeforeEndingTurnSection, endingTurnLength)
 	end


### PR DESCRIPTION
If noReverse is configured for an implement,
or the Giants function reports it should not
be reversed then don't move a turn back to
able to remain on the field as it always
introduces reverse sections.