### PR TITLE
Added support for trailer fill limit

### DIFF
--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -387,6 +387,7 @@ function AIDriveStrategyUnloadCombine:getTrailersTargetNode()
             end
         else
             self:debugSparse('Combine says it can\'t load trailer')
+            --TODO: maybe then send the unloader away if activated?
         end
     else
         self:debugSparse('Can\'t find trailer')
@@ -417,7 +418,7 @@ function AIDriveStrategyUnloadCombine:getAllTrailersFull()
     local fillLevelInfo = {}
     self.fillLevelManager:getAllFillLevels(self.vehicle, fillLevelInfo)
     for fillType, info in pairs(fillLevelInfo) do
-        if self.fillLevelManager:isValidFillType(self.vehicle, fillType) and info.fillLevel < info.capacity then
+        if self.fillLevelManager:isValidFillType(self.vehicle, fillType) and info.fillLevel < info.capacity and not info.weightLimitReached then
             -- not fuel and not full, so not all full...
             -- TODO: this assumes that other than diesel, air, etc. the only fill type we have is the one the
             -- combine is harvesting. Could consider the combine's fill type but that sometimes is UNKNOWN

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -164,6 +164,7 @@ function FillLevelManager:getAllFillLevels(object, fillLevelInfo)
             if not fillLevelInfo[fillType] then fillLevelInfo[fillType] = {fillLevel=0, capacity=0} end
             fillLevelInfo[fillType].fillLevel = fillLevelInfo[fillType].fillLevel + fillUnit.fillLevel
             fillLevelInfo[fillType].capacity = fillLevelInfo[fillType].capacity + fillUnit.capacity
+            fillLevelInfo[fillType].weightLimitReached = object:getMaxComponentMassReached()
             --used to check treePlanter fillLevel
             local treePlanterSpec = object.spec_treePlanter
             if treePlanterSpec then

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -164,7 +164,7 @@ function FillLevelManager:getAllFillLevels(object, fillLevelInfo)
             if not fillLevelInfo[fillType] then fillLevelInfo[fillType] = {fillLevel=0, capacity=0} end
             fillLevelInfo[fillType].fillLevel = fillLevelInfo[fillType].fillLevel + fillUnit.fillLevel
             fillLevelInfo[fillType].capacity = fillLevelInfo[fillType].capacity + fillUnit.capacity
-            fillLevelInfo[fillType].weightLimitReached = object:getMaxComponentMassReached()
+            fillLevelInfo[fillType].weightLimitReached = g_currentMission.missionInfo.trailerFillLimit and object:getMaxComponentMassReached()
             --used to check treePlanter fillLevel
             local treePlanterSpec = object.spec_treePlanter
             if treePlanterSpec then


### PR DESCRIPTION
Courseplay tried to unload a harvester when the weight limit is reached in the trailer. 
Now it also takes a look into the weight limit and checks if it is reached.