### PR TITLE
Reverse driving fix

### DIFF
--- a/scripts/ai/AIReverseDriver.lua
+++ b/scripts/ai/AIReverseDriver.lua
@@ -32,7 +32,7 @@ function AIReverseDriver:init(vehicle, ppc)
 	-- the main implement (towed) or trailer we are controlling
 	self.reversingImplement = AIUtil.getFirstReversingImplementWithWheels(self.vehicle)
 	if self.reversingImplement then
-		self.steeringLength = AIUtil.getTowBarLength(self.reversingImplement)
+		self.steeringLength = AIUtil.getTowBarLength(self.vehicle)
 		self:setReversingProperties(self.reversingImplement)
 	else
 		self:debug('No towed implement found.')

--- a/scripts/ai/AIReverseDriver.lua
+++ b/scripts/ai/AIReverseDriver.lua
@@ -32,6 +32,7 @@ function AIReverseDriver:init(vehicle, ppc)
 	-- the main implement (towed) or trailer we are controlling
 	self.reversingImplement = AIUtil.getFirstReversingImplementWithWheels(self.vehicle)
 	if self.reversingImplement then
+		self.steeringLength = AIUtil.getTowBarLength(self.reversingImplement)
 		self:setReversingProperties(self.reversingImplement)
 	else
 		self:debug('No towed implement found.')
@@ -221,12 +222,11 @@ end
 --- different disturbances to calculate the controller's output, which in our case is just an angle the tractor
 --- needs to drive to, in the tractor's local coordinate system.)
 function AIReverseDriver:calculateHitchCorrectionAngle(crossTrackError, orientationError, curvatureError, currentHitchAngle)
-	local _, steeringLength = AIUtil.getSteeringParameters(self.vehicle)
 	-- the following constants must be tuned based on experiments.
 
 	-- base cross track error gain. 0.6-0.7 for longer implements, 0.5 for shorter ones, should be adjusted based on
 	-- the steering length
-	local kXeBase = -0.5 - steeringLength / 50
+	local kXeBase = -0.5 - self.steeringLength / 50
 	-- base orientation error gain
 	local kOeBase = 6
 	-- base curvature error gain. 0 for now, as currently we only drive straight reverse

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -244,16 +244,26 @@ end
 function AIUtil.getFirstReversingImplementWithWheels(vehicle)
 	-- since some weird things like Seed Bigbag are also vehicles, check this first
 	if not vehicle.getAttachedImplements then return nil end
+
 	-- Check all attached implements if we are a wheeled workTool behind the tractor
 	for _, imp in ipairs(vehicle:getAttachedImplements()) do
 		-- Check if the implement is behind the tractor
 		if AIUtil.isObjectAttachedOnTheBack(vehicle, imp.object) then
 			if ImplementUtil.isWheeledImplement(imp.object) then
+				CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, 'Implement %s has wheels', CpUtil.getName(imp.object))
 				-- If the implement is a wheeled workTool, then return the object
 				return imp.object
 			else
+				CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '%s has no wheels, check if anything attached to it',
+						CpUtil.getName(imp.object))
 				-- If the implement is not a wheeled workTool, then check if that implement have an attached wheeled workTool and return that.
-				return AIUtil.getFirstReversingImplementWithWheels(imp.object)
+				local nextAttachedImplement = AIUtil.getFirstReversingImplementWithWheels(imp.object)
+				if nextAttachedImplement then
+					return nextAttachedImplement
+				else
+					CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, '%s has nothing attached, see what else is attached to %s',
+							CpUtil.getName(imp.object), CpUtil.getName(vehicle))
+				end
 			end
 		end
 	end


### PR DESCRIPTION
If the first implement we checked on the back of
the tractor (root node behind tractor's node) had
nothing attached, we stopped looking and did not
find other implements.

For instance, the JD 7R had a Laforge weight attached underneath, 
we ignored all towed implements, which messed up the turn calculations.

#828 #1306 #2054