### PR TITLE
Improved saving of settings and saves user vehicle settings #1258

### DIFF
--- a/scripts/ai/jobs/CpJobParameters.lua
+++ b/scripts/ai/jobs/CpJobParameters.lua
@@ -34,9 +34,7 @@ function CpJobParameters:init(job)
 end
 
 function CpJobParameters.registerXmlSchema(schema, baseKey)
-    local key = baseKey..CpJobParameters.xmlKey.."(?)"
-    schema:register(XMLValueType.STRING, key.."#currentValue", "Setting value")
-    schema:register(XMLValueType.STRING, key.."#name", "Setting name")
+    CpSettingsUtil.registerXmlSchema(schema, baseKey..CpJobParameters.xmlKey.."(?)")
 end
 
 function CpJobParameters.getSettings(vehicle)
@@ -62,20 +60,12 @@ function CpJobParameters:readStream(streamId, connection)
 end
 
 function CpJobParameters:saveToXMLFile(xmlFile, baseKey, usedModNames)
-	for i, parameter in ipairs(self.settings) do 
-        local key = string.format("%s(%d)", baseKey..self.xmlKey , i-1)
-        parameter:saveToXMLFile(xmlFile, key)
-        xmlFile:setValue(key.."#name", parameter:getName())
-    end
+    CpSettingsUtil.saveToXmlFile(self.settings, xmlFile, 
+        baseKey ..self.xmlKey, self.job:getVehicle(), nil)
 end
 
 function CpJobParameters:loadFromXMLFile(xmlFile, baseKey)
-	xmlFile:iterate(baseKey .. self.xmlKey, function (ix, key)
-        local name = xmlFile:getValue(key.."#name")
-        if name then
-            self[name]:loadFromXMLFile(xmlFile, key)
-        end
-	end)
+    CpSettingsUtil.loadFromXmlFile(self, xmlFile, baseKey .. self.xmlKey, self.job:getVehicle())
 end
 
 

--- a/scripts/events/VehicleSettingsEvent.lua
+++ b/scripts/events/VehicleSettingsEvent.lua
@@ -10,7 +10,7 @@ function VehicleSettingsEvent.emptyNew()
 end
 
 --- Creates a new Event
-function VehicleSettingsEvent.new(vehicle,setting)
+function VehicleSettingsEvent.new(vehicle, setting)
 	local self = VehicleSettingsEvent.emptyNew()
 	self.vehicle = vehicle
 	self.setting = setting
@@ -18,41 +18,95 @@ function VehicleSettingsEvent.new(vehicle,setting)
 end
 
 --- Reads the serialized data on the receiving end of the event.
-function VehicleSettingsEvent:readStream(streamId, connection) -- wird aufgerufen wenn mich ein Event erreicht
+function VehicleSettingsEvent:readStream(streamId, connection)
 	self.vehicle = NetworkUtil.readNodeObject(streamId)
 	VehicleSettingsEvent.debug(self.vehicle, "readStream")
 	local name = streamReadString(streamId)
 	local setting = self.vehicle:getCpSettings()[name]
-	setting:readStream(streamId,connection)
-	self:run(connection,setting);
+	setting:readStream(streamId, connection)
+	self:run(connection, setting);
 end
 
 --- Writes the serialized data from the sender.
-function VehicleSettingsEvent:writeStream(streamId, connection)  -- Wird aufgrufen wenn ich ein event verschicke (merke: reihenfolge der Daten muss mit der bei readStream uebereinstimmen 
+function VehicleSettingsEvent:writeStream(streamId, connection) 
 	VehicleSettingsEvent.debug(self.vehicle, "writeStream")
-	NetworkUtil.writeNodeObject(streamId,self.vehicle)
-	streamWriteString(streamId,self.setting:getName())
-	self.setting:writeStream(streamId,connection)
+	NetworkUtil.writeNodeObject(streamId, self.vehicle)
+	streamWriteString(streamId, self.setting:getName())
+	self.setting:writeStream(streamId, connection)
 end
 
 --- Runs the event on the receiving end of the event.
-function VehicleSettingsEvent:run(connection,setting) -- wir fuehren das empfangene event aus
+function VehicleSettingsEvent:run(connection, setting) 
 	--- If the receiver was the client make sure every clients gets also updated.
 	if not connection:getIsServer() then
 		VehicleSettingsEvent.debug(self.vehicle, "broadcastEvent")
-		g_server:broadcastEvent(VehicleSettingsEvent.new(self.vehicle,setting), nil, connection, self.vehicle)
+		g_server:broadcastEvent(VehicleSettingsEvent.new(self.vehicle, setting), nil, connection, self.vehicle)
 	end
 end
 
-function VehicleSettingsEvent.sendEvent(vehicle,setting)
+function VehicleSettingsEvent.sendEvent(vehicle, setting)
 	if g_server ~= nil then
 		VehicleSettingsEvent.debug(vehicle, "sendEvent")
-		g_server:broadcastEvent(VehicleSettingsEvent.new(vehicle,setting), nil, nil, vehicle)
+		g_server:broadcastEvent(VehicleSettingsEvent.new(vehicle, setting), nil, nil, vehicle)
 	else
-		g_client:getServerConnection():sendEvent(VehicleSettingsEvent.new(vehicle,setting))
+		g_client:getServerConnection():sendEvent(VehicleSettingsEvent.new(vehicle, setting))
 	end
 end
 
 function VehicleSettingsEvent.debug(vehicle, str, ...)
-	CpUtil.debugVehicle(CpDebug.DBG_MULTIPLAYER, vehicle, "VehicleSettingsEvent: "..str,...)
+	CpUtil.debugVehicle(CpDebug.DBG_MULTIPLAYER, vehicle, "VehicleSettingsEvent: "..str, ...)
+end
+
+--- Sends the changed setting value to the server,
+--- so it can be saved there.
+---@class VehicleUserSettingsEvent
+VehicleUserSettingsEvent = {}
+
+local VehicleUserSettingsEvent_mt = Class(VehicleUserSettingsEvent, Event)
+
+InitEventClass(VehicleUserSettingsEvent, "VehicleUserSettingsEvent")
+
+function VehicleUserSettingsEvent.emptyNew()
+	return Event.new(VehicleUserSettingsEvent_mt)
+end
+
+--- Creates a new Event
+function VehicleUserSettingsEvent.new(vehicle, setting)
+	local self = VehicleUserSettingsEvent.emptyNew()
+	self.vehicle = vehicle
+	self.setting = setting
+	return self
+end
+
+--- Reads the serialized data on the receiving end of the event.
+function VehicleUserSettingsEvent:readStream(streamId, connection)
+	self.vehicle = NetworkUtil.readNodeObject(streamId)
+	VehicleUserSettingsEvent.debug(self.vehicle, "readStream")
+	local name = streamReadString(streamId)
+	local value = streamReadInt32(streamId)
+	self:run(connection, name, value)
+end
+
+--- Writes the serialized data from the sender.
+function VehicleUserSettingsEvent:writeStream(streamId, connection) 
+	VehicleUserSettingsEvent.debug(self.vehicle, "writeStream")
+	NetworkUtil.writeNodeObject(streamId, self.vehicle)
+	streamWriteString(streamId, self.setting:getName())
+	streamWriteInt32(streamId, self.setting:getClosestSetupIx())
+end
+
+--- Runs the event on the receiving end of the event.
+function VehicleUserSettingsEvent:run(connection, name, value) 
+	local uniqueUserId = g_currentMission.userManager:getUniqueUserIdByConnection(connection)
+	VehicleUserSettingsEvent.debug(self.vehicle, "name: %s, value: %s, userId: %s", name, tostring(value), tostring(uniqueUserId))
+	self.vehicle:cpSaveUserSettingValue(uniqueUserId, name, value)
+end
+
+function VehicleUserSettingsEvent.sendEvent(vehicle, setting)
+	VehicleUserSettingsEvent.debug(vehicle, "sendEvent")
+	g_client:getServerConnection():sendEvent(VehicleUserSettingsEvent.new(vehicle, setting))
+end
+
+function VehicleUserSettingsEvent.debug(vehicle, str, ...)
+	CpUtil.debugVehicle(CpDebug.DBG_MULTIPLAYER, vehicle, "VehicleUserSettingsEvent: "..str, ...)
 end

--- a/scripts/specializations/CpAIBaleFinder.lua
+++ b/scripts/specializations/CpAIBaleFinder.lua
@@ -9,10 +9,12 @@ CpAIBaleFinder.startText = g_i18n:getText("CP_jobParameters_startAt_bales")
 CpAIBaleFinder.MOD_NAME = g_currentModName or modName
 CpAIBaleFinder.NAME = ".cpAIBaleFinder"
 CpAIBaleFinder.SPEC_NAME = CpAIBaleFinder.MOD_NAME .. CpAIBaleFinder.NAME
-CpAIBaleFinder.KEY = "."..CpAIBaleFinder.MOD_NAME..CpAIBaleFinder.NAME .. "."
+CpAIBaleFinder.KEY = "."..CpAIBaleFinder.MOD_NAME..CpAIBaleFinder.NAME
 
 function CpAIBaleFinder.initSpecialization()
     local schema = Vehicle.xmlSchemaSavegame
+    local key = "vehicles.vehicle(?)" .. CpAIBaleFinder.KEY
+    CpJobParameters.registerXmlSchema(schema, key..".cpJob")
 end
 
 function CpAIBaleFinder.prerequisitesPresent(specializations)
@@ -27,6 +29,7 @@ end
 
 function CpAIBaleFinder.registerEventListeners(vehicleType)
     SpecializationUtil.registerEventListener(vehicleType, 'onLoad', CpAIBaleFinder)
+    SpecializationUtil.registerEventListener(vehicleType, 'onLoadFinished', CpAIBaleFinder)
 end
 
 function CpAIBaleFinder.registerFunctions(vehicleType)
@@ -54,6 +57,18 @@ function CpAIBaleFinder:onLoad(savegame)
     --- This job is for starting the driving with a key bind or the mini gui.
     spec.cpJob = g_currentMission.aiJobTypeManager:createJob(AIJobType.BALE_FINDER_CP)
     spec.cpJob:setVehicle(self)
+end
+
+function CpAIBaleFinder:onLoadFinished(savegame)
+    local spec = self.spec_cpAIBaleFinder
+    if savegame ~= nil then 
+        spec.cpJob:getCpJobParameters():loadFromXMLFile(savegame.xmlFile, savegame.key.. CpAIBaleFinder.KEY..".cpJob")
+    end
+end
+
+function CpAIBaleFinder:saveToXMLFile(xmlFile, baseKey, usedModNames)
+    local spec = self.spec_cpAIBaleFinder
+    spec.cpJob:getCpJobParameters():saveToXMLFile(xmlFile, baseKey.. ".cpJob")
 end
 
 function CpAIBaleFinder:getCpBaleFinderJobParameters()

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -20,6 +20,8 @@ function CpVehicleSettings.initSpecialization()
         "vehicles.vehicle(?)" .. CpVehicleSettings.KEY .. CpVehicleSettings.SETTINGS_KEY .. "(?)")
    
     --- MP vehicle user settings
+
+    schema:register(XMLValueType.INT,"vehicles.vehicle(?)" .. CpVehicleSettings.KEY .. CpVehicleSettings.USER_KEY .. "(?)#userId", "User id")
     CpSettingsUtil.registerXmlSchema(schema, 
         "vehicles.vehicle(?)" .. CpVehicleSettings.KEY .. CpVehicleSettings.USER_KEY .. "(?)")
 end

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -7,18 +7,32 @@ CpVehicleSettings = {}
 
 CpVehicleSettings.MOD_NAME = g_currentModName
 CpVehicleSettings.KEY = "."..CpVehicleSettings.MOD_NAME..".cpVehicleSettings"
+CpVehicleSettings.SETTINGS_KEY = ".settings"
+CpVehicleSettings.USER_KEY = ".users"
 function CpVehicleSettings.initSpecialization()
 	local schema = Vehicle.xmlSchemaSavegame
-    local key = "vehicles.vehicle(?)"..CpVehicleSettings.KEY.."(?)"
-    schema:register(XMLValueType.INT, key.."#value", "Old setting save format.")
-    schema:register(XMLValueType.STRING, key.."#currentValue", "Setting value")
-    schema:register(XMLValueType.STRING, key.."#name", "Setting name")
+    --- Old xml schema for settings
+    CpSettingsUtil.registerXmlSchema(schema, 
+        "vehicles.vehicle(?)" .. CpVehicleSettings.KEY .. "(?)")
+   
+    --- New xml schema for settings
+    CpSettingsUtil.registerXmlSchema(schema, 
+        "vehicles.vehicle(?)" .. CpVehicleSettings.KEY .. CpVehicleSettings.SETTINGS_KEY .. "(?)")
+   
+    --- MP vehicle user settings
+    CpSettingsUtil.registerXmlSchema(schema, 
+        "vehicles.vehicle(?)" .. CpVehicleSettings.KEY .. CpVehicleSettings.USER_KEY .. "(?)")
 end
 
 
 function CpVehicleSettings.prerequisitesPresent(specializations)
     return SpecializationUtil.hasSpecialization(AIFieldWorker, specializations) 
 end
+
+function CpVehicleSettings.registerEvents(vehicleType)
+    SpecializationUtil.registerEvent(vehicleType, 'onCpUserSettingChanged')
+end
+
 
 function CpVehicleSettings.registerEventListeners(vehicleType)	
 --	SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", CpVehicleSettings)
@@ -30,12 +44,14 @@ function CpVehicleSettings.registerEventListeners(vehicleType)
     SpecializationUtil.registerEventListener(vehicleType, "onReadStream", CpVehicleSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onWriteStream", CpVehicleSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onStateChange", CpVehicleSettings)
+    SpecializationUtil.registerEventListener(vehicleType, "onCpUserSettingChanged", CpVehicleSettings)
 end
 
 function CpVehicleSettings.registerFunctions(vehicleType)
-
     SpecializationUtil.registerFunction(vehicleType, 'getCpSettingsTable', CpVehicleSettings.getSettingsTable)
     SpecializationUtil.registerFunction(vehicleType, 'getCpSettings', CpVehicleSettings.getSettings)
+    SpecializationUtil.registerFunction(vehicleType, 'cpSaveUserSettingValue', CpVehicleSettings.cpSaveUserSettingValue)
+    SpecializationUtil.registerFunction(vehicleType, 'getCpSavedUserSettingValue', CpVehicleSettings.getCpSavedUserSettingValue)
 end
 
 --- Gets all settings.
@@ -57,10 +73,10 @@ function CpVehicleSettings:onLoad(savegame)
     local spec = self.spec_cpVehicleSettings
 
     --- Clones the generic settings to create different settings containers for each vehicle. 
-    CpSettingsUtil.cloneSettingsTable(spec,CpVehicleSettings.settings,self,CpVehicleSettings)
+    CpSettingsUtil.cloneSettingsTable(spec, CpVehicleSettings.settings, self, CpVehicleSettings)
     
-    CpVehicleSettings.loadSettings(self,savegame)
-    
+    spec.userSettings = {}
+    CpVehicleSettings.loadSettings(self, savegame)
 end
 
 function CpVehicleSettings:onLoadFinished()
@@ -121,51 +137,88 @@ function CpVehicleSettings:setAutomaticWorkWidthAndOffset(ignoreObject)
     spec.toolOffsetX:setFloatValue(offset)
 end
 
-function CpVehicleSettings:onReadStream(streamId)
+function CpVehicleSettings:onReadStream(streamId, connection)
     local spec = self.spec_cpVehicleSettings
-    for i,setting in ipairs(spec.settings) do 
-        setting:readStream(streamId)
+    for i, setting in ipairs(spec.settings) do 
+        setting:readStream(streamId, connection)
     end
 end
 
-function CpVehicleSettings:onWriteStream(streamId)
+function CpVehicleSettings:onWriteStream(streamId, connection)
     local spec = self.spec_cpVehicleSettings
-    for i,setting in ipairs(spec.settings) do 
-        setting:writeStream(streamId)
+    for i, setting in ipairs(spec.settings) do 
+        setting:writeStream(streamId, connection)
+    end
+end
+
+function CpVehicleSettings:cpSaveUserSettingValue(userId, name, value)
+    local spec = self.spec_cpVehicleSettings
+    if spec.userSettings[userId] == nil then 
+        spec.userSettings[userId] = {}
+    end
+    spec.userSettings[userId][name] = value
+end
+
+function CpVehicleSettings:getCpSavedUserSettingValue(setting, connection)
+    local spec = self.spec_cpVehicleSettings
+    local uniqueUserId = g_currentMission.userManager:getUniqueUserIdByConnection(connection)
+    if spec.userSettings[uniqueUserId] then 
+        return spec.userSettings[uniqueUserId][setting:getName()]
     end
 end
 
 function CpVehicleSettings.loadSettingsSetup()
     local filePath = Utils.getFilename("config/VehicleSettingsSetup.xml", g_Courseplay.BASE_DIRECTORY)
-    CpSettingsUtil.loadSettingsFromSetup(CpVehicleSettings,filePath)
+    CpSettingsUtil.loadSettingsFromSetup(CpVehicleSettings, filePath)
 end
 CpVehicleSettings.loadSettingsSetup()
 
 function CpVehicleSettings.getSettingSetup()
-    return CpVehicleSettings.settingsBySubTitle,CpVehicleSettings.pageTitle
+    return CpVehicleSettings.settingsBySubTitle, CpVehicleSettings.pageTitle
 end
 
 function CpVehicleSettings:loadSettings(savegame)
     if savegame == nil or savegame.resetVehicles then return end
     local spec = self.spec_cpVehicleSettings
-	savegame.xmlFile:iterate(savegame.key..CpVehicleSettings.KEY, function (ix, key)
+
+    --- Loads the old save format
+    CpSettingsUtil.loadFromXmlFile(spec, savegame.xmlFile, 
+                        savegame.key .. CpVehicleSettings.KEY, self)
+
+    --- Loads the new save format
+    CpSettingsUtil.loadFromXmlFile(spec, savegame.xmlFile, 
+                        savegame.key .. CpVehicleSettings.KEY .. CpVehicleSettings.SETTINGS_KEY, self)
+
+    --- Loads the user settings for multiplayer.
+    savegame.xmlFile:iterate(savegame.key..CpVehicleSettings.KEY..CpVehicleSettings.USER_KEY, function (ix, key)
         local name = savegame.xmlFile:getValue(key.."#name")
-        local setting = spec[name]
-        if setting then
-            setting:loadFromXMLFile(savegame.xmlFile, key)
-            CpUtil.debugVehicle(CpUtil.DBG_HUD,self,"Loaded setting: %s, value:%s, key: %s",setting:getName(),setting:getValue(),key)
+        local value =  tonumber(savegame.xmlFile:getValue(key.."#currentValue"))
+        local userId = savegame.xmlFile:getValue(key.."#userId")
+        if userId then
+            if spec.userSettings[userId] == nil then 
+                spec.userSettings[userId] = {}
+            end
+            spec.userSettings[userId][name] = value
         end
-        spec.wasLoaded = true
 	end)
+
 end
 
-function CpVehicleSettings:saveToXMLFile(xmlFile, key, usedModNames)
+function CpVehicleSettings:saveToXMLFile(xmlFile, baseKey, usedModNames)
     local spec = self.spec_cpVehicleSettings
-    for i,setting in ipairs(spec.settings) do 
-        local key = string.format("%s(%d)",key,i-1)
-        setting:saveToXMLFile(xmlFile, key, usedModNames)
-        xmlFile:setValue(key.."#name",setting:getName())
-        CpUtil.debugVehicle(CpUtil.DBG_HUD,self,"Saved setting: %s, value:%s, key: %s",setting:getName(),setting:getValue(),key)
+    --- Saves the settings.
+    CpSettingsUtil.saveToXmlFile(spec.settings, xmlFile, 
+        baseKey .. CpVehicleSettings.SETTINGS_KEY, self, nil)
+    --- Saves the user settings for multiplayer.
+    local ix = 0
+    for userId, settings in pairs(spec.userSettings) do 
+        for name, value in pairs(settings) do 
+            local key = string.format("%s(%d)", baseKey.. CpVehicleSettings.USER_KEY, ix)
+            xmlFile:setValue(key.."#name", name)
+            xmlFile:setValue(key.."#currentValue", tostring(value))
+            xmlFile:setValue(key.."#userId", userId)
+            ix = ix + 1
+        end
     end
 end
 
@@ -177,7 +230,7 @@ function CpVehicleSettings:raiseCallback(callbackStr, setting, ...)
 end
 
 function CpVehicleSettings:raiseDirtyFlag(setting)
-    VehicleSettingsEvent.sendEvent(self,setting)
+    VehicleSettingsEvent.sendEvent(self, setting)
 end 
 
 function CpVehicleSettings:validateSettings()
@@ -238,7 +291,7 @@ end
 
 --- Are the combine settings needed.
 function CpVehicleSettings:areCombineSettingsVisible()
-    local implement = AIUtil.getImplementOrVehicleWithSpecialization(self,Combine)
+    local implement = AIUtil.getImplementOrVehicleWithSpecialization(self, Combine)
     return implement and not ImplementUtil.isChopper(implement)
 end
 
@@ -252,7 +305,7 @@ end
 
 --- Disables tool offset, as the plow drive strategy automatically handles the tool offset.
 function CpVehicleSettings:isToolOffsetDisabled()
-    return AIUtil.getImplementOrVehicleWithSpecialization(self,Plow)
+    return AIUtil.getImplementOrVehicleWithSpecialization(self, Plow)
 end
 
 --- Only shows the setting if a valid tool with ridge markers is attached.
@@ -267,8 +320,8 @@ function CpVehicleSettings:isOptionalSowingMachineSettingVisible()
 end
 
 function CpVehicleSettings:isSowingMachineFertilizerSettingVisible()
-    return AIUtil.hasChildVehicleWithSpecialization(self,FertilizingSowingMachine) or 
-             AIUtil.hasChildVehicleWithSpecialization(self,FertilizingCultivator)
+    return AIUtil.hasChildVehicleWithSpecialization(self, FertilizingSowingMachine) or 
+             AIUtil.hasChildVehicleWithSpecialization(self, FertilizingCultivator)
 end
 
 --- Only show the multi tool settings, with a multi tool course loaded.
@@ -289,4 +342,11 @@ function CpVehicleSettings:isAdditiveFillUnitSettingVisible()
         hasAdditiveTank = hasAdditiveTank or forageWagons[1].spec_forageWagon.additives.available
     end
     return hasAdditiveTank
+end
+
+--- Saves the user value changed on the server.
+function CpVehicleSettings:onCpUserSettingChanged(setting)
+    if not self.isServer then 
+        VehicleUserSettingsEvent.sendEvent(self, setting)
+    end
 end


### PR DESCRIPTION
- Tests:
  - Test the saving of global, course generator (normal and vine), vehicle and job parameters(fieldwork and balefinder) of one setting each.
  - Test MP show course setting, with a simple rejoin as client.
  - Test loading of setting values with an old save game.