### PR TITLE
Multitool unloader workaround

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -177,7 +177,7 @@ function Course:getWaypoint(ix)
 end
 
 function Course:getMultiTools()
-	return self.multiTools
+	return self.multiTools or 1
 end
 
 --- Is this a temporary course? Can be used to differentiate between recorded and dynamically generated courses


### PR DESCRIPTION
The pipe-in-fruit map created for multitools shows no fruit anywhere as it is based on the very wide
multitool course (wider than the pipe length)

Since we don't have a reliable pipe-in-fruit map
for multitool courses, use the current fruit status at the potential rendezvous waypoint instead.

#2292