### PR TITLE
Course start fix for #1265

### DIFF
--- a/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -168,8 +168,12 @@ function AIDriveStrategyDriveToFieldWorkStart:startCourseWithPathfinding(course,
         local fruitAtTarget = PathfinderUtil.hasFruit(x, z, self.workWidth, self.workWidth)
         self.pathfindingStartedAt = g_currentMission.time
         local done, path
+        local _, steeringLength = AIUtil.getSteeringParameters(self.vehicle)
+        -- always drive a behind the target waypoint so there's room to straighten out towed implements
+        -- a bit before start working
+        self:debug('Pathfinding to waypoint %d, with zOffset min(%.1f, %.1f)', ix, -self.frontMarkerDistance, -steeringLength)
         self.pathfinder, done, path = PathfinderUtil.startPathfindingFromVehicleToWaypoint(self.vehicle, course:getWaypoint(ix),
-                self.multitoolOffset, math.min(-self.frontMarkerDistance, 0), self:getAllowReversePathfinding(), fieldNum, nil, ix < 3 and math.huge, nil, nil,
+                self.multitoolOffset, math.min(-self.frontMarkerDistance, -steeringLength), self:getAllowReversePathfinding(), fieldNum, nil, ix < 3 and math.huge, nil, nil,
                 fruitAtTarget and PathfinderUtil.Area(x, z, 2 * self.workWidth))
         if done then
             return self:onPathfindingDoneToCourseStart(path)

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -476,10 +476,10 @@ function AIDriveStrategyFieldWorkCourse:startAlignmentTurn(fieldWorkCourse, star
         alignmentCourse = self:createAlignmentCourse(fieldWorkCourse, startIx)
     end
     self.ppc:setShortLookaheadDistance()
-    local fm, bm = self:getFrontAndBackMarkers()
-    self.turnContext = TurnContext(fieldWorkCourse, startIx, startIx, self.turnNodes, self:getWorkWidth(), fm, bm,
-            self:getTurnEndSideOffset(), self:getTurnEndForwardOffset())
     if alignmentCourse then
+        local fm, bm = self:getFrontAndBackMarkers()
+        self.turnContext = RowStartOrFinishContext(fieldWorkCourse, startIx, startIx, self.turnNodes, self:getWorkWidth(), fm, bm,
+                self:getTurnEndSideOffset(), self:getTurnEndForwardOffset())
         self.aiTurn = StartRowOnly(self.vehicle, self, self.ppc, self.turnContext, alignmentCourse, fieldWorkCourse, self.workWidth)
         self.state = self.states.DRIVING_TO_WORK_START_WAYPOINT
     else

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -328,8 +328,13 @@ function AIDriveStrategyFieldWorkCourse:shouldLowerThisImplement(object, turnEnd
         return dz < 0 , true, nil
     else
         -- dz will be negative as we are behind the target node. Also, dx must be close enough, otherwise
-        -- we'll lower them way too early if approaching the turn end from the side at about 90°
-        return dz > - loweringDistance and math.abs(dxFront) < loweringDistance * 1.5 , true, dz
+        -- we'll lower them way too early if approaching the turn end from the side at about 90° (and we
+        -- want a constant value here, certainly not the loweringDistance which changes with the current speed
+        -- and thus introduces a feedback loop, causing the return value to oscillate, that is, we say should be
+        -- lowered, than the vehicle stops, but now the loweringDistance will be low, so we say should not be
+        -- lowering, vehicle starts again, and so on ...
+        local normalLoweringDistance = self.loweringDurationMs * self.settings.turnSpeed:getValue() / 3600
+        return dz > - loweringDistance and math.abs(dxFront) < normalLoweringDistance * 1.5, true, dz
     end
 end
 

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -970,9 +970,11 @@ StartRowOnly = CpObject(CourseTurn)
 ---@param fieldWorkCourse Course field work course
 ---@param workWidth number
 function StartRowOnly:init(vehicle, driveStrategy, ppc, turnContext, startRowCourse, fieldWorkCourse, workWidth)
-	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, 'AlignmentTurn')
+	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, 'StartRow')
 	self.turnCourse = startRowCourse
-	TurnManeuver.setLowerImplements(self.turnCourse, math.max(math.abs(turnContext.frontMarkerDistance), self.steeringLength))
+	-- add a turn ending section into the row to make sure the implements are lowered correctly
+	local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, 3, true)
+	TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
 	self.ppc:setCourse(self.turnCourse)
 	self.ppc:initialize(1)
 	self.state = self.states.TURNING


### PR DESCRIPTION
Add a straight section after the work start waypoint so
when transitioning to work the vehicle can wait for the
implements to lower before the alignment course ends.