### PR TITLE
Better headland selection for turns

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -80,6 +80,10 @@ function Course:setVehicle(vehicle)
 	self.vehicle = vehicle
 end
 
+function Course:getVehicle()
+	return self.vehicle
+end
+
 function Course:setFieldPolygon(polygon)
 	self.fieldPolygon = polygon
 end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -784,13 +784,13 @@ function CourseTurn:generatePathfinderTurn(useHeadland)
 	self.pathfindingStartedAt = g_currentMission.time
 	local done, path
 	local turnEndNode, startOffset, goalOffset = self.turnContext:getTurnEndNodeAndOffsets(self.steeringLength)
-
+	local _, backMarkerDistance = self.driveStrategy:getFrontAndBackMarkers()
 	self:debug('Pathfinder turn (useHeadland: %s): generate turn with hybrid A*, start offset %.1f, goal offset %.1f',
 			useHeadland, startOffset, goalOffset)
 	self.driveStrategy.pathfinder, done, path = PathfinderUtil.findPathForTurn(self.vehicle, startOffset, turnEndNode, goalOffset,
 			self.turningRadius, self.driveStrategy:getAllowReversePathfinding(),
 			useHeadland and self.fieldworkCourse or nil,
-			nil,
+			self.driveStrategy:getWorkWidth(), backMarkerDistance,
 			self.driveStrategy:isTurnOnFieldActive())
 	if done then
 		return self:onPathfindingDone(path)


### PR DESCRIPTION
When the vehicle drives on the headland to the
start of the next row (because it is far away and
we want to follow the contour of the field),
use the innermost possible headland instead of
always the outermost one.

#2037