### PR TITLE
Replacing tabs with spaces

### DIFF
--- a/scripts/courseGenerator/CourseGeneratorInterface.lua
+++ b/scripts/courseGenerator/CourseGeneratorInterface.lua
@@ -38,7 +38,7 @@ function CourseGeneratorInterface.generate(fieldPolygon,
 			headlandCornerType, headlandOverlapPercent, centerMode)
 	CourseGenerator.debug('                   row direction %d, rows to skip %d, rows per land %d',
 			rowDirection, rowsToSkip, rowsPerLand)
-	CourseGenerator.debug('					  multiTools %d, pipe on left %s',
+	CourseGenerator.debug('                   multiTools %d, pipe on left %s',
 			multiTools, pipeOnLeftSide)
 
 


### PR DESCRIPTION
Replacing tabs with spaces, FS doesn't like tabs -> `Warning: Character '9' not found in texture font`