### PR TITLE
Only show combine unloader job when only 1 Trailer is attached to the unloader (and weight implementation)

### DIFF
--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -387,6 +387,7 @@ function AIDriveStrategyUnloadCombine:getTrailersTargetNode()
             end
         else
             self:debugSparse('Combine says it can\'t load trailer')
+            --TODO: maybe then send the unloader away if activated?
         end
     else
         self:debugSparse('Can\'t find trailer')
@@ -417,7 +418,7 @@ function AIDriveStrategyUnloadCombine:getAllTrailersFull()
     local fillLevelInfo = {}
     self.fillLevelManager:getAllFillLevels(self.vehicle, fillLevelInfo)
     for fillType, info in pairs(fillLevelInfo) do
-        if self.fillLevelManager:isValidFillType(self.vehicle, fillType) and info.fillLevel < info.capacity then
+        if self.fillLevelManager:isValidFillType(self.vehicle, fillType) and info.fillLevel < info.capacity and not info.weightLimitReached then
             -- not fuel and not full, so not all full...
             -- TODO: this assumes that other than diesel, air, etc. the only fill type we have is the one the
             -- combine is harvesting. Could consider the combine's fill type but that sometimes is UNKNOWN

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -404,6 +404,16 @@ function AIUtil.getImplementWithSpecializationFromList(specialization, implement
 	end
 end
 
+--- Get number of child vehicles that have a certain specialization
+---@param vehicle Vehicle
+---@param specialization specialization to check for
+---@return integer number of found vehicles
+function AIUtil.getNumberOfChildVehiclesWithSpecialization(vehicle, specialization)
+	local vehicles = AIUtil.getAllChildVehiclesWithSpecialization(vehicle, specialization, nil)
+
+	return #vehicles
+end
+
 --- Gets all child vehicles with a given specialization. 
 --- This can include the rootVehicle and implements
 --- that are not directly attached to the rootVehicle.

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -164,6 +164,7 @@ function FillLevelManager:getAllFillLevels(object, fillLevelInfo)
             if not fillLevelInfo[fillType] then fillLevelInfo[fillType] = {fillLevel=0, capacity=0} end
             fillLevelInfo[fillType].fillLevel = fillLevelInfo[fillType].fillLevel + fillUnit.fillLevel
             fillLevelInfo[fillType].capacity = fillLevelInfo[fillType].capacity + fillUnit.capacity
+            fillLevelInfo[fillType].weightLimitReached = object:getMaxComponentMassReached()
             --used to check treePlanter fillLevel
             local treePlanterSpec = object.spec_treePlanter
             if treePlanterSpec then

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -307,7 +307,7 @@ end
 function FillLevelManager.areAllTrailersFull(vehicle, fullThreshold)
     fullThreshold = fullThreshold or 0
     local totalFillLevel, totalCapacity, totalFreeCapacity =  FillLevelManager.getAllTrailerFillLevels(vehicle)
-    return totalFreeCapacity <= 0 or totalCapacity - totalFillLevel <= fullThreshold
+    return totalFreeCapacity <= fullThreshold
 end
 
 --- Gets the total fill level percentage and total fill level percentage adjusted to the max fill volume mass adjusted.

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -307,7 +307,7 @@ end
 function FillLevelManager.areAllTrailersFull(vehicle, fullThreshold)
     fullThreshold = fullThreshold or 0
     local totalFillLevel, totalCapacity, totalCapacityMassAdjusted =  FillLevelManager.getAllTrailerFillLevels(vehicle)
-    return totalCapacityMassAdjusted - totalFillLevel < fullThreshold
+    return totalCapacity <= fullThreshold
 end
 
 --- Gets the total fill level percentage and total fill level percentage adjusted to the max fill volume mass adjusted.

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -164,7 +164,6 @@ function FillLevelManager:getAllFillLevels(object, fillLevelInfo)
             if not fillLevelInfo[fillType] then fillLevelInfo[fillType] = {fillLevel=0, capacity=0} end
             fillLevelInfo[fillType].fillLevel = fillLevelInfo[fillType].fillLevel + fillUnit.fillLevel
             fillLevelInfo[fillType].capacity = fillLevelInfo[fillType].capacity + fillUnit.capacity
-            fillLevelInfo[fillType].weightLimitReached = g_currentMission.missionInfo.trailerFillLimit and object:getMaxComponentMassReached()
             --used to check treePlanter fillLevel
             local treePlanterSpec = object.spec_treePlanter
             if treePlanterSpec then

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -164,7 +164,7 @@ function FillLevelManager:getAllFillLevels(object, fillLevelInfo)
             if not fillLevelInfo[fillType] then fillLevelInfo[fillType] = {fillLevel=0, capacity=0} end
             fillLevelInfo[fillType].fillLevel = fillLevelInfo[fillType].fillLevel + fillUnit.fillLevel
             fillLevelInfo[fillType].capacity = fillLevelInfo[fillType].capacity + fillUnit.capacity
-            fillLevelInfo[fillType].weightLimitReached = object:getMaxComponentMassReached()
+            fillLevelInfo[fillType].weightLimitReached = g_currentMission.missionInfo.trailerFillLimit and object:getMaxComponentMassReached()
             --used to check treePlanter fillLevel
             local treePlanterSpec = object.spec_treePlanter
             if treePlanterSpec then

--- a/scripts/specializations/CpAICombineUnloader.lua
+++ b/scripts/specializations/CpAICombineUnloader.lua
@@ -90,7 +90,7 @@ end
 
 --- If we have a trailer which can be emptied, we can unload a combine
 function CpAICombineUnloader:getCanStartCpCombineUnloader()
-	return AIUtil.hasChildVehicleWithSpecialization(self, Trailer)
+	return AIUtil.getNumberOfChildVehiclesWithSpecialization(self, Trailer) == 1
 end
 
 function CpAICombineUnloader:getCanStartCp(superFunc)


### PR DESCRIPTION
Since multiple trailers aren't supported the job shouldn't get shown if more than one trailer-spec is part of the unloader and it`s attached trailers. After this rework this is realized.

I've also added a AIUtil-function to get the amount of specs that are in such a chain.

Additionally the weight implementation is also a part of this because ive created the new branch at a wrong point.