### PR TITLE
Use the back marker as course end offset

### DIFF
--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -395,10 +395,9 @@ function AIDriveStrategyFieldWorkCourse:onWaypointChange(ix, course)
         -- towards the end of the field course make sure the implement reaches the last waypoint
         -- TODO: this needs refactoring, for now don't do this for temporary courses like a turn as it messes up reversing
         if ix > self.course:getNumberOfWaypoints() - 3 and not self.course:isTemporary() then
-            if self.frontMarkerDistance then
-                self:debug('adding offset (%.1f front marker) to make sure we do not miss anything when the course ends', self.frontMarkerDistance)
-                self.aiOffsetZ = -self.frontMarkerDistance
-            end
+            local _, bm = self:getFrontAndBackMarkers()
+            self:debug('adding offset (%.1f front marker) to make sure we do not miss anything when the course ends', bm)
+            self.aiOffsetZ = -bm
         end
     end
 end

--- a/scripts/dev/ConsoleCommands.lua
+++ b/scripts/dev/ConsoleCommands.lua
@@ -147,7 +147,7 @@ function CpConsoleCommands:loadFile(fileName)
 		return 'Could not load ' .. path
 	else
 		local code = getXMLString(g_xmlFile, 'code')
-		local f = getfenv(0).loadstring('setfenv(1, '.. CpConsoleCommands.MOD_NAME .. '); ' .. code)
+		local f = getfenv(0).loadstring('setfenv(1, '.. Courseplay.MOD_NAME .. '); ' .. code)
 		if f then
 			f()
 			return 'OK: ' .. path .. ' loaded.'


### PR DESCRIPTION
Instead of the front marker so vehicles with front/back
attached mowers don't leave unworked patches at the end of
the course.

Will result the tractor pulling well ahead of the last waypoint
if the back marker is far, like sprayers or spreaders.

#1726