### PR TITLE
Issue 480

### DIFF
--- a/config/CourseGeneratorSettingsSetup.xml
+++ b/config/CourseGeneratorSettingsSetup.xml
@@ -8,7 +8,7 @@
 
 <Settings prefixText="CP_vehicle_courseGeneratorSetting_" autoUpdateGui="true">
 	<SettingSubTitle title="basic">
-		<Setting classType="AIParameterSettingList" name="workWidth" min="1" max="50" incremental="0.1" unit="2" setDefault="setAutomaticWorkWidth" onChangeCallback="cpShowWorkWidth"/>
+		<Setting classType="AIParameterSettingList" name="workWidth" min="1" max="50" incremental="0.1" unit="2" setDefault="setAutomaticWorkWidthAndOffset" onChangeCallback="cpShowWorkWidth"/>
 		<Setting classType="AIParameterSettingList" name="multiTools" min="1" max="5" default="1"/>
 		<Setting classType="AIParameterSettingList" name="numberOfHeadlands" min="0" max="40"/>
 	</SettingSubTitle>

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -54,7 +54,9 @@
 			</Texts>
 		</Setting>
 		<!--Tool Offset X-->
-		<Setting classType="AIParameterSettingList" name="toolOffsetX" min="-10" max="10" incremental="0.1" default="0" unit="2" onChangeCallback="cpShowWorkWidth" isDisabled = "isToolOffsetDisabled" vehicleConfiguration="toolOffsetX"/>
+		<Setting classType="AIParameterSettingList" name="toolOffsetX" min="-10" max="10" incremental="0.1" default="0" unit="2"
+				 onChangeCallback="cpShowWorkWidth" setDefault="setAutomaticWorkWidthAndOffset"
+				 isDisabled = "isToolOffsetDisabled" vehicleConfiguration="toolOffsetX"/>
 		<!--Silage additives needed?-->
 		<Setting classType="AIParameterBooleanSetting" name="useAdditiveFillUnit" defaultBool="false" isVisible="isAdditiveFillUnitSettingVisible" isExpertModeOnly="true"/>
 	</SettingSubTitle>

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -260,7 +260,7 @@ end
 --- Static parameters (won't change while driving)
 -----------------------------------------------------------------------------------------------------------------------
 function AIDriveStrategyCourse:setAllStaticParameters()
-    self.workWidth = WorkWidthUtil.getAutomaticWorkWidth(self.vehicle)
+    self.workWidth = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self.vehicle)
     self.reverser = AIReverseDriver(self.vehicle, self.ppc)
 end
 

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -260,7 +260,7 @@ end
 --- Static parameters (won't change while driving)
 -----------------------------------------------------------------------------------------------------------------------
 function AIDriveStrategyCourse:setAllStaticParameters()
-    self.workWidth = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self.vehicle)
+    self.workWidth = self.vehicle:getCourseGeneratorSettings().workWidth:getValue()
     self.reverser = AIReverseDriver(self.vehicle, self.ppc)
 end
 

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -260,7 +260,7 @@ end
 ---@param turnStartNode number at the last waypoint of the row, pointing in the direction of travel. This is where
 --- the implement should be raised when beginning a turn
 function AIDriveStrategyFieldWorkCourse:shouldRaiseThisImplement(object, turnStartNode)
-    local aiFrontMarker, _, aiBackMarker = WorkWidthUtil.getAIMarkers(object, nil, true)
+    local aiFrontMarker, _, aiBackMarker = WorkWidthUtil.getAIMarkers(object, true)
     -- if something (like a combine) does not have an AI marker it should not prevent from raising other implements
     -- like the header, which does have markers), therefore, return true here
     if not aiBackMarker or not aiFrontMarker then return true end
@@ -305,7 +305,7 @@ end
 ---@return boolean, boolean, number the second one is true when the first is valid, and the distance to the work start
 --- in meters (<0) when driving forward, nil when driving backwards.
 function AIDriveStrategyFieldWorkCourse:shouldLowerThisImplement(object, turnEndNode, reversing)
-    local aiLeftMarker, aiRightMarker, aiBackMarker = WorkWidthUtil.getAIMarkers(object, nil, true)
+    local aiLeftMarker, aiRightMarker, aiBackMarker = WorkWidthUtil.getAIMarkers(object, true)
     if not aiLeftMarker then return false, false, nil end
     local dxLeft, _, dzLeft = localToLocal(aiLeftMarker, turnEndNode, 0, 0, 0)
     local dxRight, _, dzRight = localToLocal(aiRightMarker, turnEndNode, 0, 0, 0)
@@ -354,7 +354,7 @@ function AIDriveStrategyFieldWorkCourse:areAllImplementsAligned(node)
 end
 
 function AIDriveStrategyFieldWorkCourse:isThisImplementAligned(object, node)
-    local aiFrontMarker, _, _ = WorkWidthUtil.getAIMarkers(object, nil, true)
+    local aiFrontMarker, _, _ = WorkWidthUtil.getAIMarkers(object, true)
     if not aiFrontMarker then return true end
     return CpMathUtil.isSameDirection(aiFrontMarker, node, 2)
 end

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -459,7 +459,7 @@ function AIUtil.isValidAIImplement(object)
 		-- has work areas, good.
 		return true
 	else
-		local aiLeftMarker, _, _ = WorkWidthUtil.getAIMarkers(object, nil, true)
+		local aiLeftMarker, _, _ = WorkWidthUtil.getAIMarkers(object, true)
 		if aiLeftMarker then
 			-- has AI markers, good
 			return true

--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -58,8 +58,13 @@ function WorkWidthUtil.getAutomaticWorkWidthAndOffset(object, referenceNode, ign
     end
 
     --- Work width for soil samplers.
-    if not width and object.spec_soilSampler then 
-        width = object.spec_soilSampler.samplingRadius and 2 * object.spec_soilSampler.samplingRadius/ math.sqrt(2)
+    if not width and object.spec_soilSampler then
+        if object.spec_soilSampler.samplingRadius then
+            width = 2 * object.spec_soilSampler.samplingRadius / math.sqrt(2)
+            WorkWidthUtil.debug(object, 'using soil sampler width of %.1f (from sampling radius).', width)
+        else
+            WorkWidthUtil.debug(object, 'soil sampler has no sampling radius, can\'t calculate width')
+        end
     end
 
     -- if something is foldable, and is folded, we unfold before measuring the width. This makes sure
@@ -108,7 +113,7 @@ function WorkWidthUtil.getAutomaticWorkWidthAndOffset(object, referenceNode, ign
     elseif left and right then
         width = left - right
         WorkWidthUtil.debug(object, 'working width is %.1f, left %.1f, right %.1f.', width, left, right)
-    else
+    elseif not width then
         width = 0
         WorkWidthUtil.debug(object, 'could not determine working width')
     end
@@ -116,7 +121,7 @@ function WorkWidthUtil.getAutomaticWorkWidthAndOffset(object, referenceNode, ign
     if configuredOffset then
         offset = configuredOffset
         WorkWidthUtil.debug(object, 'using configured tool offset of %.1f.', configuredOffset)
-    elseif left and right then
+    elseif width and left and right then
         offset = left - width / 2
         WorkWidthUtil.debug(object, 'calculated tool offset is %.1f.', offset)
     else
@@ -124,7 +129,6 @@ function WorkWidthUtil.getAutomaticWorkWidthAndOffset(object, referenceNode, ign
         WorkWidthUtil.debug(object, 'could not determine offset, using 0')
     end
 
-    --return math.floor(width * 10 + 0.5) / 10, math.floor(offset * 10 + 0.5) / 10, left, right
     return width, offset, left, right
 end
 

--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -77,6 +77,9 @@ function WorkWidthUtil.getAutomaticWorkWidthAndOffset(object, referenceNode, ign
             wasFolded = ImplementUtil.unfoldForGettingWidth(object)
             -- no AI markers, check work areas
             width, left, right = WorkWidthUtil.getWorkAreaWidth(object, referenceNode)
+            if not width then
+                WorkWidthUtil.debug(object, 'has NO valid work areas')
+            end
         else
             WorkWidthUtil.debug(object, 'has NO work areas')
         end
@@ -129,19 +132,22 @@ end
 ---@param object table
 function WorkWidthUtil.getWorkAreaWidth(object, referenceNode)
     -- TODO: check if there's a better way to find out if the implement has a work area
-    local maxLeft, minRight = -math.huge, math.huge
+    local hasValidWorkArea, maxLeft, minRight = false, -math.huge, math.huge
     for i, wa in WorkWidthUtil.workAreaIterator(object) do
-        -- work areas are defined by three nodes: start, width and height. These nodes
-        -- define a rectangular work area which you can make visible with the
-        -- gsVehicleDebugAttributes console command and then pressing F5
-        local left, _, _ = localToLocal(wa.start, referenceNode, 0, 0, 0)
-        local right, _, _ = localToLocal(wa.width, referenceNode, 0, 0, 0)
-        maxLeft = math.max(maxLeft, left)
-        minRight = math.min(minRight, right)
-        WorkWidthUtil.debug(object, 'work area %d is %s, left = %.1f, right %.1f m',
-                i, g_workAreaTypeManager.workAreaTypes[wa.type].name, left, right)
+        if WorkWidthUtil.isValidWorkArea(wa) then
+            hasValidWorkArea = true
+            -- work areas are defined by three nodes: start, width and height. These nodes
+            -- define a rectangular work area which you can make visible with the
+            -- gsVehicleDebugAttributes console command and then pressing F5
+            local left, _, _ = localToLocal(wa.start, referenceNode, 0, 0, 0)
+            local right, _, _ = localToLocal(wa.width, referenceNode, 0, 0, 0)
+            maxLeft = math.max(maxLeft, left)
+            minRight = math.min(minRight, right)
+            WorkWidthUtil.debug(object, 'work area %d is %s, left = %.1f, right %.1f m',
+                    i, g_workAreaTypeManager.workAreaTypes[wa.type].name, left, right)
+        end
     end
-    return maxLeft - minRight, maxLeft, minRight
+    return hasValidWorkArea and maxLeft - minRight, maxLeft, minRight
 end
 
 ---@param object table

--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -61,7 +61,7 @@ function WorkWidthUtil.getAutomaticWorkWidthAndOffset(object, referenceNode, ign
     if not left and object.spec_soilSampler then
         if object.spec_soilSampler.samplingRadius then
             local width = 2 * object.spec_soilSampler.samplingRadius / math.sqrt(2)
-            left, right = width / 2, width / 2
+            left, right = width / 2, - width / 2
             WorkWidthUtil.debug(object, 'using soil sampler width of %.1f (from sampling radius).', width)
         else
             WorkWidthUtil.debug(object, 'soil sampler has no sampling radius, can\'t calculate width')

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -323,7 +323,8 @@ end
 ---@return boolean value is not valid and could not be set.
 function AIParameterSettingList:setFloatValue(value, epsilon)
 	return setValueInternal(self, value, function(a, b)
-								local epsilon = epsilon or self.data.incremental or 0.1
+		local epsilon = epsilon or self.data.incremental or 0.1
+		if a == nil or b == nil then return false end
 		return a > b - epsilon / 2 and a <= b + epsilon / 2 end)
 end
 

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -311,7 +311,7 @@ local function setValueInternal(self, value, comparisonFunc)
 		if comparisonFunc(self.values[i], value) then
 			new = self:checkAndSetValidValue(i)
 			self:setToIx(new)
-			return
+			return false
 		end
 	end
 	return value ~= new
@@ -324,7 +324,7 @@ end
 function AIParameterSettingList:setFloatValue(value, epsilon)
 	return setValueInternal(self, value, function(a, b)
 								local epsilon = epsilon or self.data.incremental or 0.1
-		return MathUtil.equalEpsilon(a, b, epsilon) end)
+		return a > b - epsilon / 2 and a <= b + epsilon / 2 end)
 end
 
 --- Gets the closest value ix and absolute difference, relative to the value searched for.

--- a/scripts/specializations/CpCourseGeneratorSettings.lua
+++ b/scripts/specializations/CpCourseGeneratorSettings.lua
@@ -85,8 +85,7 @@ end
 function CpCourseGeneratorSettings:onLoadFinished(savegame)
     local spec = self.spec_cpCourseGeneratorSettings
     if not spec.wasLoaded then
-        local width, offset WorkWidthUtil.getAutomaticWorkWidthAndOffset(self)
-        spec.workWidth:setFloatValue(width)
+        CpCourseGeneratorSettings.setAutomaticWorkWidthAndOffset(self)
     end
 end
 
@@ -95,12 +94,17 @@ function CpCourseGeneratorSettings.onVariableWorkWidthSectionChanged(object)
     --- Object could be an implement, so make sure we use the root vehicle.
     local self = object.rootVehicle
     if self:getIsSynchronized() and self.spec_cpCourseGeneratorSettings then
-        local spec = self.spec_cpCourseGeneratorSettings
-        local width, offset = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self)
-        spec.workWidth:setFloatValue(width)
+        CpCourseGeneratorSettings.setAutomaticWorkWidthAndOffset(self)
     end
 end
 VariableWorkWidth.updateSections = Utils.appendedFunction(VariableWorkWidth.updateSections,CpCourseGeneratorSettings.onVariableWorkWidthSectionChanged)
+
+function CpCourseGeneratorSettings:setAutomaticWorkWidthAndOffset()
+    local spec = self.spec_cpCourseGeneratorSettings
+    local width, offset, _, _ = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self)
+    spec.workWidth:setFloatValue(width)
+    self:getCpSettings().toolOffsetX:setFloatValue(offset)
+end
 
 --- Loads the generic settings setup from an xmlFile.
 function CpCourseGeneratorSettings.loadSettingsSetup()

--- a/scripts/specializations/CpCourseGeneratorSettings.lua
+++ b/scripts/specializations/CpCourseGeneratorSettings.lua
@@ -26,8 +26,6 @@ end
 
 function CpCourseGeneratorSettings.registerEventListeners(vehicleType)	
 	SpecializationUtil.registerEventListener(vehicleType, "onLoad", CpCourseGeneratorSettings)
-    SpecializationUtil.registerEventListener(vehicleType, "onPreDetachImplement", CpCourseGeneratorSettings)
-    SpecializationUtil.registerEventListener(vehicleType, "onPostAttachImplement", CpCourseGeneratorSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onLoadFinished",CpCourseGeneratorSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onCpUnitChanged", CpCourseGeneratorSettings)
 end
@@ -87,18 +85,9 @@ end
 function CpCourseGeneratorSettings:onLoadFinished(savegame)
     local spec = self.spec_cpCourseGeneratorSettings
     if not spec.wasLoaded then
-        spec.workWidth:setFloatValue(WorkWidthUtil.getAutomaticWorkWidth(self))
+        local width, offset WorkWidthUtil.getAutomaticWorkWidthAndOffset(self)
+        spec.workWidth:setFloatValue(width)
     end
-end
-
-function CpCourseGeneratorSettings:onPostAttachImplement()
-    CpCourseGeneratorSettings.setAutomaticWorkWidth(self)
-    CpCourseGeneratorSettings.validateSettings(self)
-end
-
-function CpCourseGeneratorSettings:onPreDetachImplement(implement)
-    CpCourseGeneratorSettings.setAutomaticWorkWidth(self, implement.object)
-    CpCourseGeneratorSettings.validateSettings(self)
 end
 
 --- Makes sure the automatic work width gets recalculated after the variable work width was changed by the user.
@@ -107,7 +96,8 @@ function CpCourseGeneratorSettings.onVariableWorkWidthSectionChanged(object)
     local self = object.rootVehicle
     if self:getIsSynchronized() and self.spec_cpCourseGeneratorSettings then
         local spec = self.spec_cpCourseGeneratorSettings
-        spec.workWidth:setFloatValue(WorkWidthUtil.getAutomaticWorkWidth(self))
+        local width, offset = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self)
+        spec.workWidth:setFloatValue(width)
     end
 end
 VariableWorkWidth.updateSections = Utils.appendedFunction(VariableWorkWidth.updateSections,CpCourseGeneratorSettings.onVariableWorkWidthSectionChanged)
@@ -172,13 +162,6 @@ end
 ---@param setting AIParameterSettingList setting that raised the callback.
 function CpCourseGeneratorSettings:raiseCallback(callbackStr, setting, ...)
     SpecializationUtil.raiseEvent(self, callbackStr, setting, ...)
-end
-
----@param ignoreObject table ignore this object when calculating the width (as it is being detached, for instance)
-function CpCourseGeneratorSettings:setAutomaticWorkWidth(ignoreObject)
-    local spec = self.spec_cpCourseGeneratorSettings
-    local width = WorkWidthUtil.getAutomaticWorkWidth(self, nil, ignoreObject)
-    spec.workWidth:setFloatValue(width)
 end
 
 function CpCourseGeneratorSettings:validateSettings()

--- a/scripts/specializations/CpCourseGeneratorSettings.lua
+++ b/scripts/specializations/CpCourseGeneratorSettings.lua
@@ -96,8 +96,8 @@ function CpCourseGeneratorSettings:onPostAttachImplement()
     CpCourseGeneratorSettings.validateSettings(self)
 end
 
-function CpCourseGeneratorSettings:onPreDetachImplement()
-    CpCourseGeneratorSettings.setAutomaticWorkWidth(self)
+function CpCourseGeneratorSettings:onPreDetachImplement(implement)
+    CpCourseGeneratorSettings.setAutomaticWorkWidth(self, implement.object)
     CpCourseGeneratorSettings.validateSettings(self)
 end
 
@@ -174,9 +174,11 @@ function CpCourseGeneratorSettings:raiseCallback(callbackStr, setting, ...)
     SpecializationUtil.raiseEvent(self, callbackStr, setting, ...)
 end
 
-function CpCourseGeneratorSettings:setAutomaticWorkWidth()
+---@param ignoreObject table ignore this object when calculating the width (as it is being detached, for instance)
+function CpCourseGeneratorSettings:setAutomaticWorkWidth(ignoreObject)
     local spec = self.spec_cpCourseGeneratorSettings
-    spec.workWidth:setFloatValue(WorkWidthUtil.getAutomaticWorkWidth(self))
+    local width = WorkWidthUtil.getAutomaticWorkWidth(self, nil, ignoreObject)
+    spec.workWidth:setFloatValue(width)
 end
 
 function CpCourseGeneratorSettings:validateSettings()

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -76,9 +76,7 @@ function CpVehicleSettings:onPostAttachImplement(object)
         return
     end
 
-    local width, offset = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self)
-    self:getCourseGeneratorSettings().workWidth:setFloatValue(width)
-    spec.toolOffsetX:setFloatValue(offset)
+    CpVehicleSettings.setAutomaticWorkWidthAndOffset(self)
 
     CpVehicleSettings.setFromVehicleConfiguration(self, object, spec.raiseImplementLate, 'raiseLate')
     CpVehicleSettings.setFromVehicleConfiguration(self, object, spec.lowerImplementEarly, 'lowerEarly')
@@ -92,13 +90,18 @@ function CpVehicleSettings:onPreDetachImplement(implement)
         return
     end
 
-    local width, offset = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self, nil, implement.object)
-    self:getCourseGeneratorSettings().workWidth:setFloatValue(width)
-    spec.toolOffsetX:setFloatValue(offset)
+    CpVehicleSettings.setAutomaticWorkWidthAndOffset(self, implement.object)
 
     CpVehicleSettings.resetToDefault(self, implement.object, spec.raiseImplementLate, 'raiseLate', false)
     CpVehicleSettings.resetToDefault(self, implement.object, spec.lowerImplementEarly, 'lowerEarly', false)
     CpVehicleSettings.validateSettings(self)
+end
+
+function CpVehicleSettings:setAutomaticWorkWidthAndOffset(ignoreObject)
+    local spec = self.spec_cpVehicleSettings
+    local width, offset = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self, nil, ignoreObject)
+    self:getCourseGeneratorSettings().workWidth:setFloatValue(width)
+    spec.toolOffsetX:setFloatValue(offset)
 end
 
 function CpVehicleSettings:onReadStream(streamId)

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -75,9 +75,13 @@ function CpVehicleSettings:onPostAttachImplement(object)
     if spec.wasLoaded then 
         return
     end
+
+    local width, offset = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self)
+    self:getCourseGeneratorSettings().workWidth:setFloatValue(width)
+    spec.toolOffsetX:setFloatValue(offset)
+
     CpVehicleSettings.setFromVehicleConfiguration(self, object, spec.raiseImplementLate, 'raiseLate')
     CpVehicleSettings.setFromVehicleConfiguration(self, object, spec.lowerImplementEarly, 'lowerEarly')
-    CpVehicleSettings.setFromVehicleConfiguration(self, object, spec.toolOffsetX, 'toolOffsetX')
     CpVehicleSettings.validateSettings(self)
 end
 
@@ -87,9 +91,13 @@ function CpVehicleSettings:onPreDetachImplement(implement)
     if spec.wasLoaded then 
         return
     end
+
+    local width, offset = WorkWidthUtil.getAutomaticWorkWidthAndOffset(self, nil, implement.object)
+    self:getCourseGeneratorSettings().workWidth:setFloatValue(width)
+    spec.toolOffsetX:setFloatValue(offset)
+
     CpVehicleSettings.resetToDefault(self, implement.object, spec.raiseImplementLate, 'raiseLate', false)
     CpVehicleSettings.resetToDefault(self, implement.object, spec.lowerImplementEarly, 'lowerEarly', false)
-    CpVehicleSettings.resetToDefault(self, implement.object, spec.toolOffsetX, 'toolOffsetX', 0)
     CpVehicleSettings.validateSettings(self)
 end
 


### PR DESCRIPTION
Work/width offset fix

Auto work width/offset calculation reworked. Now using the left and right distances over all implements (instead of just the width) and calculate final working width/offset from that.

Configured width/offset always takes precedence over automatically detected values.