### PR TITLE
Added simple settings mode.

### DIFF
--- a/config/CourseGeneratorSettingsSetup.xml
+++ b/config/CourseGeneratorSettingsSetup.xml
@@ -24,7 +24,7 @@
 				<Text>up_down_rows</Text>
 			</Texts>
 		</Setting>
-		<Setting classType="AIParameterSettingList" name="headlandCornerType" >
+		<Setting classType="AIParameterSettingList" name="headlandCornerType" isExpertModeOnly="true" default="1">
 			<Values>
 				<Value name="HEADLAND_CORNER_TYPE_SMOOTH">1</Value> 
 				<Value name="HEADLAND_CORNER_TYPE_SHARP">2</Value> 
@@ -36,7 +36,7 @@
 				<Text>round</Text> 
 			</Texts> 
 		</Setting>
-		<Setting classType="AIParameterSettingList" name="isClockwise">
+		<Setting classType="AIParameterSettingList" name="isClockwise" isExpertModeOnly="true" default="1">
 			<Values>
 				<Value name="HEADLAND_CLOCKWISE">1</Value>
 				<Value name="HEADLAND_COUNTERCLOCKWISE">2</Value>
@@ -46,7 +46,7 @@
 				<Text>counterclockwise</Text>
 			</Texts>
 		</Setting>
-		<Setting classType="AIParameterSettingList" name="headlandOverlapPercent" min="0" max="25" default="7" unit="4"/>
+		<Setting classType="AIParameterSettingList" name="headlandOverlapPercent" min="0" max="25" default="7" unit="4" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 	<SettingSubTitle title="center">
 		<Setting classType="AIParameterSettingList" name="centerMode">
@@ -63,7 +63,7 @@
 				<Text>lands</Text> 
 			</Texts> 
 		</Setting>	
-		<Setting classType="AIParameterSettingList" name="rowDirection" >
+		<Setting classType="AIParameterSettingList" name="rowDirection" default="5" isExpertModeOnly="true">
 			<Values>
 				<Value name="ROW_DIRECTION_AUTOMATIC">5</Value>
 				<Value name="ROW_DIRECTION_LONGEST_EDGE">6</Value>
@@ -77,7 +77,7 @@
 		</Setting>
 		<Setting classType="AIParameterSettingList" name="rowsToSkip" min="0" max="6"/>
 		<Setting classType="AIParameterSettingList" name="rowsPerLand" min="2" max="24" default="6"/>
-		<Setting classType="AIParameterSettingList" name="manualRowAngleDeg" min="0" max="175" incremental="5" unit="5"/>
+		<Setting classType="AIParameterSettingList" name="manualRowAngleDeg" min="0" max="175" incremental="5" unit="5" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 	<SettingSubTitle title="advanced">
 		<Setting classType="AIParameterSettingList" name="islandBypassMode">
@@ -92,6 +92,6 @@
 				<Text>none</Text>
 			</Texts>
 		</Setting>
-		<Setting classType="AIParameterSettingList" name="fieldMargin" min="-5" max="6" default="0" incremental="0.2"/>
+		<Setting classType="AIParameterSettingList" name="fieldMargin" min="-5" max="6" default="0" incremental="0.2" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 </Settings>

--- a/config/GlobalSettingsSetup.xml
+++ b/config/GlobalSettingsSetup.xml
@@ -8,7 +8,7 @@
 <Settings prefixText="CP_global_setting_">
 	<SettingSubTitle prefix="true" title="general">
 		<!-- When enabled, then a few settings are invisible and return their default values. -->
-		<Setting classType="AIParameterBooleanSetting" name="simpleUserModeEnabled" defaultBool="false" onChangeCallback="onSimpleModeChanged"/>
+		<Setting classType="AIParameterBooleanSetting" name="expertModeActive" defaultBool="false" onChangeCallback="onExpertModeChanged"/>
 
 		<Setting classType="AIParameterSettingList" name="wageModifier" default="100" unit="4">
 			<Values>
@@ -38,14 +38,14 @@
 	</SettingSubTitle>
 	<SettingSubTitle prefix="true" title="userSettings">
 		<Setting classType="AIParameterBooleanSetting" name="controllerHudSelected" defaultBool="false" onChangeCallback="onHudSelectionChanged" isUserSetting="true"/>
-		<Setting classType="AIParameterBooleanSetting" name="showsAllActiveCourses" isUserSetting="true" defaultBool="false" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="showsAllActiveCourses" isUserSetting="true" defaultBool="false" isExpertModeOnly="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="showActionEventHelp" isUserSetting="true" defaultBool="true" onChangeCallback="onActionEventTextVisibilityChanged"/>
 		<Setting classType="AIParameterBooleanSetting" name="infoTextHudActive" isUserSetting="true" defaultBool="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="infoTextHudPlayerMouseActive" isUserSetting="true" defaultBool="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="preferCustomFields" isUserSetting="true"/>
 	</SettingSubTitle>
-	<SettingSubTitle prefix="true" title="pathfinder" isSimpleSetting="false">
-		<Setting classType="AIParameterSettingList" name="maxDeltaAngleAtGoal" min="5" max="90" incremental="5" default="45" isSimpleSetting="false"/>
-		<Setting classType="AIParameterSettingList" name="deltaAngleRelaxFactor" min="10" max="100" incremental="10" default="10" isSimpleSetting="false"/>
+	<SettingSubTitle prefix="true" title="pathfinder" isExpertModeOnly="true">
+		<Setting classType="AIParameterSettingList" name="maxDeltaAngleAtGoal" min="5" max="90" incremental="5" default="45" isExpertModeOnly="true"/>
+		<Setting classType="AIParameterSettingList" name="deltaAngleRelaxFactor" min="10" max="100" incremental="10" default="10" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 </Settings>

--- a/config/GlobalSettingsSetup.xml
+++ b/config/GlobalSettingsSetup.xml
@@ -7,6 +7,9 @@
 
 <Settings prefixText="CP_global_setting_">
 	<SettingSubTitle prefix="true" title="general">
+		<!-- When enabled, then a few settings are invisible and return their default values. -->
+		<Setting classType="AIParameterBooleanSetting" name="simpleUserModeEnabled" defaultBool="false" onChangeCallback="onSimpleModeChanged"/>
+
 		<Setting classType="AIParameterSettingList" name="wageModifier" default="100" unit="4">
 			<Values>
 				<Value>0</Value>
@@ -35,14 +38,14 @@
 	</SettingSubTitle>
 	<SettingSubTitle prefix="true" title="userSettings">
 		<Setting classType="AIParameterBooleanSetting" name="controllerHudSelected" defaultBool="false" onChangeCallback="onHudSelectionChanged" isUserSetting="true"/>
-		<Setting classType="AIParameterBooleanSetting" name="showsAllActiveCourses" isUserSetting="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="showsAllActiveCourses" isUserSetting="true" defaultBool="false" isSimpleSetting="false"/>
 		<Setting classType="AIParameterBooleanSetting" name="showActionEventHelp" isUserSetting="true" defaultBool="true" onChangeCallback="onActionEventTextVisibilityChanged"/>
 		<Setting classType="AIParameterBooleanSetting" name="infoTextHudActive" isUserSetting="true" defaultBool="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="infoTextHudPlayerMouseActive" isUserSetting="true" defaultBool="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="preferCustomFields" isUserSetting="true"/>
 	</SettingSubTitle>
-	<SettingSubTitle prefix="true" title="pathfinder">
-		<Setting classType="AIParameterSettingList" name="maxDeltaAngleAtGoal" min="5" max="90" incremental="5" default="45"/>
-		<Setting classType="AIParameterSettingList" name="deltaAngleRelaxFactor" min="10" max="100" incremental="10" default="10"/>
+	<SettingSubTitle prefix="true" title="pathfinder" isSimpleSetting="false">
+		<Setting classType="AIParameterSettingList" name="maxDeltaAngleAtGoal" min="5" max="90" incremental="5" default="45" isSimpleSetting="false"/>
+		<Setting classType="AIParameterSettingList" name="deltaAngleRelaxFactor" min="10" max="100" incremental="10" default="10" isSimpleSetting="false"/>
 	</SettingSubTitle>
 </Settings>

--- a/config/GlobalSettingsSetup.xml
+++ b/config/GlobalSettingsSetup.xml
@@ -7,9 +7,6 @@
 
 <Settings prefixText="CP_global_setting_">
 	<SettingSubTitle prefix="true" title="general">
-		<!-- When enabled, then a few settings are invisible and return their default values. -->
-		<Setting classType="AIParameterBooleanSetting" name="expertModeActive" defaultBool="false" onChangeCallback="onExpertModeChanged"/>
-
 		<Setting classType="AIParameterSettingList" name="wageModifier" default="100" unit="4">
 			<Values>
 				<Value>0</Value>
@@ -37,7 +34,9 @@
 		<Setting classType="AIParameterSettingList" name="brokenThreshold" min="0" max="100" incremental="5" default="95" unit="4"/>
 	</SettingSubTitle>
 	<SettingSubTitle prefix="true" title="userSettings">
-		<Setting classType="AIParameterBooleanSetting" name="controllerHudSelected" defaultBool="false" onChangeCallback="onHudSelectionChanged" isUserSetting="true"/>
+		<!-- When enabled, then a few settings are invisible and return their default values. -->
+		<Setting classType="AIParameterBooleanSetting" name="expertModeActive" isUserSetting="true" defaultBool="false" onChangeCallback="onExpertModeChanged"/>
+		<Setting classType="AIParameterBooleanSetting" name="controllerHudSelected" isUserSetting="true" defaultBool="false" onChangeCallback="onHudSelectionChanged"/>
 		<Setting classType="AIParameterBooleanSetting" name="showsAllActiveCourses" isUserSetting="true" defaultBool="false" isExpertModeOnly="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="showActionEventHelp" isUserSetting="true" defaultBool="true" onChangeCallback="onActionEventTextVisibilityChanged"/>
 		<Setting classType="AIParameterBooleanSetting" name="infoTextHudActive" isUserSetting="true" defaultBool="true"/>

--- a/config/GlobalSettingsSetup.xml
+++ b/config/GlobalSettingsSetup.xml
@@ -40,7 +40,7 @@
 		<Setting classType="AIParameterBooleanSetting" name="showsAllActiveCourses" isUserSetting="true" defaultBool="false" isExpertModeOnly="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="showActionEventHelp" isUserSetting="true" defaultBool="true" onChangeCallback="onActionEventTextVisibilityChanged"/>
 		<Setting classType="AIParameterBooleanSetting" name="infoTextHudActive" isUserSetting="true" defaultBool="true"/>
-		<Setting classType="AIParameterBooleanSetting" name="infoTextHudPlayerMouseActive" isUserSetting="true" defaultBool="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="infoTextHudPlayerMouseActive" isUserSetting="true" defaultBool="true" isExpertModeOnly="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="preferCustomFields" isUserSetting="true"/>
 	</SettingSubTitle>
 	<SettingSubTitle prefix="true" title="pathfinder" isExpertModeOnly="true">

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -24,21 +24,21 @@
 		<Setting classType="AIParameterBooleanSetting" name="openHudWithMouse" defaultBool="true" onChangeCallback="cpUpdateMouseAction"/>
 
 		<!--Open hud with mouse-->
-		<Setting classType="AIParameterBooleanSetting" name="fuelSave" defaultBool="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="fuelSave" defaultBool="true" isSimpleSetting="false"/>
 		<!--Stop At End-->
-		<Setting classType="AIParameterBooleanSetting" name="stopAtEnd" defaultBool="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="stopAtEnd" defaultBool="true" isSimpleSetting="false"/>
 		<!--Turn on Field-->
 		<Setting classType="AIParameterBooleanSetting" name="turnOnField" defaultBool="true"/>
 		<!--Avoid Fruit-->
-		<Setting classType="AIParameterBooleanSetting" name="avoidFruit" defaultBool="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="avoidFruit" defaultBool="true" isSimpleSetting="false"/>
 		<!--Pathfinder Reverse-->
 		<Setting classType="AIParameterBooleanSetting" name="allowReversePathfinding" defaultBool="true"/>
-		<Setting classType="AIParameterBooleanSetting" name="allowPathfinderTurns" defaultBool="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="allowPathfinderTurns" defaultBool="false" isSimpleSetting="false"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="implement">
 		<!--Fold at End-->
-		<Setting classType="AIParameterBooleanSetting" name="foldImplementAtEnd" defaultBool="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="foldImplementAtEnd" defaultBool="true" isSimpleSetting="false"/>
 		<!--Raise Implement-->
 		<Setting classType="AIParameterBooleanSetting" name="raiseImplementLate" vehicleConfiguration="raiseLate">
 			<Texts>
@@ -55,21 +55,17 @@
 		</Setting>
 		<!--Tool Offset X-->
 		<Setting classType="AIParameterSettingList" name="toolOffsetX" min="-10" max="10" incremental="0.1" default="0" unit="2" onChangeCallback="cpShowWorkWidth" isDisabled = "isToolOffsetDisabled" vehicleConfiguration="toolOffsetX"/>
-		<!--Tool Offset Y-->
-		<Setting classType="AIParameterSettingList" name="toolOffsetZ" min="-10" max="10" incremental="0.1" default="0" unit="2" onChangeCallback="cpShowWorkWidth" isDisabled = "isToolOffsetDisabled"/>
 		<!--Silage additives needed?-->
-		<Setting classType="AIParameterBooleanSetting" name="useAdditiveFillUnit" defaultBool="false" isVisible="isAdditiveFillUnitSettingVisible"/>
+		<Setting classType="AIParameterBooleanSetting" name="useAdditiveFillUnit" defaultBool="false" isVisible="isAdditiveFillUnitSettingVisible" isSimpleSetting="false"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="combine" isVisible="areCombineSettingsVisible">
-		<!--Pipe always unfold-->
-		<Setting classType="AIParameterBooleanSetting" name="pipeAlwaysUnfold" />
 		<!--Stop for unload-->
 		<Setting classType="AIParameterBooleanSetting" name="stopForUnload"/>
 		<!--Selfunload-->
 		<Setting classType="AIParameterBooleanSetting" name="selfUnload"/>
 		<!--Unload on first Headland-->
-		<Setting classType="AIParameterBooleanSetting" name="unloadOnFirstHeadland"/>
+		<Setting classType="AIParameterBooleanSetting" name="unloadOnFirstHeadland" defaultBool="true" isSimpleSetting="false"/>
 		<!--Strawswath-->
 		<Setting classType="AIParameterSettingList" name="strawSwath" default="2">
 			<Values>
@@ -87,7 +83,7 @@
 
 	<SettingSubTitle title="seeder" isVisible="areSowingMachineSettingsVisible">
 		<!--Ridgemarker-->	
-		<Setting classType="AIParameterBooleanSetting" name="ridgeMarkersAutomatic" isVisible="isRidgeMarkerSettingVisible"/>
+		<Setting classType="AIParameterBooleanSetting" name="ridgeMarkersAutomatic" defaultBool="false" isVisible="isRidgeMarkerSettingVisible" isSimpleSetting="true"/>
 		<!--Fertilizer-->
 		<Setting classType="AIParameterBooleanSetting" name="sowingMachineFertilizerEnabled" defaultBool="true" isVisible="isSowingMachineFertilizerSettingVisible"/>
 		<!--Optional sowing machine-->
@@ -101,15 +97,15 @@
 		<Setting classType="AIParameterSettingList" name="convoyDistance" min="40" max="400" default ="50" unit="2"/>
 	</SettingSubTitle>
 
-	<SettingSubTitle title="speed">
+	<SettingSubTitle title="speed" isSimpleSetting="false">
 		<!--Fieldwork Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="fieldWorkSpeed" min="5" max="50" default="25" unit="1"/>
+		<Setting classType="AIParameterSpeedSetting" name="fieldWorkSpeed" min="5" max="50" default="25" unit="1" isSimpleSetting="false"/>
 		<!--Field Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="fieldSpeed" min="5" max="50" default="20" unit="1"/>
+		<Setting classType="AIParameterSpeedSetting" name="fieldSpeed" min="5" max="50" default="20" unit="1" isSimpleSetting="false"/>
 		<!--Turn Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="turnSpeed" min="2" max="25" default="8" unit="1"/>
+		<Setting classType="AIParameterSpeedSetting" name="turnSpeed" min="2" max="25" default="8" unit="1" isSimpleSetting="false"/>
 		<!--Reverse Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="reverseSpeed" min="2" max="25" default="5" unit="1"/>
+		<Setting classType="AIParameterSpeedSetting" name="reverseSpeed" min="2" max="25" default="5" unit="1" isSimpleSetting="false"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="debug">

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -94,7 +94,7 @@
 		<!--Symetric Langechange-->
 		<Setting classType="AIParameterBooleanSetting" name="symmetricLaneChange"/>
 		<!--Convoy Distance-->
-		<Setting classType="AIParameterSettingList" name="convoyDistance" min="40" max="400" default ="50" unit="2" isExpertModeOnly="true"/>
+		<Setting classType="AIParameterSettingList" name="convoyDistance" min="40" max="400" default ="75" unit="2" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="speed" isExpertModeOnly="true">

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -32,7 +32,7 @@
 		<!--Avoid Fruit-->
 		<Setting classType="AIParameterBooleanSetting" name="avoidFruit" defaultBool="true" isExpertModeOnly="true"/>
 		<!--Pathfinder Reverse-->
-		<Setting classType="AIParameterBooleanSetting" name="allowReversePathfinding" defaultBool="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="allowReversePathfinding" defaultBool="true" isExpertModeOnly="true"/>
 		<Setting classType="AIParameterBooleanSetting" name="allowPathfinderTurns" defaultBool="false" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 
@@ -94,7 +94,7 @@
 		<!--Symetric Langechange-->
 		<Setting classType="AIParameterBooleanSetting" name="symmetricLaneChange"/>
 		<!--Convoy Distance-->
-		<Setting classType="AIParameterSettingList" name="convoyDistance" min="40" max="400" default ="50" unit="2"/>
+		<Setting classType="AIParameterSettingList" name="convoyDistance" min="40" max="400" default ="50" unit="2" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="speed" isExpertModeOnly="true">

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -24,21 +24,21 @@
 		<Setting classType="AIParameterBooleanSetting" name="openHudWithMouse" defaultBool="true" onChangeCallback="cpUpdateMouseAction"/>
 
 		<!--Open hud with mouse-->
-		<Setting classType="AIParameterBooleanSetting" name="fuelSave" defaultBool="true" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="fuelSave" defaultBool="true" isExpertModeOnly="true"/>
 		<!--Stop At End-->
-		<Setting classType="AIParameterBooleanSetting" name="stopAtEnd" defaultBool="true" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="stopAtEnd" defaultBool="true" isExpertModeOnly="true"/>
 		<!--Turn on Field-->
 		<Setting classType="AIParameterBooleanSetting" name="turnOnField" defaultBool="true"/>
 		<!--Avoid Fruit-->
-		<Setting classType="AIParameterBooleanSetting" name="avoidFruit" defaultBool="true" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="avoidFruit" defaultBool="true" isExpertModeOnly="true"/>
 		<!--Pathfinder Reverse-->
 		<Setting classType="AIParameterBooleanSetting" name="allowReversePathfinding" defaultBool="true"/>
-		<Setting classType="AIParameterBooleanSetting" name="allowPathfinderTurns" defaultBool="false" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="allowPathfinderTurns" defaultBool="false" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="implement">
 		<!--Fold at End-->
-		<Setting classType="AIParameterBooleanSetting" name="foldImplementAtEnd" defaultBool="true" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="foldImplementAtEnd" defaultBool="true" isExpertModeOnly="true"/>
 		<!--Raise Implement-->
 		<Setting classType="AIParameterBooleanSetting" name="raiseImplementLate" vehicleConfiguration="raiseLate">
 			<Texts>
@@ -56,7 +56,7 @@
 		<!--Tool Offset X-->
 		<Setting classType="AIParameterSettingList" name="toolOffsetX" min="-10" max="10" incremental="0.1" default="0" unit="2" onChangeCallback="cpShowWorkWidth" isDisabled = "isToolOffsetDisabled" vehicleConfiguration="toolOffsetX"/>
 		<!--Silage additives needed?-->
-		<Setting classType="AIParameterBooleanSetting" name="useAdditiveFillUnit" defaultBool="false" isVisible="isAdditiveFillUnitSettingVisible" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="useAdditiveFillUnit" defaultBool="false" isVisible="isAdditiveFillUnitSettingVisible" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="combine" isVisible="areCombineSettingsVisible">
@@ -65,7 +65,7 @@
 		<!--Selfunload-->
 		<Setting classType="AIParameterBooleanSetting" name="selfUnload"/>
 		<!--Unload on first Headland-->
-		<Setting classType="AIParameterBooleanSetting" name="unloadOnFirstHeadland" defaultBool="true" isSimpleSetting="false"/>
+		<Setting classType="AIParameterBooleanSetting" name="unloadOnFirstHeadland" defaultBool="true" isExpertModeOnly="true"/>
 		<!--Strawswath-->
 		<Setting classType="AIParameterSettingList" name="strawSwath" default="2">
 			<Values>
@@ -83,7 +83,7 @@
 
 	<SettingSubTitle title="seeder" isVisible="areSowingMachineSettingsVisible">
 		<!--Ridgemarker-->	
-		<Setting classType="AIParameterBooleanSetting" name="ridgeMarkersAutomatic" defaultBool="false" isVisible="isRidgeMarkerSettingVisible" isSimpleSetting="true"/>
+		<Setting classType="AIParameterBooleanSetting" name="ridgeMarkersAutomatic" defaultBool="false" isVisible="isRidgeMarkerSettingVisible" isExpertModeOnly="true"/>
 		<!--Fertilizer-->
 		<Setting classType="AIParameterBooleanSetting" name="sowingMachineFertilizerEnabled" defaultBool="true" isVisible="isSowingMachineFertilizerSettingVisible"/>
 		<!--Optional sowing machine-->
@@ -97,15 +97,15 @@
 		<Setting classType="AIParameterSettingList" name="convoyDistance" min="40" max="400" default ="50" unit="2"/>
 	</SettingSubTitle>
 
-	<SettingSubTitle title="speed" isSimpleSetting="false">
+	<SettingSubTitle title="speed" isExpertModeOnly="true">
 		<!--Fieldwork Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="fieldWorkSpeed" min="5" max="50" default="25" unit="1" isSimpleSetting="false"/>
+		<Setting classType="AIParameterSpeedSetting" name="fieldWorkSpeed" min="5" max="50" default="25" unit="1" isExpertModeOnly="true"/>
 		<!--Field Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="fieldSpeed" min="5" max="50" default="20" unit="1" isSimpleSetting="false"/>
+		<Setting classType="AIParameterSpeedSetting" name="fieldSpeed" min="5" max="50" default="20" unit="1" isExpertModeOnly="true"/>
 		<!--Turn Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="turnSpeed" min="2" max="25" default="8" unit="1" isSimpleSetting="false"/>
+		<Setting classType="AIParameterSpeedSetting" name="turnSpeed" min="2" max="25" default="8" unit="1" isExpertModeOnly="true"/>
 		<!--Reverse Speed-->
-		<Setting classType="AIParameterSpeedSetting" name="reverseSpeed" min="2" max="25" default="5" unit="1" isSimpleSetting="false"/>
+		<Setting classType="AIParameterSpeedSetting" name="reverseSpeed" min="2" max="25" default="5" unit="1" isExpertModeOnly="true"/>
 	</SettingSubTitle>
 
 	<SettingSubTitle title="debug">

--- a/scripts/CpGlobalSettings.lua
+++ b/scripts/CpGlobalSettings.lua
@@ -108,7 +108,7 @@ function CpGlobalSettings:onUnitChanged()
     end
 end
 
-function CpGlobalSettings:onSimpleModeChanged()
+function CpGlobalSettings:onExpertModeChanged()
     CpGlobalSettingsFrame.updateGui()
 end
 

--- a/scripts/CpGlobalSettings.lua
+++ b/scripts/CpGlobalSettings.lua
@@ -108,6 +108,10 @@ function CpGlobalSettings:onUnitChanged()
     end
 end
 
+function CpGlobalSettings:onSimpleModeChanged()
+    CpGlobalSettingsFrame.updateGui()
+end
+
 function CpGlobalSettings:debug(str,...)
     CpUtil.debugFormat(CpDebug.DBG_HUD,"Global settings: "..str,...)    
 end

--- a/scripts/CpSettingsUtil.lua
+++ b/scripts/CpSettingsUtil.lua
@@ -28,7 +28,7 @@ CpSettingsUtil.classTypes = {
 			- isDisabled (string): function called from the parent container, to disable all setting under the subtitle.
 			- isVisible (string): function called from the parent container, to change the visibility of all setting under the subtitle.
 
-			- isSimpleSetting(bool): are the setting visible in the simple version?, default = true
+			- isExpertModeOnly(bool): are the setting visible in the expert version?, default = false
 
 			- Setting(?)
 				- classType (string): class name
@@ -39,7 +39,7 @@ CpSettingsUtil.classTypes = {
 				- defaultBool(bool) : default value to be set. (optional)
 				- textInput(bool) : is text input allowed ? (optional), every automatic generated number sequence is automatically allowed.
 				- isUserSetting(bool): should the setting be saved in the game settings and not in the savegame dir.
-				- isSimpleSetting(bool): is the setting visible in the simple version?, default = true
+				- isExpertModeOnly(bool): is the setting visible in the expert version?, default = false
 
 				- min (int): min value
 				- max (int): max value
@@ -79,7 +79,7 @@ function CpSettingsUtil.init()
 	
 	schema:register(XMLValueType.STRING, key.."#isDisabled", "Callback function, if the settings is disabled.") -- optional
 	schema:register(XMLValueType.STRING, key.."#isVisible", "Callback function, if the settings is visible.") -- optional
-	schema:register(XMLValueType.BOOL, key.."#isSimpleSetting", "Is enabled in simple mode?") -- optional
+	schema:register(XMLValueType.BOOL, key.."#isExpertModeOnly", "Is enabled in simple mode?", false) -- optional
 
 	key = "Settings.SettingSubTitle(?).Setting(?)"
     schema:register(XMLValueType.STRING, key.."#name", "Setting name",nil,true)
@@ -89,8 +89,8 @@ function CpSettingsUtil.init()
 	schema:register(XMLValueType.INT, key.."#default", "Setting default value") -- optional
 	schema:register(XMLValueType.BOOL, key.."#defaultBool", "Setting default bool value") -- optional
 	schema:register(XMLValueType.BOOL, key .. "#textInput", "Setting input text allowed.") --optional
-	schema:register(XMLValueType.BOOL, key .. "#isUserSetting", "Setting will be saved in the gameSettings file.") --optional
-	schema:register(XMLValueType.BOOL, key.."#isSimpleSetting", "Is enabled in simple mode?") -- optional
+	schema:register(XMLValueType.BOOL, key .. "#isUserSetting", "Setting will be saved in the gameSettings file.", false) --optional
+	schema:register(XMLValueType.BOOL, key.."#isExpertModeOnly", "Is enabled in simple mode?", false) -- optional
 
 	schema:register(XMLValueType.INT, key.."#min", "Setting min value")
 	schema:register(XMLValueType.INT, key.."#max", "Setting max value")
@@ -146,14 +146,14 @@ function CpSettingsUtil.loadSettingsFromSetup(class, filePath)
 
 		local isDisabledFunc = xmlFile:getValue(masterKey.."#isDisabled")
 		local isVisibleFunc = xmlFile:getValue(masterKey.."#isVisible")
-		local isSimpleSetting = xmlFile:getValue(masterKey.."#isSimpleSetting",true)
+		local isExpertModeOnly = xmlFile:getValue(masterKey.."#isExpertModeOnly",false)
 
 		local subTitleSettings = {
 			title = subTitle,
 			elements = {},
 			isDisabledFunc = isDisabledFunc,
 			isVisibleFunc = isVisibleFunc,
-			isVisibleSimpleMode = isSimpleSetting,
+			isExpertModeOnly = isExpertModeOnly,
 			class = class
 		}
 		xmlFile:iterate(masterKey..".Setting", function (i, baseKey)
@@ -177,7 +177,7 @@ function CpSettingsUtil.loadSettingsFromSetup(class, filePath)
 			settingParameters.defaultBool = xmlFile:getValue(baseKey.."#defaultBool")
 			settingParameters.textInputAllowed = xmlFile:getValue(baseKey.."#textInput",false)
 			settingParameters.isUserSetting = xmlFile:getValue(baseKey.."#isUserSetting",false)
-			settingParameters.isSimpleSetting = xmlFile:getValue(baseKey.."#isSimpleSetting",true)
+			settingParameters.isExpertModeOnly = xmlFile:getValue(baseKey.."#isExpertModeOnly",false)
 
 			settingParameters.min = xmlFile:getValue(baseKey.."#min")
 			settingParameters.max = xmlFile:getValue(baseKey.."#max")
@@ -310,8 +310,8 @@ function CpSettingsUtil.linkGuiElementsAndSettings(settings,layout,settingsBySub
 			valid = true
 			local isDisabledFunc = settingsBySubTitle[j].isDisabledFunc
 			local isVisibleFunc = settingsBySubTitle[j].isVisibleFunc
-			local isVisibleSimpleMode = settingsBySubTitle[j].isVisibleSimpleMode
-			if not isVisibleSimpleMode and g_Courseplay.globalSettings.simpleUserModeEnabled:getValue() then 
+			local isVisibleExpertMode = settingsBySubTitle[j].isExpertModeOnly
+			if isVisibleExpertMode and not g_Courseplay.globalSettings.expertModeActive:getValue() then 
 				valid = false
 			end
 			local class = settingsBySubTitle[j].class

--- a/scripts/CpSettingsUtil.lua
+++ b/scripts/CpSettingsUtil.lua
@@ -28,6 +28,8 @@ CpSettingsUtil.classTypes = {
 			- isDisabled (string): function called from the parent container, to disable all setting under the subtitle.
 			- isVisible (string): function called from the parent container, to change the visibility of all setting under the subtitle.
 
+			- isSimpleSetting(bool): are the setting visible in the simple version?, default = true
+
 			- Setting(?)
 				- classType (string): class name
 				- name (string): name of the setting 
@@ -37,6 +39,7 @@ CpSettingsUtil.classTypes = {
 				- defaultBool(bool) : default value to be set. (optional)
 				- textInput(bool) : is text input allowed ? (optional), every automatic generated number sequence is automatically allowed.
 				- isUserSetting(bool): should the setting be saved in the game settings and not in the savegame dir.
+				- isSimpleSetting(bool): is the setting visible in the simple version?, default = true
 
 				- min (int): min value
 				- max (int): max value
@@ -76,6 +79,7 @@ function CpSettingsUtil.init()
 	
 	schema:register(XMLValueType.STRING, key.."#isDisabled", "Callback function, if the settings is disabled.") -- optional
 	schema:register(XMLValueType.STRING, key.."#isVisible", "Callback function, if the settings is visible.") -- optional
+	schema:register(XMLValueType.BOOL, key.."#isSimpleSetting", "Is enabled in simple mode?") -- optional
 
 	key = "Settings.SettingSubTitle(?).Setting(?)"
     schema:register(XMLValueType.STRING, key.."#name", "Setting name",nil,true)
@@ -86,6 +90,7 @@ function CpSettingsUtil.init()
 	schema:register(XMLValueType.BOOL, key.."#defaultBool", "Setting default bool value") -- optional
 	schema:register(XMLValueType.BOOL, key .. "#textInput", "Setting input text allowed.") --optional
 	schema:register(XMLValueType.BOOL, key .. "#isUserSetting", "Setting will be saved in the gameSettings file.") --optional
+	schema:register(XMLValueType.BOOL, key.."#isSimpleSetting", "Is enabled in simple mode?") -- optional
 
 	schema:register(XMLValueType.INT, key.."#min", "Setting min value")
 	schema:register(XMLValueType.INT, key.."#max", "Setting max value")
@@ -141,12 +146,14 @@ function CpSettingsUtil.loadSettingsFromSetup(class, filePath)
 
 		local isDisabledFunc = xmlFile:getValue(masterKey.."#isDisabled")
 		local isVisibleFunc = xmlFile:getValue(masterKey.."#isVisible")
+		local isSimpleSetting = xmlFile:getValue(masterKey.."#isSimpleSetting",true)
 
 		local subTitleSettings = {
 			title = subTitle,
 			elements = {},
 			isDisabledFunc = isDisabledFunc,
 			isVisibleFunc = isVisibleFunc,
+			isVisibleSimpleMode = isSimpleSetting,
 			class = class
 		}
 		xmlFile:iterate(masterKey..".Setting", function (i, baseKey)
@@ -170,6 +177,7 @@ function CpSettingsUtil.loadSettingsFromSetup(class, filePath)
 			settingParameters.defaultBool = xmlFile:getValue(baseKey.."#defaultBool")
 			settingParameters.textInputAllowed = xmlFile:getValue(baseKey.."#textInput",false)
 			settingParameters.isUserSetting = xmlFile:getValue(baseKey.."#isUserSetting",false)
+			settingParameters.isSimpleSetting = xmlFile:getValue(baseKey.."#isSimpleSetting",true)
 
 			settingParameters.min = xmlFile:getValue(baseKey.."#min")
 			settingParameters.max = xmlFile:getValue(baseKey.."#max")
@@ -302,6 +310,10 @@ function CpSettingsUtil.linkGuiElementsAndSettings(settings,layout,settingsBySub
 			valid = true
 			local isDisabledFunc = settingsBySubTitle[j].isDisabledFunc
 			local isVisibleFunc = settingsBySubTitle[j].isVisibleFunc
+			local isVisibleSimpleMode = settingsBySubTitle[j].isVisibleSimpleMode
+			if not isVisibleSimpleMode and g_Courseplay.globalSettings.simpleUserModeEnabled:getValue() then 
+				valid = false
+			end
 			local class = settingsBySubTitle[j].class
 			if vehicle then 
 				if class[isVisibleFunc] then 
@@ -318,6 +330,7 @@ function CpSettingsUtil.linkGuiElementsAndSettings(settings,layout,settingsBySub
 					element:setDisabled(class[isDisabledFunc](vehicle))
 				end
 			end
+			
 			element:setVisible(valid)
 			j =  j + 1
 		end

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1175,8 +1175,7 @@ end
 
 function AIDriveStrategyCombineCourse:handleCombinePipe(dt)
     
-  if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() or (self:isWaitingForUnload() and 
-		  self.settings.pipeAlwaysUnfold:getValue()) then
+  if self:isFillableTrailerUnderPipe() or self:isAutoDriveWaitingForPipe() then
 		self:openPipe()
 		if self.pipe and self.pipe.currentState == AIUtil.PIPE_STATE_OPEN then 
 			-- TODO_22 self:isWorkingToolPositionReached(dt,1)

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -575,7 +575,7 @@ end
 function AIDriveStrategyFieldWorkCourse:updateFieldworkOffset()
     self.course:setOffset(
         self.settings.toolOffsetX:getValue() + self.aiOffsetX + (self.tightTurnOffset or 0),
-        self.settings.toolOffsetZ:getValue() + self.aiOffsetZ)
+        0 + self.aiOffsetZ)
 end
 
 function AIDriveStrategyFieldWorkCourse:setOffsetX()

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -4,6 +4,7 @@ AIParameterSettingList = {}
 local AIParameterSettingList_mt = Class(AIParameterSettingList, AIParameter)
 
 function AIParameterSettingList.new(data,vehicle,class,customMt)
+	---@type AIParameterSettingList
 	local self = AIParameter.new(customMt or AIParameterSettingList_mt)
 	self.type = AIParameterType.SELECTOR
 	self.vehicle = vehicle
@@ -222,7 +223,7 @@ function AIParameterSettingList:getDebugString()
 end
 
 function AIParameterSettingList:saveToXMLFile(xmlFile, key, usedModNames)
-	xmlFile:setString(key .. "#currentValue", tostring(self:getValue()))
+	xmlFile:setString(key .. "#currentValue", tostring(self.values[self.current]))
 end
 
 --- Old load function.
@@ -397,6 +398,16 @@ end
 
 --- Gets a specific value.
 function AIParameterSettingList:getValue()
+	--- In the simple user mode returns the default values.
+	if not self.data.isSimpleSetting and g_Courseplay.globalSettings.simpleUserModeEnabled:getValue() then 
+		if self.data.default then 
+			return self.data.default
+		end
+		if self.data.defaultBool then 
+			return self.data.defaultBool
+		end
+		return self.values[1]
+	end
 	return self.values[self.current]
 end
 
@@ -429,9 +440,9 @@ end
 --- Copy the value to another setting.
 function AIParameterSettingList:copy(setting)
 	if self.data.incremental and self.data.incremental ~= 1 then 
-		self:setFloatValue(setting:getValue())
+		self:setFloatValue(setting.values[self.current])
 	else 
-		self:setValue(setting:getValue())
+		self:setValue(setting.values[self.current])
 	end
 end
 
@@ -612,6 +623,9 @@ function AIParameterSettingList:getCanBeChanged()
 end
 
 function AIParameterSettingList:getIsVisible()
+	if not self.data.isSimpleSetting and g_Courseplay.globalSettings.simpleUserModeEnabled:getValue() then 
+		return false
+	end
 	if self:hasCallback(self.data.isVisibleFunc) then 
 		return self:getCallback(self.data.isVisibleFunc)
 	end

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -399,7 +399,7 @@ end
 --- Gets a specific value.
 function AIParameterSettingList:getValue()
 	--- In the simple user mode returns the default values.
-	if not self.data.isSimpleSetting and g_Courseplay.globalSettings.simpleUserModeEnabled:getValue() then 
+	if self.data.isExpertModeOnly and not g_Courseplay.globalSettings.expertModeActive:getValue() then 
 		if self.data.default then 
 			return self.data.default
 		end
@@ -623,7 +623,7 @@ function AIParameterSettingList:getCanBeChanged()
 end
 
 function AIParameterSettingList:getIsVisible()
-	if not self.data.isSimpleSetting and g_Courseplay.globalSettings.simpleUserModeEnabled:getValue() then 
+	if self.data.isExpertModeOnly and not g_Courseplay.globalSettings.expertModeActive:getValue() then 
 		return false
 	end
 	if self:hasCallback(self.data.isVisibleFunc) then 

--- a/scripts/gui/CpGlobalSettingsFrame.lua
+++ b/scripts/gui/CpGlobalSettingsFrame.lua
@@ -33,15 +33,18 @@ function CpGlobalSettingsFrame:onGuiSetupFinished()
 
 	self.settings = g_Courseplay.globalSettings:getSettingsTable()
 	local settingsBySubTitle,pageTitle = g_Courseplay.globalSettings:getSettingSetup()
+	self.settingsBySubTitle = settingsBySubTitle
 	self.header:setText(pageTitle)	
 	CpSettingsUtil.generateGuiElementsFromSettingsTable(settingsBySubTitle,
 	self.boxLayout,self.multiTextOptionPrefab, self.subTitlePrefab)
-	CpSettingsUtil.linkGuiElementsAndSettings(self.settings,self.boxLayout)
 	self.boxLayout:invalidateLayout()
 end
 
 function CpGlobalSettingsFrame:onFrameOpen()
 	CpGlobalSettingsFrame:superClass().onFrameOpen(self)
+
+	CpSettingsUtil.linkGuiElementsAndSettings(self.settings, self.boxLayout, self.settingsBySubTitle)
+
 	FocusManager:loadElementFromCustomValues(self.boxLayout)
 	self.boxLayout:invalidateLayout()
 	self:setSoundSuppressed(true)
@@ -51,5 +54,12 @@ end
 
 function CpGlobalSettingsFrame:onFrameClose()
 	CpGlobalSettingsFrame:superClass().onFrameClose(self)
+	CpSettingsUtil.unlinkGuiElementsAndSettings(self.settings,self.boxLayout)
+	self.boxLayout:invalidateLayout()
+end
 
+function CpGlobalSettingsFrame.updateGui()
+	local self = g_currentMission.inGameMenu.pageCpGlobalSettings
+	self:onFrameClose()
+	self:onFrameOpen()
 end

--- a/scripts/gui/CpGlobalSettingsFrame.lua
+++ b/scripts/gui/CpGlobalSettingsFrame.lua
@@ -60,7 +60,7 @@ end
 
 function CpGlobalSettingsFrame.updateGui()
 	local self = g_currentMission.inGameMenu.pageCpGlobalSettings
-	if g_gui:getIsGuiVisible() and g_currentMission.inGameMenu.currentPage == self then
+	if self and g_gui:getIsGuiVisible() and g_currentMission.inGameMenu.currentPage == self then
 		self:onFrameClose()
 		self:onFrameOpen()
 	end

--- a/scripts/gui/CpGlobalSettingsFrame.lua
+++ b/scripts/gui/CpGlobalSettingsFrame.lua
@@ -60,6 +60,8 @@ end
 
 function CpGlobalSettingsFrame.updateGui()
 	local self = g_currentMission.inGameMenu.pageCpGlobalSettings
-	self:onFrameClose()
-	self:onFrameOpen()
+	if g_gui:getIsGuiVisible() and g_currentMission.inGameMenu.currentPage == self then
+		self:onFrameClose()
+		self:onFrameOpen()
+	end
 end

--- a/scripts/specializations/CpHud.lua
+++ b/scripts/specializations/CpHud.lua
@@ -233,7 +233,7 @@ function CpHud:onDraw()
 			WorkWidthUtil.showWorkWidth(self,
 										self:getCourseGeneratorSettings().workWidth:getValue(),
 											self:getCpSettings().toolOffsetX:getValue(),
-											self:getCpSettings().toolOffsetZ:getValue())
+											0)
 		end
 	end
 end

--- a/scripts/specializations/CpVehicleSettingDisplay.lua
+++ b/scripts/specializations/CpVehicleSettingDisplay.lua
@@ -131,7 +131,7 @@ end
 --- Gets called by the active mini gui, as vehicle:onDraw() is otherwise not displayed.
 function CpVehicleSettingDisplay:onDraw()
 	local spec = self.spec_cpVehicleSettingDisplay
-	WorkWidthUtil.showWorkWidth(self,spec.workWidth:getValue(),spec.toolOffsetX:getValue(),spec.toolOffsetZ:getValue())
+	WorkWidthUtil.showWorkWidth(self,spec.workWidth:getValue(),spec.toolOffsetX:getValue(),0)
 end
 
 

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -238,6 +238,9 @@
 		<text name="CP_global_setting_title"															text="Configurações global"/>
 		<text name="CP_global_setting_subTitle_general"													text="Configurações Basicas"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Cp pagamento ao motorista"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Cp pagamento ao motorista por porcentagem"/>
 

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -240,6 +240,9 @@
 		<text name="CP_global_setting_title"															text="全局设置"/>
 		<text name="CP_global_setting_subTitle_general"													text="基本设置"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Cp帮手工资"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Cp帮手工资占普通帮手工资的百分比。"/>
 

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -237,6 +237,9 @@
 		<text name="CP_global_setting_title"															text="Global settings"/>
 		<text name="CP_global_setting_subTitle_general"													text="Basic settings"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Cp driver wages"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Cp driver wages as percentage of normal worker's wages"/>
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -238,6 +238,9 @@
 		<text name="CP_global_setting_title"															text="Globální nastavení"/>
 		<text name="CP_global_setting_subTitle_general"													text="Základní nastavení."/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Mzdy pracovníků"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Mzdy CP pracovníků jako procento mzdy normálního pracovníka."/>
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -244,6 +244,9 @@
 		<text name="CP_global_setting_wageModifier_title" 												text="CP Chaufførløn"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Chaufførløn til CP Arbejter, procentvis af stanard løn."/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_autoRepair_title" 												text="Automatisk reparation"/>
 		<text name="CP_global_setting_autoRepair_tooltip" 												text="CP Chauffør reparere automatisk køretøj og redskab."/>
 		<text name="CP_global_setting_autoRepair_off" 													text="Ikke reparere"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -239,6 +239,9 @@
 		<text name="CP_global_setting_title"															text="Globale Einstellungen"/>
 		<text name="CP_global_setting_subTitle_general"													text="Grundeinstellungen"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="CP Fahrerlohn"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Fahrerlohn für CP Arbeiter, prozentual von dem standart Lohn."/>
 

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -239,8 +239,8 @@
 		<text name="CP_global_setting_title"															text="Globale Einstellungen"/>
 		<text name="CP_global_setting_subTitle_general"													text="Grundeinstellungen"/>
 
-		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
-		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+		<text name="CP_global_setting_expertModeActive_title" 											text="Experten Modus"/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Schaltet den Experten Modus an/aus um weitere Einstellungen frei zu schalten."/>
 
 		<text name="CP_global_setting_wageModifier_title" 												text="CP Fahrerlohn"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Fahrerlohn für CP Arbeiter, prozentual von dem standart Lohn."/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -238,6 +238,9 @@
 		<text name="CP_global_setting_title"															text="Global settings"/>
 		<text name="CP_global_setting_subTitle_general"													text="Basic settings"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Cp driver wages"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Cp driver wages as percentage of normal worker's wages"/>
 

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -239,6 +239,9 @@
 		<text name="CP_global_setting_title"															text="Ajustes globales"/>
 		<text name="CP_global_setting_subTitle_general"													text="Ajustes globales"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Salarios de conductores CP"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Salarios de conductores CP en porcentaje"/>
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -240,6 +240,9 @@
 		<text name="CP_global_setting_title"															text="Paramètres globaux"/>
 		<text name="CP_global_setting_subTitle_general"													text="Paramètres généraux"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Salaire des ouvriers Courseplay"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Salaire des ouvriers Courseplay en pourcentage du salaire des ouvriers normaux."/>
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -238,6 +238,9 @@
 		<text name="CP_global_setting_title"															text="Általános beállítások"/>
 		<text name="CP_global_setting_subTitle_general"													text="Alapbeállítások"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="CP segítő bére"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="CP segítő bére a normál segítői bér százalékában"/>
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -238,6 +238,9 @@
 		<text name="CP_global_setting_title"															text="Impostazioni Courseplay"/>
 		<text name="CP_global_setting_subTitle_general"													text="Generali"/>
 		
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Salario autista"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Percentuale Salario autista Courseplay (Percentuale basata su lavoratore normale del gioco)"/>
 		

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -240,6 +240,9 @@
 		<text name="CP_global_setting_title"															text="グローバル設定"/>
 		<text name="CP_global_setting_subTitle_general"													text="一般設定"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="コースプレイAIヘルパーの賃金"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="コースプレイAIヘルパーに支払う金額を設定します（0～500%）"/>
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -240,6 +240,9 @@
 		<text name="CP_global_setting_title"															text="Globale instellingen"/>
 		<text name="CP_global_setting_subTitle_general"													text="Basisinstellingen"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Cp chauffeur loon"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Cp chauffeursloon als percentage van het normale loon van de werknemer"/>
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -240,6 +240,9 @@
 		<text name="CP_global_setting_title"															text="Ustawienia globalne"/>
 		<text name="CP_global_setting_subTitle_general"													text="Ustawienia podstawowe"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Wynagrodzenie pracowników CP"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Procentowe wynagrodzenie pracowników CP względem zwykłych pracowników"/>
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -240,6 +240,9 @@
 		<text name="CP_global_setting_title"															text="Global settings"/>
 		<text name="CP_global_setting_subTitle_general"													text="Basic settings"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Cp driver wages"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Cp driver wages as percentage of normal worker's wages"/>
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -241,6 +241,9 @@
 		<text name="CP_global_setting_title"															text="Глобальные настройки CoursePlay"/>
 		<text name="CP_global_setting_subTitle_general"													text="Основные настройки"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="Заработная плата работника"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="Заработная плата работника CoursePlay в процентах от заработной платы обычного рабочего."/>
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -242,6 +242,9 @@
 		<text name="CP_global_setting_title"															text="Globalainställningar"/>
 		<text name="CP_global_setting_subTitle_general"													text="Standardinställningar"/>
 
+		<text name="CP_global_setting_expertModeActive_title" 											text="Expert mode "/>
+		<text name="CP_global_setting_expertModeActive_tooltip" 										text="Enables/disables expert mode with additional features."/>
+
 		<text name="CP_global_setting_wageModifier_title" 												text="CP förarens lön"/>
 		<text name="CP_global_setting_wageModifier_tooltip" 											text="CP-förarens lön i procent av normala arbetarlöner (AI lön)"/>
 


### PR DESCRIPTION
- Removed settings:
  - toolOffsetZ
  - pipeAlwaysUnfold
- invisible settings in simplified mode, will always return their default value.
- invisible settings in simplified mode:
  - all speed settings
  - ridgeMarkersAutomatic
  - unloadOnFirstHeadland
  - useAdditiveFillUnit
  - foldImplementAtEnd
  - allowPathfinderTurns
  - avoidFruit
  - stopAtEnd
  - fuelSave
  - showsAllActiveCourses
  - maxDeltaAngleAtGoal
  - deltaAngleRelaxFactor
TODO:
  - check the course generator settings
  - check if more simplification is possible
  - test the gui interactions (simple/ not simple) mode
  - test the use of the default value, even if other values were set in not simple mode.