### PR TITLE
Fix for course start/headland turns with tool offset

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -421,6 +421,7 @@ function Course:useTightTurnOffset(ix)
 end
 
 --- Returns the position of the waypoint at ix with the current offset applied.
+---@param ix number waypoint index
 ---@return number, number, number x, y, z
 function Course:getWaypointPosition(ix)
 	if self:isTurnStartAtIx(ix) then

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1579,7 +1579,7 @@ function AIDriveStrategyCombineCourse:returnToFieldworkAfterSelfUnload()
 		self:debug('Return to fieldwork after self unload at waypoint %d', ix)
 		local done, path
 		self.pathfinder, done, path = PathfinderUtil.startPathfindingFromVehicleToWaypoint(
-				self.vehicle, fieldWorkCourse:getWaypoint(ix), 0,0,
+				self.vehicle, fieldWorkCourse, ix, 0,0,
 				self:getAllowReversePathfinding(), nil)
 		if done then
 			return self:onPathfindingDoneAfterSelfUnload(path)

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -487,11 +487,17 @@ function AIDriveStrategyCourse:isCloseToCourseStart(distance)
     return self.course:getDistanceFromFirstWaypoint(self.ppc:getCurrentWaypointIx()) < distance
 end
 
-
 --- Event raised when the drive is finished.
 --- This gets called in the :stopCurrentAIJob(), as the giants code might stop the driver and not the active strategy.
 function AIDriveStrategyCourse:onFinished()
     self:raiseControllerEvent(self.onFinishedEvent)
+end
+
+--- This is to set the offsets on the course at start, or update those values
+--- if the user changed them during the run or the AI driver wants to add an offset
+function AIDriveStrategyCourse:updateFieldworkOffset(course)
+    course:setOffset(self.settings.toolOffsetX:getValue() + (self.aiOffsetX or 0) + (self.tightTurnOffset or 0),
+            (self.aiOffsetZ or 0))
 end
 
 ------------------------------------------------------------------------------------------------------------------------

--- a/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -68,6 +68,7 @@ function AIDriveStrategyDriveToFieldWorkStart:initializeImplementControllers(veh
 end
 
 function AIDriveStrategyDriveToFieldWorkStart:start(course, startIx, jobParameters)
+    self:updateFieldworkOffset(course)
     local distance = course:getDistanceBetweenVehicleAndWaypoint(self.vehicle, startIx)
     if distance < AIDriveStrategyDriveToFieldWorkStart.minDistanceToDrive then
         self:debug('Closer than %.0f m to start waypoint (%d), start fieldwork directly',
@@ -161,6 +162,7 @@ function AIDriveStrategyDriveToFieldWorkStart:startCourseWithPathfinding(course,
         self:rememberCourse(course, ix)
         self:setFrontAndBackMarkers()
         local x, _, z = course:getWaypointPosition(ix)
+        self:debug('offsetx %.1f, x %.1f, z %.1f', course.offsetX, x, z)
         self.state = self.states.WAITING_FOR_PATHFINDER
         local fieldNum = CpFieldUtil.getFieldIdAtWorldPosition(x, z)
         -- if there is fruit at the target, create an area around it where the pathfinder ignores the fruit
@@ -172,7 +174,7 @@ function AIDriveStrategyDriveToFieldWorkStart:startCourseWithPathfinding(course,
         -- always drive a behind the target waypoint so there's room to straighten out towed implements
         -- a bit before start working
         self:debug('Pathfinding to waypoint %d, with zOffset min(%.1f, %.1f)', ix, -self.frontMarkerDistance, -steeringLength)
-        self.pathfinder, done, path = PathfinderUtil.startPathfindingFromVehicleToWaypoint(self.vehicle, course:getWaypoint(ix),
+        self.pathfinder, done, path = PathfinderUtil.startPathfindingFromVehicleToWaypoint(self.vehicle, course, ix,
                 self.multitoolOffset, math.min(-self.frontMarkerDistance, -steeringLength), self:getAllowReversePathfinding(), fieldNum, nil, ix < 3 and math.huge, nil, nil,
                 fruitAtTarget and PathfinderUtil.Area(x, z, 2 * self.workWidth))
         if done then

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -62,6 +62,7 @@ end
 --- the most we need is an alignment course to lower the implements
 function AIDriveStrategyFieldWorkCourse:start(course, startIx, jobParameters)
     self:showAllInfo('Starting field work at waypoint %d', startIx)
+    self:updateFieldworkOffset(course)
     self.fieldWorkCourse = course
     -- remember at which waypoint we started, especially for the convoy
     self.startWaypointIx = startIx
@@ -124,7 +125,7 @@ end
 --- This is the interface to the Giant's AIFieldWorker specialization, telling it the direction and speed
 function AIDriveStrategyFieldWorkCourse:getDriveData(dt, vX, vY, vZ)
 
-    self:updateFieldworkOffset()
+    self:updateFieldworkOffset(self.course)
     self:updateLowFrequencyImplementControllers()
 
     local moveForwards = not self.ppc:isReversing()
@@ -576,14 +577,6 @@ function AIDriveStrategyFieldWorkCourse:getBestWaypointToContinueFieldWork()
     end
     self:debug('Best return to fieldwork waypoint is %d', bestWpIx)
     return bestWpIx
-end
-
---- We already set the offsets on the course at start, this is to update those values
--- if the user changed them during the run or the AI driver wants to add an offset
-function AIDriveStrategyFieldWorkCourse:updateFieldworkOffset()
-    self.course:setOffset(
-        self.settings.toolOffsetX:getValue() + self.aiOffsetX + (self.tightTurnOffset or 0),
-        0 + self.aiOffsetZ)
 end
 
 function AIDriveStrategyFieldWorkCourse:setOffsetX()

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -344,16 +344,13 @@ end
 --- Create a corner based on the turn context's start and end waypoints
 ---@param vehicle table
 ---@param r number turning radius in m
----@param sideOffset number (left < 0, right > 0) side offset to use when the course has an offset, for example
---- due to a tool setting.
---- TODO_22: side offset used the toolOffsetX setting for the vehicle
-function TurnContext:createCorner(vehicle, r, sideOffset)
+function TurnContext:createCorner(vehicle, r)
     -- use the average angle of the turn end and the next wp as there is often a bend there
     local endAngleDeg = self:getAverageEndAngleDeg()
     CpUtil.debugVehicle(CpDebug.DBG_TURN, vehicle, 'start angle: %.1f, end angle: %.1f (from %.1f and %.1f)', self.beforeTurnStartWp.angle,
             endAngleDeg, self.turnEndWp.angle, self.afterTurnEndWp.angle)
     return Corner(vehicle, self.beforeTurnStartWp.angle, self.turnStartWp, endAngleDeg, self.turnEndWp, r,
-            sideOffset)
+            vehicle:getCpSettings().toolOffsetX:getValue())
 end
 
 --- Course to reverse before starting a turn to make sure the turn is completely on the field

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -483,9 +483,11 @@ function AlignmentCourse:init(vehicle, vehicleDirectionNode, turningRadius, cour
 	self:debug('creating alignment course to waypoint %d, zOffset = %.1f', ix, zOffset)
 	local x, z, yRot = PathfinderUtil.getNodePositionAndDirection(vehicleDirectionNode, 0, 0)
 	local start = State3D(x, -z, CourseGenerator.fromCpAngle(yRot))
-	local targetWp = course:getWaypoint(ix)
-	x, _, z = targetWp:getOffsetPosition(0, zOffset)
+	x, _, z = course:getWaypointPosition(ix)
 	local goal = State3D(x, -z, CourseGenerator.fromCpAngle(math.rad(course:getWaypointAngleDeg(ix))))
+
+	local offset = Vector(zOffset, 0)
+	goal:add(offset:rotate(goal.t))
 
 	-- have a little reserve to make sure vehicles can always follow the course
 	turningRadius = turningRadius * 1.1

--- a/scripts/pathfinder/PathfinderUtil.lua
+++ b/scripts/pathfinder/PathfinderUtil.lua
@@ -777,7 +777,8 @@ end
 --- Interface function to start the pathfinder in the game
 ------------------------------------------------------------------------------------------------------------------------
 ---@param vehicle table, will be used as the start location/heading, turn radius and size
----@param goalWaypoint Waypoint The destination waypoint (x, z, angle)
+---@param course Course the course with the destination waypoint
+---@param goalWaypointIx number index of the waypoint
 ---@param xOffset number side offset of the goal from the goalWaypoint
 ---@param zOffset number length offset of the goal from the goalWaypoint
 ---@param allowReverse boolean allow reverse driving
@@ -788,12 +789,12 @@ end
 ---@param offFieldPenalty number penalty to apply to nodes off the field
 ---@param areaToAvoid PathfinderUtil.NodeArea nodes in this area will be penalized so the path will most likely avoid it
 ---@param areaToIgnoreFruit PathfinderUtil.Area area to ignore fruit
-function PathfinderUtil.startPathfindingFromVehicleToWaypoint(vehicle, goalWaypoint,
+function PathfinderUtil.startPathfindingFromVehicleToWaypoint(vehicle, course, goalWaypointIx,
                                                               xOffset, zOffset, allowReverse,
                                                               fieldNum, vehiclesToIgnore, maxFruitPercent,
 															  offFieldPenalty, areaToAvoid, areaToIgnoreFruit)
-
-    local goal = State3D(goalWaypoint.x, -goalWaypoint.z, CourseGenerator.fromCpAngleDeg(goalWaypoint.angle))
+    local x, _, z = course:getWaypointPosition(goalWaypointIx)
+    local goal = State3D(x, -z, CourseGenerator.fromCpAngleDeg(course:getWaypointAngleDeg(goalWaypointIx)))
     local offset = Vector(zOffset, -xOffset)
     goal:add(offset:rotate(goal.t))
     return PathfinderUtil.startPathfindingFromVehicleToGoal(


### PR DESCRIPTION
Use the current tool offset now when creating a corner, this
was somehow lost when migrating from FS19.

Set the course offset on start (not just when actually driving)

Use the course offset when calculating the path to the
start waypoint.