### PR TITLE
Turn fix for vehicles with reverser node

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -106,6 +106,13 @@ You can define the following custom settings:
              turnRadius="5"
              useVehicleSizeForMarkers="true"
     />
+    
+    <!--\vehicles\grimme-->
+    <Vehicle name="ventor4150.xml"
+             raiseLate = "true"
+             lowerEarly = "true"
+    />
+
     <!-- Implements -->
 
     <!--\vehicles\Bergmann-->

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -149,28 +149,21 @@ function AIUtil.getArticulatedAxisVehicleReverserNode(vehicle)
 end
 
 -- Find the node to use by the PPC when driving in reverse
-function AIUtil.getReverserNode(vehicle)
+function AIUtil.getReverserNode(vehicle, reversingImplement)
 	local reverserNode, debugText
 	-- if there's a reverser node on the tool, use that
-	local reverserDirectionNode = AIVehicleUtil.getAIToolReverserDirectionNode(vehicle)
-	local reversingWheeledWorkTool = AIUtil.getFirstReversingImplementWithWheels(vehicle)
-	if reverserDirectionNode then
-		reverserNode = reverserDirectionNode
-		debugText = 'implement reverse (Giants)'
-	elseif reversingWheeledWorkTool and reversingWheeledWorkTool.steeringAxleNode then
-		reverserNode = reversingWheeledWorkTool.steeringAxleNode
-		debugText = 'implement reverse (Courseplay)'
-	elseif vehicle.spec_articulatedAxis ~= nil then
+	reversingImplement = reversingImplement and reversingImplement or AIUtil.getFirstReversingImplementWithWheels(vehicle)
+	if reversingImplement and reversingImplement.steeringAxleNode then
+		reverserNode, debugText = reversingImplement.steeringAxleNode, 'implement steering axle node'
+	end
+	if not reverserNode then
+		reverserNode, debugText = AIVehicleUtil.getAIToolReverserDirectionNode(vehicle), 'AIToolReverserDirectionNode'
+	end
+	if not reverserNode then
+		reverserNode, debugText = vehicle:getAIReverserNode(), 'AIReverserNode'
+	end
+	if not reverserNode and vehicle.spec_articulatedAxis ~= nil then
 		reverserNode, debugText = AIUtil.getArticulatedAxisVehicleReverserNode(vehicle)
-	else
-		-- otherwise see if the vehicle has a reverser node
-		if vehicle.getAIVehicleReverserNode then
-			reverserDirectionNode = vehicle:getAIVehicleReverserNode()
-			if reverserDirectionNode then
-				reverserNode = reverserDirectionNode
-				debugText = 'vehicle reverse'
-			end
-		end
 	end
 	return reverserNode, debugText
 end

--- a/scripts/ai/PurePursuitController.lua
+++ b/scripts/ai/PurePursuitController.lua
@@ -227,18 +227,7 @@ function PurePursuitController:switchControlledNode()
 		if not self.reversingImplement then
 			self.reversingImplement = AIUtil.getFirstReversingImplementWithWheels(self.vehicle)
 		end
-		if self.reversingImplement and self.reversingImplement.steeringAxleNode then
-			reverserNode, debugText = self.reversingImplement.steeringAxleNode, 'implement steering axle node'
-		end
-		if not reverserNode then
-			reverserNode, debugText = AIVehicleUtil.getAIToolReverserDirectionNode(self.vehicle), 'AIToolReverserDirectionNode'
-		end
-		if not reverserNode then
-			reverserNode, debugText = self.vehicle:getAIReverserNode(), 'AIReverserNode'
-		end
-		if not reverserNode and self.vehicle.spec_articulatedAxis ~= nil then
-			reverserNode, debugText = AIUtil.getArticulatedAxisVehicleReverserNode(self.vehicle)
-		end
+		reverserNode, debugText = AIUtil.getReverserNode(self.vehicle, self.reversingImplement)
 		if reverserNode then
 			self:setControlledNode(reverserNode)
 		else


### PR DESCRIPTION
Fixed AIUtil.getReverserNode() and moveCourseBack() for the case when there is no room on the field to make the turn without backing up first.

Some vehicles have a reverser node which we use as a reference when driving backwards, the reverse portion of the turn course must begin behind this node in that case.