### PR TITLE
Somewhat better headland turns for sugarcane harvesters

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1342,7 +1342,7 @@ function AIDriveStrategyCombineCourse:handleChopperPipe()
     local trailer = self.pipeController:getClosestObject()
     local dischargeNode = self.pipeController:getDischargeNode()
     local targetObject = self.pipeController:getDischargeObject()
-    self:debug('%s %s', dischargeNode, self:isAnyWorkAreaProcessing())
+    self:debugSparse('%s %s', dischargeNode, self:isAnyWorkAreaProcessing())
     if not self.waitingForTrailer and self:isAnyWorkAreaProcessing() and (targetObject == nil or trailer == nil) then
         self:debug('Chopper waiting for trailer, discharge node %s, target object %s, trailer %s',
                 tostring(dischargeNode), tostring(targetObject), tostring(trailer))

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -873,14 +873,17 @@ function CombinePocketHeadlandTurn:generatePocketHeadlandTurn(turnContext)
 	local offset = math.min(self.turningRadius + turnContext.frontMarkerDistance, self.workWidth)
 	local corner = turnContext:createCorner(self.vehicle, self.turningRadius)
 	local d = -self.workWidth / 2 + turnContext.frontMarkerDistance
-	local wp = corner:getPointAtDistanceFromCornerStart(d + 2)
-	table.insert(cornerWaypoints, wp)
-	-- drive forward up to the field edge
-	wp = corner:getPointAtDistanceFromCornerStart(d)
-	table.insert(cornerWaypoints, wp)
-	-- drive back to prepare for making a pocket
-	-- reverse back to set up for the headland after the corner
 	local reverseDistance = 2 * offset
+	local wp
+	if reverseDistance / 2 > d + 2 then
+		-- drive forward only if we aren't there yet
+		wp = corner:getPointAtDistanceFromCornerStart(d + 2)
+		table.insert(cornerWaypoints, wp)
+		-- drive forward up to the field edge
+		wp = corner:getPointAtDistanceFromCornerStart(d)
+		table.insert(cornerWaypoints, wp)
+	end
+	-- drive back to prepare for making a pocket
 	wp = corner:getPointAtDistanceFromCornerStart(reverseDistance / 2)
 	wp.rev = true
 	table.insert(cornerWaypoints, wp)


### PR DESCRIPTION
In general, for harvesters where the front marker distance is comparable to the working width.

#2165