### PR TITLE
Don't wait for the combine when almost full

### DIFF
--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -154,12 +154,12 @@
 	</Category>
 	<Category name="AI combine unloader job parameters">
 		<Translation name="CP_combineUnloaderJobParameters_subTitle_fullThreshold">
-			<Text language="de"><![CDATA[Abtanken ab:]]></Text>
-			<Text language="en"><![CDATA[Full threshold:]]></Text>
+			<Text language="de"><![CDATA[Entleeren wenn über:]]></Text>
+			<Text language="en"><![CDATA[Empty when over:]]></Text>
 		</Translation>
 		<Translation name="CP_combineUnloaderJobParameters_fullThreshold_title">
-			<Text language="de"><![CDATA[Abtanken ab:]]></Text>
-			<Text language="en"><![CDATA[Full threshold:]]></Text>
+			<Text language="de"><![CDATA[Entleeren wenn über:]]></Text>
+			<Text language="en"><![CDATA[Empty when over:]]></Text>
 		</Translation>
 		<Translation name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader">
 			<Text language="de"><![CDATA[Giants Ablader:]]></Text>

--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -153,14 +153,6 @@
 		</Translation>
 	</Category>
 	<Category name="AI combine unloader job parameters">
-		<Translation name="CP_combineUnloaderJobParameters_subTitle_fullThreshold">
-			<Text language="de"><![CDATA[Entleeren wenn über:]]></Text>
-			<Text language="en"><![CDATA[Empty when over:]]></Text>
-		</Translation>
-		<Translation name="CP_combineUnloaderJobParameters_fullThreshold_title">
-			<Text language="de"><![CDATA[Entleeren wenn über:]]></Text>
-			<Text language="en"><![CDATA[Empty when over:]]></Text>
-		</Translation>
 		<Translation name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader">
 			<Text language="de"><![CDATA[Giants Ablader:]]></Text>
 			<Text language="en"><![CDATA[Giants unloader:]]></Text>
@@ -375,6 +367,14 @@
 		<Translation name="CP_vehicle_setting_toolOffsetZ_tooltip">
 			<Text language="de"><![CDATA[Geräteversatz vertikal]]></Text>
 			<Text language="en"><![CDATA[Tool offset vertical]]></Text>
+		</Translation>
+		<Translation name="CP_vehicle_setting_fullThreshold_title">
+			<Text language="de"><![CDATA[Entleeren wenn über:]]></Text>
+			<Text language="en"><![CDATA[Empty when over:]]></Text>
+		</Translation>
+		<Translation name="CP_vehicle_setting_fullThreshold_tooltip">
+			<Text language="de"><![CDATA[TODO]]></Text>
+			<Text language="en"><![CDATA[TODO]]></Text>
 		</Translation>
 		<Translation name="CP_vehicle_setting_useAdditiveFillUnit_title">
 			<Text language="de"><![CDATA[Siliermittel überwachen.]]></Text>

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -60,6 +60,8 @@
 		<!--Tool Offset Z-->
 		<Setting classType="AIParameterSettingList" name="toolOffsetZ" min="-10" max="10" incremental="0.1" default="0" unit="2"
 				 onChangeCallback="cpShowWorkWidth" isDisabled = "isToolOffsetDisabled" />
+		<!-- Full threshold -->
+		<Setting classType="AIParameterSettingList" name="fullThreshold" min="50" max="100" incremental="5" default="85" unit="4"/>
 		<!--Silage additives needed?-->
 		<Setting classType="AIParameterBooleanSetting" name="useAdditiveFillUnit" defaultBool="false" isVisible="isAdditiveFillUnitSettingVisible" isExpertModeOnly="true"/>
 	</SettingSubTitle>

--- a/config/gamePadHud/UnloaderGamePadHudPage.xml
+++ b/config/gamePadHud/UnloaderGamePadHudPage.xml
@@ -7,7 +7,7 @@
 <Settings title="CP_vehicle_setting_display">
 	<Setting type="combineUnloaderJobParameters" name = "useGiantsUnload" />
 	<Setting type="combineUnloaderJobParameters" name = "unloadingStation" />
-	<Setting type="combineUnloaderJobParameters" name = "fullThreshold" />
+	<Setting type="vehicleSettings" name = "fullThreshold" />
 	<Setting type="vehicleSettings" name = "toolOffsetX" />
 	<Setting type="vehicleSettings" name = "toolOffsetZ" />
 </Settings>

--- a/config/jobParameters/CombineUnloaderJobParameterSetup.xml
+++ b/config/jobParameters/CombineUnloaderJobParameterSetup.xml
@@ -6,9 +6,6 @@
 -->
 
 <Settings prefixText="CP_combineUnloaderJobParameters_">
-	<SettingSubTitle title="fullThreshold">
-		<Setting classType="AIParameterSettingList" name="fullThreshold" min="50" max="100" incremental="5" default="85" unit="4"/>
-	</SettingSubTitle>
 	<SettingSubTitle title="giantsUnloader">
 		<!-- Is the giants ai unloader wanted for unloading? -->
 		<Setting classType="AIParameterBooleanSetting" name="useGiantsUnload" defaultBool="false" isDisabled ="hasPipe"/>

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -140,8 +140,7 @@ function AIDriveStrategyUnloadCombine:getGeneratedCourse(jobParameters)
 end
 
 function AIDriveStrategyUnloadCombine:setJobParameterValues(jobParameters)
-    self.fullThresholdPercentage = jobParameters.fullThreshold:getValue()
-    self:debug("Will not wait for a combine over %d percent fill level", self.fullThresholdPercentage)
+    
 end
 
 function AIDriveStrategyUnloadCombine:setAIVehicle(vehicle, jobParameters)
@@ -217,8 +216,8 @@ function AIDriveStrategyUnloadCombine:getDriveData(dt, vX, vY, vZ)
     elseif self.state == self.states.WAITING_FOR_COMBINE_TO_CALL then
         self:setMaxSpeed(0)
 
-        if self:isDriveUnloadNowRequested() or self:getAllTrailersFull(self.fullThresholdPercentage) then
-            self:debug('Drive unload now requested or trailers over %d fill level', self.fullThresholdPercentage)
+        if self:isDriveUnloadNowRequested() or self:getAllTrailersFull(self.settings.fullThreshold:getValue()) then
+            self:debug('Drive unload now requested or trailers over %d fill level', self.settings.fullThreshold:getValue())
             self:startUnloadingTrailers()
         end
     elseif self.state == self.states.WAITING_FOR_PATHFINDER then

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -107,7 +107,6 @@ function AIDriveStrategyUnloadCombine.new(customMt)
     self.combineToUnloadReversing = 0
     self.doNotSwerveForVehicle = CpTemporaryObject()
     self.justFinishedPathfindingForDistance = CpTemporaryObject()
-    self.timeToCheckCombines = CpTemporaryObject(true)
     self.vehicleInFrontOfUS = CpTemporaryObject()
     self.blockedVehicleReversing = CpTemporaryObject(false)
     self.driveUnloadNowRequested = CpTemporaryObject(false)
@@ -141,8 +140,8 @@ function AIDriveStrategyUnloadCombine:getGeneratedCourse(jobParameters)
 end
 
 function AIDriveStrategyUnloadCombine:setJobParameterValues(jobParameters)
-    self.fullThreshold = jobParameters.fullThreshold:getValue()
-    self:debug("Will consider itself full over %d percent", self.fullThreshold)
+    self.fullThresholdPercentage = jobParameters.fullThreshold:getValue()
+    self:debug("Will not wait for a combine over %d percent fill level", self.fullThresholdPercentage)
 end
 
 function AIDriveStrategyUnloadCombine:setAIVehicle(vehicle, jobParameters)
@@ -218,7 +217,8 @@ function AIDriveStrategyUnloadCombine:getDriveData(dt, vX, vY, vZ)
     elseif self.state == self.states.WAITING_FOR_COMBINE_TO_CALL then
         self:setMaxSpeed(0)
 
-        if self:isDriveUnloadNowRequested() or self:getAllTrailersFull() then
+        if self:isDriveUnloadNowRequested() or self:getAllTrailersFull(self.fullThresholdPercentage) then
+            self:debug('Drive unload now requested or trailers over %d fill level', self.fullThresholdPercentage)
             self:startUnloadingTrailers()
         end
     elseif self.state == self.states.WAITING_FOR_PATHFINDER then
@@ -284,7 +284,6 @@ end
 
 function AIDriveStrategyUnloadCombine:startWaitingForCombine()
     self:releaseCombine()
-    self.timeToCheckCombines:set(false, 5000)
     self.course = Course.createStraightForwardCourse(self.vehicle, 25)
     self:setNewState(self.states.WAITING_FOR_COMBINE_TO_CALL)
 end
@@ -407,8 +406,8 @@ function AIDriveStrategyUnloadCombine:getCombinesMeasuredBackDistance()
     return self.combineToUnload:getCpDriveStrategy():getMeasuredBackDistance()
 end
 
-function AIDriveStrategyUnloadCombine:getAllTrailersFull()
-    return FillLevelManager.areAllTrailersFull(self.vehicle, 0)
+function AIDriveStrategyUnloadCombine:getAllTrailersFull(fullThresholdPercentage)
+    return FillLevelManager.areAllTrailersFull(self.vehicle, fullThresholdPercentage)
 end
 
 --- Fill level in %.
@@ -1488,26 +1487,6 @@ function AIDriveStrategyUnloadCombine:isActiveCpCombine(vehicle)
     end
     local driveStrategy = vehicle.getCpDriveStrategy and vehicle:getCpDriveStrategy()
     return driveStrategy.needUnloader ~= nil
-end
-
-function AIDriveStrategyUnloadCombine:findCombine()
-    for _, vehicle in pairs(g_currentMission.vehicles) do
-        if self:isActiveCpCombine(vehicle) then
-            local x, _, z = getWorldTranslation(vehicle.rootNode)
-            if CpMathUtil.isPointInPolygon(self.fieldPolygon, x, z) then
-                local driveStrategy = vehicle:getCpDriveStrategy()
-                if driveStrategy:needUnloader(self.fullThreshold) then
-                    self:debug('Found combine %s on my field, fill level over %d in need of an unloader',
-                            CpUtil.getName(vehicle), self.fullThreshold)
-                    return vehicle, driveStrategy
-                else
-                    self:debug('Found combine %s on my field but it does not need an unloader', CpUtil.getName(vehicle))
-                end
-            else
-                self:debug('Combine %s is not on my field', CpUtil.getName(vehicle))
-            end
-        end
-    end
 end
 
 -----------------------------------------------------------------------------------------------------------------------

--- a/scripts/ai/FillLevelManager.lua
+++ b/scripts/ai/FillLevelManager.lua
@@ -302,12 +302,13 @@ end
 
 --- Are all trailers full?
 ---@param vehicle table
----@param fullThreshold number optional threshold
+---@param fullThresholdPercentage number optional threshold, if fill level in percentage is greater than the threshold,
+--- consider trailers full
 ---@return boolean
-function FillLevelManager.areAllTrailersFull(vehicle, fullThreshold)
-    fullThreshold = fullThreshold or 0
+function FillLevelManager.areAllTrailersFull(vehicle, fullThresholdPercentage)
     local totalFillLevel, totalCapacity, totalFreeCapacity =  FillLevelManager.getAllTrailerFillLevels(vehicle)
-    return totalFreeCapacity <= fullThreshold
+    local fillLevelPercentage = 100 * totalFillLevel / totalCapacity
+    return totalFreeCapacity <= 0 or fillLevelPercentage >= (fullThresholdPercentage or 100)
 end
 
 --- Gets the total fill level percentage and total fill level percentage adjusted to the max fill volume mass adjusted.

--- a/scripts/ai/jobs/CpAIJobCombineUnloader.lua
+++ b/scripts/ai/jobs/CpAIJobCombineUnloader.lua
@@ -312,7 +312,7 @@ function CpAIJobCombineUnloader:getStartTaskIndex()
 	local vehicle = self:getVehicle()
 	local fillLevelPercentage = FillLevelManager.getTotalTrailerFillLevelPercentage(vehicle)
 
-	local readyToDriveUnloading = self.cpJobParameters.fullThreshold:getValue() < fillLevelPercentage
+	local readyToDriveUnloading = vehicle:getCpSettings().fullThreshold:getValue() < fillLevelPercentage
 	
 	local vehicle = self.vehicleParameter:getVehicle()
 	local x, _, z = getWorldTranslation(vehicle.rootNode)

--- a/scripts/gui/hud/CpCombineUnloaderHudPage.lua
+++ b/scripts/gui/hud/CpCombineUnloaderHudPage.lua
@@ -20,7 +20,7 @@ function CpCombineUnloaderHudPageElement:setupElements(baseHud, vehicle, lines, 
 
     --- Full threshold 
     self.fullThresholdBtn = baseHud:addLineTextButton(self, 3, CpBaseHud.defaultFontSize, 
-                                                vehicle:getCpCombineUnloaderJobParameters().fullThreshold)              
+                                                vehicle:getCpSettings().fullThreshold)              
 
     --- Giants unloading station
     local x, y = unpack(lines[4].left)
@@ -92,7 +92,7 @@ function CpCombineUnloaderHudPageElement:updateContent(vehicle, status)
     self.toolOffsetZBtn:setTextDetails(toolOffsetZ:getTitle(), toolOffsetZ:getString())
     self.toolOffsetZBtn:setDisabled(toolOffsetZ:getIsDisabled())
 
-    local fullThreshold = vehicle:getCpCombineUnloaderJobParameters().fullThreshold
+    local fullThreshold = vehicle:getCpSettings().fullThreshold
     self.fullThresholdBtn:setTextDetails(fullThreshold:getTitle(), fullThreshold:getString())
     self.fullThresholdBtn:setDisabled(fullThreshold:getIsDisabled())
 

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Distancia horizontal do implemento"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Distancia vertical do implemento"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Distancia vertical do implemento"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifique se há aditivo de silagem."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Se o aditivo ativo e de silagem estiver vazio, o motorista irá parar."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Mudança de fileira simétrica"/>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="工具横向调整"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="工具纵向调整"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="工具纵向调整"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="检查青贮添加剂"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="工作中的车辆青贮添加剂存箱是空的会停止工作。"/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="对称变道"/>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Nastaví horizontální odsazení nástroje."/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Vertikální odsazení nástroje"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Nastaví vertikální odsazení nástroje."/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrola silážních aditiv"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Pokud je aktivní a dojdou silážní aditiva, pracovník se zastaví."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Pravidelné otáčení"/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Redskab forskudt vandret"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Redskab forskudt lodret"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Redskab Versatz vertikal"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Tjek for ensilagetilsætning."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Hvis aktiv og ensilageadditiv er tom, stopper føreren."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetrisk baneskift"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Entleeren wenn über:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Entleeren wenn über:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants Ablader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Giants Ablader benutzen:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Abladestation:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Geräteversatz horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Geräteversatz vertikal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Geräteversatz vertikal"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Entleeren wenn über:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Siliermittel überwachen."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Wenn aktiv und das Siliermittel leer ist, wird der Fahrer gestoppt."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetrischer Bahnenwechsel"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -51,8 +51,8 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Abtanken ab:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Abtanken ab:"/>
+    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Entleeren wenn über:"/>
+    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Entleeren wenn über:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants Ablader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Giants Ablader benutzen:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Abladestation:"/>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -51,8 +51,8 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
+    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Empty when over:"/>
+    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Empty when over:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Desp. Herramienta Izq/Der"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Desp. Herramienta Del/Tra"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Desp. Herramienta Del/Tra"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Comprobar Aditivo de Ensilaje."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Si está activo y el Aditivo de Ensilaje está vacío, el conductor se detendrá."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Cambio a carril simétrico"/>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Décalage horizontal de l'outil."/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Décalage vertical de l'outil"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Décalage vertical de l'outil."/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Arrêt si additif d'ensilage vide"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Le conducteur s'arrêtera si la réserve d'additif d'ensilage est vide."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Changement de ligne symétrique"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Szerszámeltolás balra/jobbra"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Szerszámeltolás hosszirányban"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Szerszámeltolás előre/hátra"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Szilázsadalék ellenőrzés"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Álljon meg ha a szilázsadalék-tartály üres"/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Szimmetrikus sávváltás"/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Soglia piena:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Soglia piena:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="scaricatore Giants:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Usa scaricatore giants:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Stazione di scarico:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Correzione oriz."/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Correzione vert."/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Correzione vert."/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Controllare l'additivo per insilato."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Se attivo, e l'additivo per insilato è vuoto, il conducente si fermerà."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Cambio di corsia simmetrico"/>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="作業機の位置を水平方向にオフセットします"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="ツールオフセット（垂直）"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="作業機の位置を垂直方向にオフセットします"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="対称レーン切り替え"/>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Werktuig horizontale offset"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Werktuig verticale offset"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Werktuig verticale offset"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetrische rijstrookwisseling"/>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Przesunięcie horyzontalne (poziome) dla narzędzi."/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Przes. pionowe dla narzędzi"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Przesunięcie wertykalne (pionowe) dla narzędzi."/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Sprawdź dodatek do kiszenia"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Jeśli aktywne i dodatek do zakiszania jest pusty, kierowca się zatrzyma."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symetryczna zmiana ścieżki"/>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Deslocamento da ferramenta horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Deslocamento da ferramenta vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Deslocamento da ferramenta vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifique se há aditivo de silagem."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Se o aditivo ativo e de silagem estiver vazio, o motorista irá parar."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Mudança de faixa simétrica"/>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Порог заполнения:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Порог заполнения:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Разгружающий Giants:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Использовать разгружающего giants:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Станция разгрузки:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Поперечное смещение инструмента."/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Продольное смещение"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Продольное смещение инструмента."/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Контроль силосной добавки."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Если активная и силовая добавка закончилась, водитель остановится."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Симметричная смена полосы движения"/>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Redskapsskjutning horisontellt"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Redskapsskjutning vertikalt"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Redskapsskjutning vertikalt"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrollerar om där finns ensilage tillsatts."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="Om aktivt och ensilage tillsattsen är tom, så stoppas föraren."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetrisk linjebyte"/>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -51,8 +51,6 @@
     <!---->
     <!--AI combine unloader job parameters-->
     <!---->
-    <text name="CP_combineUnloaderJobParameters_subTitle_fullThreshold" text="Full threshold:"/>
-    <text name="CP_combineUnloaderJobParameters_fullThreshold_title" text="Full threshold:"/>
     <text name="CP_combineUnloaderJobParameters_subTitle_giantsUnloader" text="Giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_useGiantsUnload_title" text="Use giants unloader:"/>
     <text name="CP_combineUnloaderJobParameters_unloadingStation_title" text="Unloading station:"/>
@@ -114,6 +112,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
+    <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_tooltip" text="If active and silage additive is emtpy, the driver will stop."/>
     <text name="CP_vehicle_setting_symmetricLaneChange_title" text="Symmetric lane change"/>


### PR DESCRIPTION
Attempt to unload trailers when fill level is over the threshold, instead of waiting for a combine to call.