### PR TITLE
Multitool course start fix for #1347

### DIFF
--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -131,25 +131,25 @@ end
 function AIDriveStrategyCourse:getGeneratedCourse(jobParameters)
     local course = self.vehicle:getFieldWorkCourse()
     local numMultiTools = course:getMultiTools()
-    local laneNumber = numMultiTools > 1 and jobParameters.laneOffset:getValue() or 0
+    local position = numMultiTools > 1 and jobParameters.laneOffset:getValue() or 0
     if numMultiTools < 2 then
         self:debug('Single vehicle fieldwork course')
         self.vehicle:setOffsetFieldWorkCourse(nil)
         return course
-    elseif laneNumber == 0 then
+    elseif position == 0 then
         self:debug('Multitool course, center vehicle, using original course')
         self.vehicle:setOffsetFieldWorkCourse(nil)
         return course
     else
-        self:debug('Multitool course, non-center vehicle, generating offset course for lane number %d',laneNumber)
-        --- Lane number needs to be zero for only one vehicle.
-        --- Work width of a single vehicle.
-        local offsetCourse = self.vehicle:getOffsetFieldWorkCourse()
-        if offsetCourse == nil then
+        self:debug('Multitool course, non-center vehicle, generating offset course for lane number %d', position)
+        --- only one vehicle can have position zero (center)
+        local offsetCourse, previousPosition = self.vehicle:getOffsetFieldWorkCourse()
+        if offsetCourse == nil or position ~= previousPosition then
+            --- Work width of a single vehicle.
             local width = course:getWorkWidth() / numMultiTools
-            offsetCourse = course:calculateOffsetCourse(numMultiTools, laneNumber, width,
+            offsetCourse = course:calculateOffsetCourse(numMultiTools, position, width,
                     self.settings.symmetricLaneChange:getValue())
-            self.vehicle:setOffsetFieldWorkCourse(offsetCourse)
+            self.vehicle:setOffsetFieldWorkCourse(offsetCourse, position)
         end
         return offsetCourse
     end

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -58,27 +58,6 @@ function AIDriveStrategyFieldWorkCourse:delete()
     self:rememberWaypointToContinueFieldWork()
 end
 
-function AIDriveStrategyFieldWorkCourse:getGeneratedCourse(jobParameters)
-    local course = self.vehicle:getFieldWorkCourse()
-    local numMultiTools = course:getMultiTools()
-    local laneNumber = numMultiTools > 1 and jobParameters.laneOffset:getValue() or 0
-    if numMultiTools < 2 then
-        self:debug('Single vehicle fieldwork course')
-        return course
-    elseif laneNumber == 0 then
-        self:debug('Multitool course, center vehicle, using original course')
-        return course
-    else
-        self:debug('Multitool course, non-center vehicle, generating offset course for lane number %d',laneNumber)
-        --- Lane number needs to be zero for only one vehicle.
-        --- Work width of a single vehicle.
-        local width = course:getWorkWidth() / numMultiTools
-        local offsetCourse = course:calculateOffsetCourse(numMultiTools, laneNumber, width,
-                                                        self.settings.symmetricLaneChange:getValue())
-        return offsetCourse
-    end
-end
-
 --- Start a fieldwork course. We expect that something else dropped us off close enough to startIx so
 --- the most we need is an alignment course to lower the implements
 function AIDriveStrategyFieldWorkCourse:start(course, startIx, jobParameters)

--- a/scripts/ai/AIDriveStrategyFindBales.lua
+++ b/scripts/ai/AIDriveStrategyFindBales.lua
@@ -54,6 +54,10 @@ function AIDriveStrategyFindBales:delete()
     TurnContext.deleteNodes(self.turnNodes)
 end
 
+function AIDriveStrategyFindBales:getGeneratedCourse(jobParameters)
+    return nil
+end
+
 function AIDriveStrategyFindBales:startWithoutCourse()
     -- to always have a valid course (for the traffic conflict detector mainly)
     self.course = self:getStraightForwardCourse(25)

--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -127,7 +127,7 @@ function WorkWidthUtil.getAIMarkers(object, logPrefix, suppressLog)
         if not suppressLog then
             WorkWidthUtil.debug(object, logPrefix, 'has no AI markers, try work areas')
         end
-        aiLeftMarker, aiRightMarker, aiBackMarker = WorkWidthUtil.getAIMarkersFromWorkAreas(object)
+        aiLeftMarker, aiRightMarker, aiBackMarker = WorkWidthUtil.getAIMarkersFromWorkAreas(object, suppressLog)
         if not aiLeftMarker or not aiRightMarker or not aiLeftMarker then
             if g_vehicleConfigurations:get(object, 'useVehicleSizeForMarkers') then
                 if not suppressLog then
@@ -152,15 +152,17 @@ end
 
 --- Calculate the front and back marker nodes of a work area
 ---@param object table
-function WorkWidthUtil.getAIMarkersFromWorkAreas(object)
+function WorkWidthUtil.getAIMarkersFromWorkAreas(object, suppressLog)
     -- work areas are defined by three nodes: start, width and height. These nodes
     -- define a rectangular work area which you can make visible with the
     -- gsVehicleDebugAttributes console command and then pressing F5
     for _, area in WorkWidthUtil.workAreaIterator(object) do
         if WorkWidthUtil.isValidWorkArea(area) then
             -- for now, just use the first valid work area we find
-            WorkWidthUtil.debug(object,nil,'Using %s work area markers as AIMarkers',
-                    g_workAreaTypeManager.workAreaTypes[area.type].name)
+            if not suppressLog then
+                WorkWidthUtil.debug(object,nil,'Using %s work area markers as AIMarkers',
+                        g_workAreaTypeManager.workAreaTypes[area.type].name)
+            end
             return area.start, area.width, area.height
         end
     end

--- a/scripts/specializations/CpCourseManager.lua
+++ b/scripts/specializations/CpCourseManager.lua
@@ -69,6 +69,8 @@ end
 function CpCourseManager.registerFunctions(vehicleType)
     SpecializationUtil.registerFunction(vehicleType, 'setFieldWorkCourse', CpCourseManager.setFieldWorkCourse)
     SpecializationUtil.registerFunction(vehicleType, 'getFieldWorkCourse', CpCourseManager.getFieldWorkCourse)
+    SpecializationUtil.registerFunction(vehicleType, 'setOffsetFieldWorkCourse', CpCourseManager.setOffsetFieldWorkCourse)
+    SpecializationUtil.registerFunction(vehicleType, 'getOffsetFieldWorkCourse', CpCourseManager.getOffsetFieldWorkCourse)
     SpecializationUtil.registerFunction(vehicleType, 'addCpCourse', CpCourseManager.addCourse)
     SpecializationUtil.registerFunction(vehicleType, 'getCpCourses', CpCourseManager.getCourses)
     SpecializationUtil.registerFunction(vehicleType, 'hasCpCourse', CpCourseManager.hasCourse)
@@ -226,6 +228,21 @@ function CpCourseManager:getFieldWorkCourse()
     local spec = self.spec_cpCourseManager 
     --- TODO: For now only returns the first course.
     return spec.courses[1]
+end
+
+--- Set the offset course which is generated for a multitool configuration (offset to the left or right when multiple
+--- vehicles working on the same field)
+---@param course Course
+function CpCourseManager:setOffsetFieldWorkCourse(course)
+    local spec = self.spec_cpCourseManager
+    spec.offsetFieldWorkCourse = course
+end
+
+--- If the offset course has been calculated for a multitool config, return here
+---@return Course
+function CpCourseManager:getOffsetFieldWorkCourse()
+    local spec = self.spec_cpCourseManager
+    return spec.offsetFieldWorkCourse
 end
 
 function CpCourseManager:getCourses()


### PR DESCRIPTION
The offset course must be calculated when the drive to fieldwork
task starts so it can find and drive to the nearest/first waypoint
of the _offset_ course, not the original course.
