### PR TITLE
Make AD always start at the first WP or last WP.

### DIFF
--- a/scripts/specializations/CpAIFieldWorker.lua
+++ b/scripts/specializations/CpAIFieldWorker.lua
@@ -234,12 +234,12 @@ function CpAIFieldWorker:onCpADStartedByPlayer()
     local spec = self.spec_cpAIFieldWorker
     --- Applies the lane offset set in the hud, so ad can start with the correct one.
     spec.cpJobStartAtLastWp:getCpJobParameters().laneOffset:setValue(self:getCpLaneOffsetSetting():getValue())
-    --spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(self:getCpStartingPointSetting():getValue())
+    spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(CpJobParameters.START_AT_LAST_POINT)
 end
 
 function CpAIFieldWorker:onCpADRestarted()
     local spec = self.spec_cpAIFieldWorker
-    --spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(CpJobParameters.START_AT_LAST_POINT)
+    spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(CpJobParameters.START_AT_LAST_POINT)
 end
 
 --- Event listener called, when an implement is full.

--- a/scripts/specializations/CpAIFieldWorker.lua
+++ b/scripts/specializations/CpAIFieldWorker.lua
@@ -234,12 +234,12 @@ function CpAIFieldWorker:onCpADStartedByPlayer()
     local spec = self.spec_cpAIFieldWorker
     --- Applies the lane offset set in the hud, so ad can start with the correct one.
     spec.cpJobStartAtLastWp:getCpJobParameters().laneOffset:setValue(self:getCpLaneOffsetSetting():getValue())
-    spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(self:getCpStartingPointSetting():getValue())
+    --spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(self:getCpStartingPointSetting():getValue())
 end
 
 function CpAIFieldWorker:onCpADRestarted()
     local spec = self.spec_cpAIFieldWorker
-    spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(CpJobParameters.START_AT_LAST_POINT)
+    --spec.cpJobStartAtLastWp:getCpJobParameters().startAt:setValue(CpJobParameters.START_AT_LAST_POINT)
 end
 
 --- Event listener called, when an implement is full.


### PR DESCRIPTION
This needs Mulitplayer tests, as I am not sure, if something might break.
- Test if the laneoffset is set correctly for multitool.
- Test if the starting point is correcty
#2012 #1994