### PR TITLE
fix: turns on headlands when islands present

### DIFF
--- a/scripts/courseGenerator/geo.lua
+++ b/scripts/courseGenerator/geo.lua
@@ -854,9 +854,8 @@ function Polyline:tuck( iterator, s, minSmoothAngle, maxSmoothAngle )
 			-- vector from current point to mid point
 			local mx, my = midPNx - cp.x, midPNy - cp.y
 			-- move current point towards (or away from) the midpoint by the factor s
-			self[ i ] = { x=cp.x + mx * s, y=cp.y + my * s }
-		else
-			self[ i ] = cp
+			self[ i ].x = cp.x + mx * s
+			self[ i ].y = cp.y + my * s
 		end
 	end
 	self:calculateData()


### PR DESCRIPTION
Wide turns where the vehicle drives on one of the
headlands to the next row failed when the headland bypassed islands elsewhere because the headland
pass number property of some waypoints were lost
when smoothing the transition to the bypass
circle.

Fix smoothing adjust the waypoint coordinates only instead of creating a new waypoint.

#2163