### PR TITLE
Ability to skip 2 lines in vines

### DIFF
--- a/config/VineCourseGeneratorSettingsSetup.xml
+++ b/config/VineCourseGeneratorSettingsSetup.xml
@@ -21,6 +21,6 @@
             </Texts>
         </Setting>
         <Setting classType="AIParameterSettingList" name="vineMultiTools" min="1" max="5" default="1"/>
-        <Setting classType="AIParameterSettingList" name="vineRowsToSkip" min="0" max="1" default="0"/>
+        <Setting classType="AIParameterSettingList" name="vineRowsToSkip" min="0" max="2" default="0"/>
     </SettingSubTitle>
 </Settings>


### PR DESCRIPTION
This just a quick edit to give the ability to skip two lines in vine course. 

Useful for the Marshall ST1800 slurry spreader mod (https://www.farming-simulator.com/mod.php?lang=en&country=us&mod_id=233075&title=fs2022)

Screenshot of the mod working in an olive grove 
![20220418230717_1](https://user-images.githubusercontent.com/1066320/163942328-fceb8466-692f-48b4-9bfa-21411629384b.jpg)

