### PR TITLE
Fix for vehicles leaving the course #1478

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -843,12 +843,13 @@ function Course:getNextFwdWaypointIx(ix)
 	return ix
 end
 
-function Course:getNextFwdWaypointIxFromVehiclePosition(ix, vehicleNode, lookAheadDistance)
-	for i = ix, #self.waypoints do
+function Course:getNextFwdWaypointIxFromVehiclePosition(ix, vehicleNode, maxDx)
+	-- only look at the next few waypoints, we don't want to find anything far away, really, it should be in front of us
+	for i = ix, math.min(ix + 10, #self.waypoints) do
 		if not self:isReverseAt(i) then
 			local uX, uY, uZ = self:getWaypointPosition(i)
-			local _, _, z = worldToLocal(vehicleNode, uX, uY, uZ);
-			if z > lookAheadDistance then
+			local dx, _, dz = worldToLocal(vehicleNode, uX, uY, uZ);
+			if dz > 0 and math.abs(dx) < maxDx then
 				return i
 			end
 		end

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -506,7 +506,8 @@ function AIDriveStrategyFieldWorkCourse:resumeFieldworkAfterTurn(ix, forceIx)
     self:lowerImplements()
     -- restore our own listeners for waypoint changes
     self.ppc:registerListeners(self, 'onWaypointPassed', 'onWaypointChange')
-    local startIx = forceIx and ix or self.course:getNextFwdWaypointIxFromVehiclePosition(ix, self.vehicle:getAIDirectionNode(), 0)
+    local startIx = forceIx and ix or self.course:getNextFwdWaypointIxFromVehiclePosition(ix,
+            self.vehicle:getAIDirectionNode(), self.workWidth / 2)
     self:startCourse(self.course, startIx)
 end
 


### PR DESCRIPTION
When looking for the next waypoint after ending a turn,
limit the search for the next few waypoints within the
working width lateral distance.

This makes sure we don't continue at a waypoint somewhere at the
other side of the field just because it is in front of us.