### PR TITLE
fix: truck attached bale loaders

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -413,4 +413,12 @@ You can define the following custom settings:
             ignoreBaleCollisionForward = "true"
     />
 
+    <!--Mod: FS22_McCormack_Cotton_Trailer_Pack-->
+    <Vehicle name="cottonTagTrailer3000.xml"
+             baleCollectorOffset = "2.7"
+    />
+    <Vehicle name="cottonTagTrailer5000.xml"
+             baleCollectorOffset = "2.7"
+    />
+
 </VehicleConfigurations>

--- a/scripts/ai/ImplementUtil.lua
+++ b/scripts/ai/ImplementUtil.lua
@@ -109,13 +109,12 @@ function ImplementUtil.isWheeledImplement(implement)
         for _, jointType in ipairs(jointTypeList) do
             local index = AttacherJoints.jointTypeNameToInt[jointType]
             if index then
-                table.insert(allowedJointTypes, index, true)
+                allowedJointTypes[index] = true
             end
         end
     end
 
     local activeInputAttacherJoint = implement:getActiveInputAttacherJoint()
-
     if activeInputAttacherJoint and allowedJointTypes[activeInputAttacherJoint.jointType] and
             implement.spec_wheels and implement.spec_wheels.wheels and #implement.spec_wheels.wheels > 0 then
         -- Attempt to find the pivot node.


### PR DESCRIPTION
Fixed allowed joint type table initialization, so
now they are recognized as wheeled implements.

Thanks to @rgoe for the great analysis.

#2393 #2396