### PR TITLE
Issue 1554

### DIFF
--- a/scripts/DevHelper.lua
+++ b/scripts/DevHelper.lua
@@ -53,7 +53,7 @@ function DevHelper:update()
         end
 
         self.vehicle = g_currentMission.controlledVehicle
-        self.node = g_currentMission.controlledVehicle.rootNode
+        self.node = g_currentMission.controlledVehicle:getAIDirectionNode()
         lx, _, lz = localDirectionToWorld(self.node, 0, 0, 1)
 
     else

--- a/scripts/ai/PurePursuitController.lua
+++ b/scripts/ai/PurePursuitController.lua
@@ -55,6 +55,10 @@ HOW TO USE
 ---@class PurePursuitController
 PurePursuitController = CpObject()
 
+--- if the vehicle is more than cutOutDistanceLimit meters from the current segment's endpoints, cut-out the
+--- controller to stop. Some error must have caused us to wander way off-track, unlikely to recover.
+PurePursuitController.cutOutDistanceLimit = 50
+
 -- constructor
 function PurePursuitController:init(vehicle)
 	self.normalLookAheadDistance = math.min(vehicle.maxTurningRadius, 6)
@@ -472,6 +476,11 @@ function PurePursuitController:findGoalPoint()
 					self.lookAheadDistance, self.crossTrackError)
 				-- current waypoint is the waypoint at the end of the path segment
 				self:setCurrentWaypoint(ix + 1)
+			end
+			if (q1 > self.cutOutDistanceLimit) and (q2 > self.cutOutDistanceLimit) then
+				CpUtil.infoVehicle(self.vehicle, 'vehicle off track, shutting off Courseplay now.')
+				self.vehicle:stopCurrentAIJob(AIMessageErrorUnknown.new())
+				return
 			end
 			break
 		end

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -236,7 +236,10 @@ function TurnContext:isHeadlandCorner()
 	-- in headland turns there's no significant direction change at the turn start waypoint, as the turn end waypoint
 	-- marks the actual corner. In a non-headland turn (usually 180) there is about 90 degrees direction change at
 	-- both the turn start and end waypoints
-	return math.abs(getDeltaAngle(math.rad(self.turnStartWp.angle), math.rad(self.beforeTurnStartWp.angle))) < (math.pi / 6)
+    -- a turn is a headland turn only when there is minimal direction change at the turn start and the total direction
+    -- change is less than 150 degrees
+	return math.abs(getDeltaAngle(math.rad(self.turnStartWp.angle), math.rad(self.beforeTurnStartWp.angle))) < (math.pi / 6) and
+            math.abs( self.directionChangeDeg ) < 150
 end
 
 --- A simple wide turn is where there's no corner to avoid, no headland to follow, there is a straight line on the

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -236,7 +236,7 @@ function TurnContext:isHeadlandCorner()
 	-- in headland turns there's no significant direction change at the turn start waypoint, as the turn end waypoint
 	-- marks the actual corner. In a non-headland turn (usually 180) there is about 90 degrees direction change at
 	-- both the turn start and end waypoints
-	return getDeltaAngle(math.rad(self.turnStartWp.angle), math.rad(self.beforeTurnStartWp.angle)) < (math.pi / 6)
+	return math.abs(getDeltaAngle(math.rad(self.turnStartWp.angle), math.rad(self.beforeTurnStartWp.angle))) < (math.pi / 6)
 end
 
 --- A simple wide turn is where there's no corner to avoid, no headland to follow, there is a straight line on the

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -233,8 +233,10 @@ function TurnContext:isPointingToTurnEnd(node, thresholdDeg)
 end
 
 function TurnContext:isHeadlandCorner()
-    -- TODO: there should be a better way to find this out
-    return math.abs( self.directionChangeDeg ) < 150
+	-- in headland turns there's no significant direction change at the turn start waypoint, as the turn end waypoint
+	-- marks the actual corner. In a non-headland turn (usually 180) there is about 90 degrees direction change at
+	-- both the turn start and end waypoints
+	return getDeltaAngle(math.rad(self.turnStartWp.angle), math.rad(self.beforeTurnStartWp.angle)) < (math.pi / 6)
 end
 
 --- A simple wide turn is where there's no corner to avoid, no headland to follow, there is a straight line on the


### PR DESCRIPTION
Headland corner detection improved

Changed logic to detect headland corners: instead of
looking at the total direction change, look at the direction
change on the turn start waypoint only. If there's no significant
direction change there, it is a headland corner (as the actual
corner is at the turn end waypoint).

Stop Courseplay when wandering off-track.
