### PR TITLE
Enable tight turn offset for alignment course

### DIFF
--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -474,7 +474,7 @@ end
 function AIDriveStrategyCourse:createAlignmentCourse(course, ix)
     self:debug('Generate alignment course to waypoint %d', ix)
     local alignmentCourse = AlignmentCourse(self.vehicle, self.vehicle:getAIDirectionNode(), self.turningRadius,
-            course, ix, math.min(-self.frontMarkerDistance, 0)):getCourse()
+            course, ix, math.min(-self.frontMarkerDistance, -1)):getCourse()
     return alignmentCourse
 end
 

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -774,7 +774,7 @@ function CourseTurn:generateCalculatedTurn()
 		if self.steeringLength > 0 and not (SpecializationUtil.hasSpecialization(ArticulatedAxis, self.vehicle.specializations) or
 				SpecializationUtil.hasSpecialization(Crawler, self.vehicle.specializations)) then
 			self:debug('Enabling tight turn offset')
-			self.enableTightTurnOffset = 1
+			self.enableTightTurnOffset = true
 		end
 	end
 	self.turnCourse = turnManeuver:getCourse()
@@ -974,6 +974,8 @@ StartRowOnly = CpObject(CourseTurn)
 function StartRowOnly:init(vehicle, driveStrategy, ppc, turnContext, startRowCourse, fieldWorkCourse, workWidth)
 	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, 'StartRow')
 	self.turnCourse = startRowCourse
+	self.enableTightTurnOffset = true
+	self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
 	-- add a turn ending section into the row to make sure the implements are lowered correctly
 	local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, 3, true)
 	TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)


### PR DESCRIPTION
This should help to align towed implements better when
using an alignment course, for instance on the headland ->
up/down rows transition.

Also moved back the destination a meter so with non-towed
(3-point) implements the alignment course ends a meter
before the row starts to help align those better.

#1728