### PR TITLE
Issue 2001, 2006 and 2007

### DIFF
--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -98,7 +98,7 @@
 	</SettingSubTitle>
 	
 	<SettingSubTitle title="multitool" isVisible="hasMultiToolCourse">
-		<!--Symetric Langechange-->
+		<!--Symmetric Lane Change-->
 		<Setting classType="AIParameterBooleanSetting" name="symmetricLaneChange"/>
 		<!--Convoy Distance-->
 		<Setting classType="AIParameterSettingList" name="convoyDistance" min="40" max="400" default ="75" unit="2" isExpertModeOnly="true"/>

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -808,7 +808,7 @@ function AIDriveStrategyCombineCourse:callUnloaderWhenNeeded()
                 -- do not call too early (like minutes before we get there), only when it needs at least as
                 -- much time to get there as the combine (-5 seconds)
                 if bestUnloader:getCpDriveStrategy():call(self.vehicle,
-                        self.course:getWaypoint(self.unloaderRendezvousWaypointIx)) then
+                        self.course:getWaypoint(tentativeRendezvousWaypointIx)) then
                     self.unloaderToRendezvous:set(bestUnloader, 1000 * (bestEte + 30))
                     self.unloaderRendezvousWaypointIx = tentativeRendezvousWaypointIx
                     self:debug('callUnloaderWhenNeeded: harvesting, unloader accepted rendezvous at waypoint %d', self.unloaderRendezvousWaypointIx)

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -223,13 +223,13 @@ function AIDriveStrategyCombineCourse:getDriveData(dt, vX, vY, vZ)
     elseif self.state == self.states.UNLOADING_ON_FIELD then
         -- Unloading
         self:driveUnloadOnField()
+        self:callUnloaderWhenNeeded()
     end
     if self:isTurning() and not self:isTurningOnHeadland() then
         if self:shouldHoldInTurnManeuver() then
             self:setMaxSpeed(0)
         end
     end
-    self:callUnloaderWhenNeeded()
     return AIDriveStrategyCombineCourse.superClass().getDriveData(self, dt, vX, vY, vZ)
 end
 
@@ -424,6 +424,7 @@ function AIDriveStrategyCombineCourse:onWaypointPassed(ix, course)
 
     if self.state == self.states.WORKING then
         self:estimateDistanceUntilFull(ix)
+        self:callUnloaderWhenNeeded()
     end
 
     if self.state == self.states.UNLOADING_ON_FIELD and

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -809,11 +809,11 @@ function AIDriveStrategyCombineCourse:callUnloaderWhenNeeded()
                 -- much time to get there as the combine (-5 seconds)
                 if bestUnloader:getCpDriveStrategy():call(self.vehicle,
                         self.course:getWaypoint(self.unloaderRendezvousWaypointIx)) then
-                    self:debug('callUnloaderWhenNeeded: harvesting, unloader accepted rendezvous at waypoint %d', self.unloaderRendezvousWaypointIx)
                     self.unloaderToRendezvous:set(bestUnloader, 1000 * (bestEte + 30))
                     self.unloaderRendezvousWaypointIx = tentativeRendezvousWaypointIx
+                    self:debug('callUnloaderWhenNeeded: harvesting, unloader accepted rendezvous at waypoint %d', self.unloaderRendezvousWaypointIx)
                 else
-                    self:debug('callUnloaderWhenNeeded: harvesting, unloader rejected rendezvous at waypoint %d', self.unloaderRendezvousWaypointIx)
+                    self:debug('callUnloaderWhenNeeded: harvesting, unloader rejected rendezvous at waypoint %d', tentativeRendezvousWaypointIx)
                 end
             end
         end

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -623,7 +623,7 @@ function AIDriveStrategyUnloadCombine:startUnloadingTrailers()
         if self:startSelfUnload() then
             self:debug('Trailer to unload to found, attempting self unload now')
         else
-            self:debug('No trailer for self unload found but not full, keep waiting')
+            self:debug('No trailer for self unload found, keep waiting')
             self:startWaitingForSomethingToDo()
         end
     else

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -829,7 +829,7 @@ function AIDriveStrategyUnloadCombine:call(combine, waypoint)
     if waypoint then
         -- combine set up a rendezvous waypoint for us, go there
         local xOffset, zOffset = self:getPipeOffset(combine)
-        if self:isPathfindingNeeded(self.vehicle, self.rendezvousWaypoint, xOffset, zOffset, 25) then
+        if self:isPathfindingNeeded(self.vehicle, waypoint, xOffset, zOffset, 25) then
             self.rendezvousWaypoint = waypoint
             self.combineToUnload = combine
             self:setNewState(self.states.WAITING_FOR_PATHFINDER)

--- a/scripts/ai/SelfUnloadHelper.lua
+++ b/scripts/ai/SelfUnloadHelper.lua
@@ -65,8 +65,8 @@ function SelfUnloadHelper:findBestTrailer(fieldPolygon, myVehicle, fillType, pip
     if bestTrailer then
         fillRootNode = bestTrailer:getFillUnitExactFillRootNode(bestFillUnitIndex)
         CpUtil.debugVehicle(self.debugChannel, myVehicle,
-                'Best trailer is %s at %.1f meters, free capacity %d, root node %s',
-                bestTrailer:getName(), minDistance, maxCapacity, tostring(fillRootNode))
+                'Best trailer is %s at %.1f meters, free capacity %d, fill node %s',
+                bestTrailer:getName(), minDistance, maxCapacity, bestFillUnitIndex)
         local bestFillNode = self:findBestFillNode(myVehicle, fillRootNode, pipeOffsetX)
         return bestTrailer, bestFillNode
     else

--- a/scripts/ai/SelfUnloadHelper.lua
+++ b/scripts/ai/SelfUnloadHelper.lua
@@ -125,7 +125,7 @@ function SelfUnloadHelper:getTargetParameters(fieldPolygon, myVehicle, fillType,
     CpUtil.debugVehicle(CpDebug.DBG_FIELDWORK, myVehicle,
             'Trailer length: %.1f, width: %.1f, dZ: %.1f, align length %.1f, my length: %.1f, steering length %.1f, offsetX %.1f',
             trailerLength, trailerWidth, dZ, alignLength, myVehicle.size.length, steeringLength, offsetX)
-    return targetNode, alignLength, offsetX
+    return targetNode, alignLength, offsetX, bestTrailer
 end
 
 --- Check if this trailer is driven by AutoDrive and is really ready to be loaded. There may be

--- a/scripts/ai/controllers/PipeController.lua
+++ b/scripts/ai/controllers/PipeController.lua
@@ -56,6 +56,10 @@ function PipeController:isPipeMoving()
     return self:needToOpenPipe() and self.pipeSpec.currentState == PipeController.PIPE_STATE_MOVING
 end
 
+function PipeController:isPipeOpen()
+    return self:needToOpenPipe() and self.pipeSpec.currentState == PipeController.PIPE_STATE_OPEN
+end
+
 function PipeController:getFillType()
     local dischargeNode = self.implement:getDischargeNodeByIndex(self.implement:getPipeDischargeNodeIndex())
     if dischargeNode then


### PR DESCRIPTION
    - use the discharge node/target node distance for a
    more accurate pipe positioning, auger wagon pipe should
    not overshoot the target anymore, or if it does, it'll
    back up a bit
    - if we can't discharge anymore into a trailer but has
    more than 10% fruit, it'll look for another trailer,
    or another fill target of the same trailer. This
    should improve how long trailers with multiple fill
    nodes are handled
    - once done with unloading, move ahead a bit so the
    pathfinder has a clear view when it needs to drive
    to the combine

#2001 #2006 #2007
