### PR TITLE
Combine unloader

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -115,11 +115,6 @@ You can define the following custom settings:
 
     <!-- Implements -->
 
-    <!--\vehicles\Bergmann-->
-    <Vehicle name="rrw500.xml"
-             turnRadius = "10"
-    />
-
     <!--\vehicles\johndeer-->
     <Vehicle name="planter1775NT.xml"
              turnRadius = "12"
@@ -333,13 +328,6 @@ You can define the following custom settings:
     />
 
     <!--Implements-->
-    <!--Mod: Kinze Wagon Pack-->
-    <Vehicle name="wagon851.xml"
-             turnRadius="10"
-    />
-    <Vehicle name="wagon1051.xml"
-             turnRadius="10"
-    />
     <!--Mod: Gregoire Besson SPSL9 -->
     <Vehicle name="spsl9.xml"
              toolOffsetX="2.1"

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -65,6 +65,9 @@ AIDriveStrategyUnloadCombine.proximitySensorRange = 15
 AIDriveStrategyUnloadCombine.maxDirectionDifferenceDeg = 35 -- under this angle the unloader considers itself aligned with the combine
 -- Add a short straight section to align with the combine's course in case it is late for the rendezvous
 AIDriveStrategyUnloadCombine.driveToCombineCourseExtensionLength = 10
+-- Auger wagons don't usually have a proper turn radius configured which causes problems when we
+-- are calculating the path to a trailer when unloading. Use this as a minimum turn radius.
+AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon = 10
 
 -- Developer hack: to check the class of an object one should use the is_a() defined in CpObject.lua.
 -- However, when we reload classes on the fly during the development, the is_a() calls in other modules still
@@ -145,6 +148,11 @@ end
 
 function AIDriveStrategyUnloadCombine:setAIVehicle(vehicle, jobParameters)
     AIDriveStrategyUnloadCombine:superClass().setAIVehicle(self, vehicle)
+    if self.augerWagon and self.turningRadius < AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon then
+        self:debug('Auger wagon turn radius %.1f is too small, setting it to %.1f', self.turningRadius,
+                AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon)
+        self.turningRadius = AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon
+    end
     self.reverser = AIReverseDriver(self.vehicle, self.ppc)
     self.proximityController = ProximityController(self.vehicle, self:getProximitySensorWidth())
     self.proximityController:registerIsSlowdownEnabledCallback(self, AIDriveStrategyUnloadCombine.isProximitySpeedControlEnabled)

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -65,9 +65,6 @@ AIDriveStrategyUnloadCombine.proximitySensorRange = 15
 AIDriveStrategyUnloadCombine.maxDirectionDifferenceDeg = 35 -- under this angle the unloader considers itself aligned with the combine
 -- Add a short straight section to align with the combine's course in case it is late for the rendezvous
 AIDriveStrategyUnloadCombine.driveToCombineCourseExtensionLength = 10
--- Auger wagons don't usually have a proper turn radius configured which causes problems when we
--- are calculating the path to a trailer when unloading. Use this as a minimum turn radius.
-AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon = 10
 
 -- Developer hack: to check the class of an object one should use the is_a() defined in CpObject.lua.
 -- However, when we reload classes on the fly during the development, the is_a() calls in other modules still
@@ -148,11 +145,6 @@ end
 
 function AIDriveStrategyUnloadCombine:setAIVehicle(vehicle, jobParameters)
     AIDriveStrategyUnloadCombine:superClass().setAIVehicle(self, vehicle)
-    if self.augerWagon and self.turningRadius < AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon then
-        self:debug('Auger wagon turn radius %.1f is too small, setting it to %.1f', self.turningRadius,
-                AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon)
-        self.turningRadius = AIDriveStrategyUnloadCombine.minimumTurningRadiusWithAugerWagon
-    end
     self.reverser = AIReverseDriver(self.vehicle, self.ppc)
     self.proximityController = ProximityController(self.vehicle, self:getProximitySensorWidth())
     self.proximityController:registerIsSlowdownEnabledCallback(self, AIDriveStrategyUnloadCombine.isProximitySpeedControlEnabled)

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -204,9 +204,18 @@ function AIUtil.getTurningRadius(vehicle)
 		end
 		if turnRadius == 0 then
 			if AIUtil.isImplementTowed(vehicle, implement.object) then
-				turnRadius = 6
-				CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  %s: no Giants turn radius, towed implement, we use a default %.1f',
+				if AIUtil.hasImplementWithSpecialization(vehicle, Trailer) and
+						AIUtil.hasImplementWithSpecialization(vehicle, Pipe) then
+					-- Auger wagons don't usually have a proper turn radius configured which causes problems when we
+					-- are calculating the path to a trailer when unloading. Use this as a minimum turn radius.
+					turnRadius = 10
+                    CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  %s: no Giants turn radius, auger wagon, we use a default %.1f',
+                            implement.object:getName(), turnRadius)
+				else
+				    turnRadius = 6
+				    CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  %s: no Giants turn radius, towed implement, we use a default %.1f',
 						implement.object:getName(), turnRadius)
+				end
 			else
 				CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '  %s: no Giants turn radius, not towed, do not use turn radius',
 					implement.object:getName())
@@ -411,14 +420,14 @@ end
 --- This can include the rootVehicle and implements
 --- that are not directly attached to the rootVehicle.
 ---@param vehicle Vehicle
----@param specialization table 
+---@param specialization table
 ---@param specializationReference string alternative for mod specializations, as their object is not accessible by us.
 ---@return table all found vehicles/implements
 ---@return boolean at least one vehicle/implement was found
 function AIUtil.getAllChildVehiclesWithSpecialization(vehicle, specialization, specializationReference)
 	local validVehicles = {}
-	for _, childVehicle in pairs(vehicle:getChildVehicles()) do 
-		if specializationReference and childVehicle[specializationReference] then 
+	for _, childVehicle in pairs(vehicle:getChildVehicles()) do
+		if specializationReference and childVehicle[specializationReference] then
 			table.insert(validVehicles, childVehicle)
 		end
 		if specialization and SpecializationUtil.hasSpecialization(specialization, childVehicle.specializations) then
@@ -513,30 +522,30 @@ end
 --- Is a sugarcane trailer attached ?
 ---@param vehicle table
 function AIUtil.hasSugarCaneTrailer(vehicle)
-	if vehicle.spec_shovel and vehicle.spec_trailer then 
+	if vehicle.spec_shovel and vehicle.spec_trailer then
 		return true
 	end
 	for _, implement in pairs(AIUtil.getAllAttachedImplements(vehicle)) do
 		local object = implement.object
-		if object.spec_shovel and object.spec_trailer then 
+		if object.spec_shovel and object.spec_trailer then
 			return true
 		end
 	end
 end
 
 --- Are there any trailer under the pipe ?
----@param pipe table 
+---@param pipe table
 ---@param shouldTrailerBeStandingStill boolean
 function AIUtil.isTrailerUnderPipe(pipe, shouldTrailerBeStandingStill)
 	if not pipe then return end
 	for trailer, value in pairs(pipe.objectsInTriggers) do
 		if value > 0 then
-			if shouldTrailerBeStandingStill then 
+			if shouldTrailerBeStandingStill then
 				local rootVehicle = trailer:getRootVehicle()
-				if rootVehicle then 
-					if AIUtil.isStopped(rootVehicle) then 
+				if rootVehicle then
+					if AIUtil.isStopped(rootVehicle) then
 						return true
-					else 
+					else
 						return false
 					end
 				end
@@ -556,10 +565,10 @@ function AIUtil.getVehicleAndImplementsTotalLength(vehicle)
 		end
 	end
 	return totalLength
-end 
+end
 
 function AIUtil.getShieldWorkWidth(object,logPrefix)
-	if object.spec_leveler then 
+	if object.spec_leveler then
 		local width = object.spec_leveler.nodes[1].maxDropWidth * 2
 		CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, object, '%s%s: Is a shield with work width: %.1f', logPrefix, nameNum(object), width)
 		return width

--- a/scripts/ai/ImplementUtil.lua
+++ b/scripts/ai/ImplementUtil.lua
@@ -389,7 +389,6 @@ function ImplementUtil.setPipeAttributes(object, implementWithPipe)
     end
     object.pipe = implementWithPipe.spec_pipe
     object.objectWithPipe = implementWithPipe
-    local referenceVehicle = implementWithPipe.rootVehicle 
     if object.pipe then
         -- check the pipe length:
         -- unfold everything, open the pipe, check the side offset, then close pipe, fold everything back (if it was folded)
@@ -412,9 +411,9 @@ function ImplementUtil.setPipeAttributes(object, implementWithPipe)
         -- use combine so attached harvesters have the offset relative to the harvester's root node
         -- (and thus, does not depend on the angle between the tractor and the harvester)
         object.pipeOffsetX, _, object.pipeOffsetZ = localToLocal(dischargeNode.node,
-                (referenceVehicle.getAIDirectionNode and referenceVehicle:getAIDirectionNode()) or referenceVehicle.rootNode, 0, 0, 0)
+                (implementWithPipe.getAIDirectionNode and implementWithPipe:getAIDirectionNode()) or implementWithPipe.rootNode, 0, 0, 0)
         object.pipeOnLeftSide = object.pipeOffsetX >= 0
-        CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, referenceVehicle, 'Pipe offset: x = %.1f, z = %.1f, on left side %s',
+        CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, implementWithPipe, 'Pipe offset: x = %.1f, z = %.1f, on left side %s',
                 object.pipeOffsetX, object.pipeOffsetZ, tostring(object.pipeOnLeftSide))
         if wasClosed then
             if object.pipe.animation.name then
@@ -426,6 +425,7 @@ function ImplementUtil.setPipeAttributes(object, implementWithPipe)
                 object.objectWithPipe:updatePipeNodes(999999, nil)
             end
         end
+        local referenceVehicle = implementWithPipe.rootVehicle
         if wasFolded and referenceVehicle.spec_foldable then
             ImplementUtil.foldAfterGettingWidth(referenceVehicle)
             -- fold and unfold quickly, if we don't do that, the implement start event won't unfold the combine pipe

--- a/scripts/ai/ImplementUtil.lua
+++ b/scripts/ai/ImplementUtil.lua
@@ -408,10 +408,15 @@ function ImplementUtil.setPipeAttributes(object, implementWithPipe)
         end
         local dischargeIx = object.objectWithPipe:getPipeDischargeNodeIndex()
         local dischargeNode = object.objectWithPipe:getDischargeNodeByIndex(dischargeIx)
-        -- use combine so attached harvesters have the offset relative to the harvester's root node
+        -- for the side (X) offset, use combine so attached harvesters have the offset relative to the harvester's root node
         -- (and thus, does not depend on the angle between the tractor and the harvester)
-        object.pipeOffsetX, _, object.pipeOffsetZ = localToLocal(dischargeNode.node,
+        object.pipeOffsetX, _, _ = localToLocal(dischargeNode.node,
                 (implementWithPipe.getAIDirectionNode and implementWithPipe:getAIDirectionNode()) or implementWithPipe.rootNode, 0, 0, 0)
+        local referenceVehicle = implementWithPipe.rootVehicle
+        -- for the Z offset, we want the root vehicle, the offset for auger wagons and towed harvesters
+        -- should be relative to the tractor
+        _, _, object.pipeOffsetZ = localToLocal(dischargeNode.node,
+                (referenceVehicle.getAIDirectionNode and referenceVehicle:getAIDirectionNode()) or referenceVehicle.rootNode, 0, 0, 0)
         object.pipeOnLeftSide = object.pipeOffsetX >= 0
         CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, implementWithPipe, 'Pipe offset: x = %.1f, z = %.1f, on left side %s',
                 object.pipeOffsetX, object.pipeOffsetZ, tostring(object.pipeOnLeftSide))
@@ -425,7 +430,6 @@ function ImplementUtil.setPipeAttributes(object, implementWithPipe)
                 object.objectWithPipe:updatePipeNodes(999999, nil)
             end
         end
-        local referenceVehicle = implementWithPipe.rootVehicle
         if wasFolded and referenceVehicle.spec_foldable then
             ImplementUtil.foldAfterGettingWidth(referenceVehicle)
             -- fold and unfold quickly, if we don't do that, the implement start event won't unfold the combine pipe

--- a/scripts/ai/SelfUnloadHelper.lua
+++ b/scripts/ai/SelfUnloadHelper.lua
@@ -117,7 +117,7 @@ function SelfUnloadHelper:getTargetParameters(fieldPolygon, myVehicle, fillType,
     -- this should put the pipe's end 1.1 m from the trailer's edge towards the middle. We are not aiming for
     -- the centerline of the trailer to avoid bumping into very wide trailers, we don't want to get closer
     -- than what is absolutely necessary.
-    local offsetX = math.abs(objectWithPipeAttributes.pipeOffsetX) + trailerWidth / 2 - 1.1
+    local offsetX = math.abs(objectWithPipeAttributes.pipeOffsetX) + trailerWidth / 2 - 1.6
     offsetX = objectWithPipeAttributes.pipeOnLeftSide and -offsetX or offsetX
     -- arrive near the trailer alignLength meters behind the target, from there, continue straight a bit
     local _, steeringLength = AIUtil.getSteeringParameters(myVehicle)


### PR DESCRIPTION
- enforce a minimum turn radius for auger wagons, as they seem to have no configured one, which resulted in very tight turns calculated by the pathfinder and unloaders bumping into trailers
- offset calculation for auger wagons fixed, was incorrectly using the tractor as a reference point which leads to different offset depending on the angle between the trailer and the tractor