### PR TITLE
WIP Bunker silo driver fixes and improvements

### DIFF
--- a/Courseplay.lua
+++ b/Courseplay.lua
@@ -113,6 +113,7 @@ function Courseplay:deleteMap()
 	BufferedCourseDisplay.deleteBuffer()
 	g_signPrototypes:delete()
 	g_devHelper:delete()
+	Markers.delete()
 end
 
 function Courseplay:setupGui()

--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -309,11 +309,11 @@
 		</Translation>
 		<Translation name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title">
 			<Text language="de"><![CDATA[Stoppen bei 99% verdichtet]]></Text>
-			<Text language="en"><![CDATA[Stop with 99% compaction]]></Text>
+			<Text language="en"><![CDATA[Stop at 99% compaction]]></Text>
 		</Translation>
 		<Translation name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo">
 			<Text language="de"><![CDATA[Stoppen bei 99% verdichtet]]></Text>
-			<Text language="en"><![CDATA[Stop with 99% compaction]]></Text>
+			<Text language="en"><![CDATA[Stop at 99% compaction]]></Text>
 		</Translation>
 		<Translation name="CP_bunkerSilo_compactionPercentage">
 			<Text language="de"><![CDATA[Silo Verdichtung:]]></Text>

--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -307,6 +307,18 @@
 			<Text language="de"><![CDATA[bei Parkposition]]></Text>
 			<Text language="en"><![CDATA[at park position]]></Text>
 		</Translation>
+		<Translation name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title">
+			<Text language="de"><![CDATA[Stoppen bei 99% verdichtet]]></Text>
+			<Text language="en"><![CDATA[Stop with 99% compaction]]></Text>
+		</Translation>
+		<Translation name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo">
+			<Text language="de"><![CDATA[Stoppen bei 99% verdichtet]]></Text>
+			<Text language="en"><![CDATA[Stop with 99% compaction]]></Text>
+		</Translation>
+		<Translation name="CP_bunkerSilo_compactionPercentage">
+			<Text language="de"><![CDATA[Silo Verdichtung:]]></Text>
+			<Text language="en"><![CDATA[Silo compaction:]]></Text>
+		</Translation>		
 	</Category>
 	<Category name="AI silo lader worker job parameters">
 		<Translation name="CP_siloLoaderJobParameters_subTitle_loadPosition">

--- a/config/gamePadHud/BunkerSiloGamePadHudPage.xml
+++ b/config/gamePadHud/BunkerSiloGamePadHudPage.xml
@@ -9,4 +9,5 @@
 	<Setting type="vehicleSettings" name="bunkerSiloWorkWidth"/>
 	<Setting type="bunkerSiloJobParameters" name = "drivingForwardsIntoSilo" />
 	<Setting type="bunkerSiloJobParameters" name = "waitAtParkPosition" />
+	<Setting type="bunkerSiloJobParameters" name = "stopWithCompactedSilo" />
 </Settings>

--- a/config/jobParameters/BunkerSiloJobParameterSetup.xml
+++ b/config/jobParameters/BunkerSiloJobParameterSetup.xml
@@ -28,4 +28,7 @@
 			</Texts>
 		</Setting>
 	</SettingSubTitle>
+	<SettingSubTitle title="stopWithCompactedSilo">
+		<Setting classType="AIParameterBooleanSetting" name="stopWithCompactedSilo" defaultBool="false" isDisabled="isCpActive"/>
+	</SettingSubTitle>
 </Settings>

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -219,7 +219,7 @@ end
 ---@param x number
 ---@param z number
 ---@param yRotation number
----@param rootNode number
+---@param rootNode number|nil
 function CpUtil.createNode(name, x, z, yRotation, rootNode)
 	local node = createTransformGroup(name)
 	link(rootNode or g_currentMission.terrainRootNode, node)

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -238,9 +238,13 @@ function CpUtil.destroyNode(node)
 	end
 end
 
-function CpUtil.drawDebugNode(node, alignToGround, yOffset)
+---@param node number
+---@param alignToGround boolean|nil
+---@param yOffset number|nil
+---@param text string|nil
+function CpUtil.drawDebugNode(node, alignToGround, yOffset, text)
 	if node and entityExists(node) then
-		DebugUtil.drawDebugNode(node, getName(node), alignToGround, yOffset)
+		DebugUtil.drawDebugNode(node, text or getName(node), alignToGround, yOffset)
 	end
 end
 

--- a/scripts/ai/AIDriveStrategyBunkerSilo.lua
+++ b/scripts/ai/AIDriveStrategyBunkerSilo.lua
@@ -91,6 +91,7 @@ function AIDriveStrategyBunkerSilo:startWithoutCourse(jobParameters)
         return
     end
 
+    self.stopWithCompactedSilo = jobParameters.stopWithCompactedSilo:getValue()
     self.waitAtParkPosition = jobParameters.waitAtParkPosition:getValue()
     self:debug("Wait at park position: %s", tostring(jobParameters.waitAtParkPosition:getValue()))
     if self.leveler then 
@@ -105,18 +106,16 @@ function AIDriveStrategyBunkerSilo:startWithoutCourse(jobParameters)
     end
 
     --- Proximity sensor to detect the silo end wall.
-    self.siloEndDetectionMarker = self:getEndMarker()
     if self.drivingForwardsIntoSilo then
-        self.siloEndProximitySensor = SingleForwardLookingProximitySensorPack(self.vehicle, self.siloEndDetectionMarker, 
-                                                                        self.siloEndProximitySensorRange, 1)
+        self.siloEndProximitySensor = SingleForwardLookingProximitySensorPack(self.vehicle, self.frontMarkerNode, 
+                                                                    self.siloEndProximitySensorRange, 1)
     else
-        self.siloEndProximitySensor = SingleBackwardLookingProximitySensorPack(self.vehicle, self.siloEndDetectionMarker, 
-                                                                        self.siloEndProximitySensorRange, 1)
+        self.siloEndProximitySensor = SingleBackwardLookingProximitySensorPack(self.vehicle, self.backMarkerNode, 
+                                                                    self.siloEndProximitySensorRange, 1)
     end
 
-
     --- Setup the silo controller, that handles the driving conditions and coordinations.
-	self.siloController = self.silo:setupLevelerTarget(self.vehicle, self, self.drivingForwardsIntoSilo)
+	self.siloController = self.silo:setupLevelerTarget(self.vehicle, self)
 
     if self.silo:isVehicleInSilo(self.vehicle) then 
         self:startDrivingIntoSilo()
@@ -150,9 +149,9 @@ end
 function AIDriveStrategyBunkerSilo:setAllStaticParameters()
     AIDriveStrategyCourse.setAllStaticParameters(self)
     Markers.setMarkerNodes(self.vehicle)
-    local _
-    _, self.frontMarkerDistance = Markers.getFrontMarkerNode(self.vehicle)
-    _, self.backMarkerDistance = Markers.getBackMarkerNode(self.vehicle)
+
+    self.frontMarkerNode, self.backMarkerNode, self.frontMarkerDistance, self.backMarkerDistance = 
+        Markers.getMarkerNodesRelativeToDirectionNode(self.vehicle)
 
     self.proximityController:registerIgnoreObjectCallback(self, self.ignoreProximityObject)
 
@@ -178,6 +177,7 @@ function AIDriveStrategyBunkerSilo:setAllStaticParameters()
 end
 
 function AIDriveStrategyBunkerSilo:setSilo(silo)
+    ---@type CpBunkerSilo
 	self.silo = silo	
 end
 
@@ -254,6 +254,17 @@ function AIDriveStrategyBunkerSilo:getDriveData(dt, vX, vY, vZ)
     if self.vehicle:getIsAIPreparingToDrive() then 
         self:setMaxSpeed(0) --- Unfolding/folding
     end
+
+    if self.stopWithCompactedSilo and self.silo:getCompactionPercentage() >= 99 then 
+        self:debug("Stopping, as the silo is compacted.")
+        self.vehicle:stopCurrentAIJob(AIMessageSuccessFinishedJob.new())
+    end
+
+    if not self.silo:canBeFilled() then 
+        self:debug("Stopping, as the silo state is no longer filling.")
+        self.vehicle:stopCurrentAIJob(AIMessageSuccessFinishedJob.new())
+    end
+
     return gx, gz, moveForwards, self.maxSpeed, 100
 end
 
@@ -285,9 +296,9 @@ function AIDriveStrategyBunkerSilo:update(dt)
         if self.siloEndDetectionMarker ~= nil then
             DebugUtil.drawDebugNode(self.siloEndDetectionMarker, "siloEndDetectionMarker", false, 1)
         end
-        local frontMarkerNode, backMarkerNode = Markers.getMarkerNodes(self.vehicle)
-        DebugUtil.drawDebugNode(frontMarkerNode, "FrontMarker", false, 1)
-        DebugUtil.drawDebugNode(backMarkerNode, "BackMarker", false, 1)
+
+        DebugUtil.drawDebugNode(self.frontMarkerNode, "FrontMarker", false, 1)
+        DebugUtil.drawDebugNode(self.backMarkerNode, "BackMarker", false, 1)
         if self.parkNode then 
             DebugUtil.drawDebugNode(self.parkNode, "ParkNode", true, 3)
         end
@@ -305,11 +316,17 @@ function AIDriveStrategyBunkerSilo:drive()
     if self.state == self.states.DRIVING_INTO_SILO then
 
         local _, _, closestObject = self.siloEndProximitySensor:getClosestObjectDistanceAndRootVehicle()
-        local isEndReached, maxSpeed = self.siloController:isEndReached(self:getEndMarker(), self:getEndMarkerOffset())
-        if self.silo:isTheSameSilo(closestObject) or isEndReached then
-            self:debug("End wall detected or bunker silo end is reached.")
+        if self.silo:isTheSameSilo(closestObject) then
+            self:debug("End wall detected.")
             self:startDrivingOutOfSilo()
         end
+
+        local isEndReached, maxSpeed = self.siloController:isEndReached(self:getEndMarker(), self:getEndMarkerOffset())
+        if isEndReached then
+            self:debug("Bunker silo end is reached.")
+            self:startDrivingOutOfSilo()
+        end
+
         self:setMaxSpeed(maxSpeed)
 
         if self:isDrivingToParkPositionAllowed() then
@@ -372,13 +389,13 @@ function AIDriveStrategyBunkerSilo:getTemporaryBackCourseLength()
 end
 
 function AIDriveStrategyBunkerSilo:getEndMarker()
-    local frontMarker, backMarker = Markers.getMarkerNodesRelativeToDirectionNode(self.vehicle)
-    return self:isDriveDirectionReverse() and backMarker or frontMarker
+  
+    return self:isDriveDirectionReverse() and self.backMarkerNode or self.frontMarkerNode
 end
 
 function AIDriveStrategyBunkerSilo:getEndMarkerOffset()
     --- While reverse driven, then the offset needs to be inverted, as end marker is rotated wrong.
-    return AIUtil.isReverseDriving(self.vehicle) and -self.endReachedOffset or self.endReachedOffset
+    return self.endReachedOffset--AIUtil.isReverseDriving(self.vehicle) and -self.endReachedOffset or self.endReachedOffset
 end
 
 --- Gets the work width.
@@ -387,7 +404,7 @@ function AIDriveStrategyBunkerSilo:getWorkWidth()
 end
 
 function AIDriveStrategyBunkerSilo:startTransitionToNextLane()
-    local course, firstWpIx = self:getDriveIntoSiloCourse()
+    local course, _ = self:getDriveIntoSiloCourse()
         
     local x, y, z = course:getWaypointPosition(1)
     local yRot = course:getWaypointYRotation(1)
@@ -398,7 +415,7 @@ function AIDriveStrategyBunkerSilo:startTransitionToNextLane()
         setRotation(self.turnNode, 0, yRot + math.pi, 0)
     end
 
-    local path = PathfinderUtil.findAnalyticPath(self:getReedsSheppSolver(), self.vehicle:getAIDirectionNode(), 0, self.turnNode,
+    local path = PathfinderUtil.findAnalyticPath(ReedsSheppSolver(), self.vehicle:getAIDirectionNode(), 0, self.turnNode,
     0, 0, self.turningRadius)
     if not path or #path == 0 then
         self:debug('Could not find ReedsShepp path, skipping turn!')
@@ -411,30 +428,6 @@ function AIDriveStrategyBunkerSilo:startTransitionToNextLane()
         self.state = self.states.DRIVING_TURN
         self:debug("Started driving turn to next lane.")
     end
-end
-
-function AIDriveStrategyBunkerSilo:getReedsSheppSolver()
-
-    local forwardToReversePathWords = {
-    --    ReedsShepp.PathWords.LfRbLb,
-    --    ReedsShepp.PathWords.RfLbRb,
-    --    ReedsShepp.PathWords.LfRfLb, 
-     --   ReedsShepp.PathWords.RfLfRb,
-        ReedsShepp.PathWords.LfRufLubRb,
-        --LbRubLufRf = {},
-        ReedsShepp.PathWords.RfLufRubLb,
-        --RbLubRufLf = {},
-    }
-    
-    local reverseToForwardPathWords = {
-        ReedsShepp.PathWords.LbRfLf,
-        ReedsShepp.PathWords.RbLfRf,
-        ReedsShepp.PathWords.LbRbLf,
-        ReedsShepp.PathWords.RbLbRf,
-    }
-    
-    local pathWords = self:isDriveDirectionReverse() and forwardToReversePathWords or ReedsShepp.PathWords
-    return ReedsSheppSolver()
 end
 
 --- Starts driving into the silo.
@@ -666,3 +659,7 @@ function AIDriveStrategyBunkerSilo:onPathfindingDoneToParkPosition(path)
     end
 end
 
+---@param status CpStatus
+function AIDriveStrategyBunkerSilo:updateCpStatus(status)
+    status:setLevelSiloStatus(self.silo:getCompactionPercentage())
+end

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -205,7 +205,7 @@ end
 ---@param class ImplementController
 ---@param spec table
 ---@param states table
----@param specReference string
+---@param specReference string|nil
 ---@return table last implement found.
 ---@return table last implement controller
 function AIDriveStrategyCourse:addImplementController(vehicle, class, spec, states, specReference)

--- a/scripts/ai/ProximityController.lua
+++ b/scripts/ai/ProximityController.lua
@@ -21,10 +21,11 @@ function ProximityController:init(vehicle, width)
     self.blockingVehicle = CpTemporaryObject(nil)
     self.ignoreObjectCallbackRegistrations = {}
     self:setState(self.states.NO_OBSTACLE, 'proximity controller initialized')
+    local frontMarker, backMarker = Markers.getMarkerNodesRelativeToDirectionNode(self.vehicle)
     self.forwardLookingProximitySensorPack = WideForwardLookingProximitySensorPack(
-            self.vehicle, Markers.getFrontMarkerNode(self.vehicle), self.sensorRange, 1, width)
+            self.vehicle, frontMarker, self.sensorRange, 1, width)
     self.backwardLookingProximitySensorPack = WideBackwardLookingProximitySensorPack(
-            self.vehicle, Markers.getBackMarkerNode(self.vehicle), self.sensorRange, 1, self.vehicle.size.width)
+            self.vehicle, backMarker, self.sensorRange, 1, self.vehicle.size.width)
 
     self.showBlockedByObjectMessageTimer = CpTemporaryObject(false)
 end

--- a/scripts/dev/DevHelper.lua
+++ b/scripts/dev/DevHelper.lua
@@ -257,6 +257,15 @@ function DevHelper:showAIMarkers()
             showAIMarkersOfObject(implement.object)
         end
     end
+
+    local frontMarker, backMarker = Markers.getMarkerNodes(self.vehicle)
+    CpUtil.drawDebugNode(frontMarker, false, 3)
+    CpUtil.drawDebugNode(backMarker, false, 3)
+
+    if self.vehicle:getAIDirectionNode() then 
+        CpUtil.drawDebugNode(self.vehicle:getAIDirectionNode(), false , 3, "AiDirectionNode")
+    end
+
 end
 
 -- make sure to recreate the global dev helper whenever this script is (re)loaded

--- a/scripts/gui/hud/CpBunkerSiloWorkerHudPage.lua
+++ b/scripts/gui/hud/CpBunkerSiloWorkerHudPage.lua
@@ -96,8 +96,7 @@ function CpBunkerSiloWorkerHudPageElement:updateContent(vehicle, status)
     else
         compactionText = status:getCompactionText()
     end
-    --g_i18n:getText("CP_bunkerSilo_compactionPercentage")
-    self.compactionPercentageBtn:setTextDetails("-", compactionText)
+    self.compactionPercentageBtn:setTextDetails(g_i18n:getText("CP_bunkerSilo_compactionPercentage"), compactionText)
     self.compactionPercentageBtn:setDisabled(stopWithCompactedSilo:getIsDisabled())
 end
 

--- a/scripts/gui/hud/CpBunkerSiloWorkerHudPage.lua
+++ b/scripts/gui/hud/CpBunkerSiloWorkerHudPage.lua
@@ -24,8 +24,8 @@ function CpBunkerSiloWorkerHudPageElement:setupElements(baseHud, vehicle, lines,
 	self.driveDirectionBtn:setCallback(callback, callback)             			
     
     --- Waiting at park position
-	local x, y = unpack(lines[2].left)
-	local xRight,_ = unpack(lines[2].right)
+	local x, y = unpack(lines[1].left)
+	local xRight,_ = unpack(lines[1].right)
 	self.waitAtBtn = CpHudTextSettingElement.new(self, x, y,
 										xRight, CpBaseHud.defaultFontSize)
 	local callback = {
@@ -36,7 +36,7 @@ function CpBunkerSiloWorkerHudPageElement:setupElements(baseHud, vehicle, lines,
 	self.waitAtBtn:setCallback(callback, callback)             				
 	
     --- Work width
-    self.workWidthBtn = baseHud:addLineTextButton(self, 3, CpBaseHud.defaultFontSize, 
+    self.workWidthBtn = baseHud:addLineTextButton(self, 2, CpBaseHud.defaultFontSize, 
                                                 vehicle:getCpSettings().bunkerSiloWorkWidth) 
 
     --- Goal button.
@@ -54,8 +54,8 @@ function CpBunkerSiloWorkerHudPageElement:setupElements(baseHud, vehicle, lines,
     end)
 
     --- Bunker silo compaction percentage
-    local x, y = unpack(lines[1].left)
-	local xRight,_ = unpack(lines[1].right)
+    local x, y = unpack(lines[3].left)
+	local xRight,_ = unpack(lines[3].right)
 	self.compactionPercentageBtn = CpHudTextSettingElement.new(self, x, y,
 										xRight, CpBaseHud.defaultFontSize)
 	local callback = {

--- a/scripts/gui/hud/CpBunkerSiloWorkerHudPage.lua
+++ b/scripts/gui/hud/CpBunkerSiloWorkerHudPage.lua
@@ -53,7 +53,17 @@ function CpBunkerSiloWorkerHudPageElement:setupElements(baseHud, vehicle, lines,
         baseHud:openCourseGeneratorGui(vehicle)
     end)
 
-    CpGuiUtil.addCopyCourseBtn(self, baseHud, vehicle, lines, wMargin, hMargin, 1)
+    --- Bunker silo compaction percentage
+    local x, y = unpack(lines[1].left)
+	local xRight,_ = unpack(lines[1].right)
+	self.compactionPercentageBtn = CpHudTextSettingElement.new(self, x, y,
+										xRight, CpBaseHud.defaultFontSize)
+	local callback = {
+		callbackStr = "onClickPrimary",
+		class =  vehicle:getCpBunkerSiloWorkerJobParameters().stopWithCompactedSilo,
+		func =   vehicle:getCpBunkerSiloWorkerJobParameters().stopWithCompactedSilo.setNextItem,
+	}
+	self.compactionPercentageBtn:setCallback(callback, callback)             				
 end
 
 function CpBunkerSiloWorkerHudPageElement:update(dt)
@@ -61,6 +71,8 @@ function CpBunkerSiloWorkerHudPageElement:update(dt)
 	
 end
 
+---@param vehicle table
+---@param status CpStatus
 function CpBunkerSiloWorkerHudPageElement:updateContent(vehicle, status)
    
 	local driveDirection = vehicle:getCpBunkerSiloWorkerJobParameters().drivingForwardsIntoSilo
@@ -77,7 +89,16 @@ function CpBunkerSiloWorkerHudPageElement:updateContent(vehicle, status)
     self.workWidthBtn:setTextDetails(workWidth:getTitle(), workWidth:getString())
     self.workWidthBtn:setVisible(workWidth:getIsVisible())
 
-    CpGuiUtil.updateCopyBtn(self, vehicle, status)
+    local compactionText 
+    local stopWithCompactedSilo = vehicle:getCpBunkerSiloWorkerJobParameters().stopWithCompactedSilo
+    if stopWithCompactedSilo:getValue() then
+        compactionText = string.format("%s/99%%", status:getCompactionText(true))
+    else
+        compactionText = status:getCompactionText()
+    end
+    --g_i18n:getText("CP_bunkerSilo_compactionPercentage")
+    self.compactionPercentageBtn:setTextDetails("-", compactionText)
+    self.compactionPercentageBtn:setDisabled(stopWithCompactedSilo:getIsDisabled())
 end
 
 function CpBunkerSiloWorkerHudPageElement:isStartingPointBtnDisabled(vehicle)

--- a/scripts/silo/BunkerSiloVehicleController.lua
+++ b/scripts/silo/BunkerSiloVehicleController.lua
@@ -19,18 +19,56 @@ function CpBunkerSiloVehicleController:init(silo, vehicle, driveStrategy, direct
 	local _, _, dhz = worldToLocal(directionNode, hx, 0, hz)
 
 	if dsz > 0 and dhz > 0 then 
+		self:debug("Start distance: dsz: %.2f, dhz: %.2f", dsz, dhz)
 		--- In front of the silo
+		--[[
+				hx
+			|	|
+			wx	sx
+			  
+			  ^
+			  |
+		]]
+		
+
 		if dsz > dhz then 
+			self:debug("Silo needs to be inverted.")
 			self.isInverted = true
 		end
 	elseif dsz > 0 and dhz < 0 then 
+		self:debug("Start distance: dsz: %.2f, dhz: %.2f", dsz, dhz)
 		--- Is in the silo but in the wrong direction.
+		--[[
+				hx
+			| |	|
+			| v	|
+			wx	sx  
+		]]
+
+
 		self.isInverted = true
 	elseif dsz < 0 and dhz > 0 then 
+		self:debug("Start distance: dsz: %.2f, dhz: %.2f", dsz, dhz)
 		--- Is in the silo and in the correct direction.
+		--[[
+				hx
+			| ^	|
+			| |	|
+			wx	sx  
+		]]
 	elseif dsz < 0 and dhz < 0 then 
+		self:debug("Start distance: dsz: %.2f, dhz: %.2f", dsz, dhz)
 		--- Exited the silo
-		if dsz > dhz then 
+		--[[
+		  ^
+		  |
+			hx
+		| 	|
+		| 	|
+		wx	sx  
+		]]
+		if dsz < dhz then 
+			self:debug("Silo needs to be inverted.")
 			self.isInverted = true
 		end
 	end

--- a/scripts/silo/BunkerSiloWrapper.lua
+++ b/scripts/silo/BunkerSiloWrapper.lua
@@ -394,6 +394,21 @@ function CpBunkerSilo:draw()
 	end
 end
 
+--- Gets the compaction percentage in 0-100
+---@return number
+function CpBunkerSilo:getCompactionPercentage()
+	return self.silo.compactedPercent
+end
+
+---@return boolean
+function CpBunkerSilo:canBeFilled()
+	return self.silo.state == BunkerSilo.STATE_FILL
+end
+
+---@return boolean
+function CpBunkerSilo:canBeEmptied()
+	return self.silo.state == BunkerSilo.STATE_DRAIN
+end
 
 --------------------------------------------------
 --- Vehicle controllers.

--- a/scripts/silo/BunkerSiloWrapper.lua
+++ b/scripts/silo/BunkerSiloWrapper.lua
@@ -380,9 +380,11 @@ function CpBunkerSilo:draw()
 	for i, controller in pairs(self.controllers) do 
 		controller:draw()
 	end
+	if CpDebug:isChannelActive(CpDebug.DBG_SILO, self.vehicle) then
+		self:drawDebug()
+	end
 	if CpBunkerSilo.DRAW_DEBUG then
 		self:drawUnloaderArea()
-		self:drawDebug()
 
 		local x, z = self.sx + self.dirXWidth * self.width/2 + self.dirXLength * 2, self.sz + self.dirZWidth * self.width/2 + self.dirZLength * 2
 		local y = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, x, 0, z) + 2
@@ -417,9 +419,10 @@ end
 --- Creates a controller for the vehicle.
 ---@param vehicle Vehicle
 ---@param driveStrategy AIDriveStrategyBunkerSilo
+---@param directionNode number
 ---@return CpBunkerSiloLevelerController
-function CpBunkerSilo:setupLevelerTarget(vehicle, driveStrategy)
-	self.controllers[vehicle.rootNode] = CpBunkerSiloLevelerController(self, vehicle, driveStrategy)
+function CpBunkerSilo:setupLevelerTarget(vehicle, driveStrategy, directionNode)
+	self.controllers[vehicle.rootNode] = CpBunkerSiloLevelerController(self, vehicle, driveStrategy, directionNode)
 	self.numControllers = self.numControllers + 1 
 	return self.controllers[vehicle.rootNode]
 end

--- a/scripts/specializations/CpAIWorker.lua
+++ b/scripts/specializations/CpAIWorker.lua
@@ -379,7 +379,9 @@ function CpAIWorker:onUpdate(dt)
         end
         if g_updateLoopIndex % 4 == 0 then
             local tX, tZ, moveForwards, maxSpeed =  spec.driveStrategy:getDriveData(dt)
-
+            if not spec.driveStrategy then 
+                return
+            end
             -- same as AIFieldWorker:updateAIFieldWorker(), do the actual driving
             local tY = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, tX, 0, tZ)
             local pX, _, pZ = worldToLocal(self:getAISteeringNode(), tX, tY, tZ)
@@ -437,10 +439,15 @@ function CpAIWorker:stopCpDriver()
         spec.driveStrategy = nil
     end
 
-    self:brake(1)
+    if self.isServer then 
+        WheelsUtil.updateWheelsPhysics(self, 0, 0, 0, true, true)
+    end
+    if self.brake then 
+        self:brake(1)
+    end
 	self:stopVehicle()
 	self:setCruiseControlState(Drivable.CRUISECONTROL_STATE_OFF, true)
-
+    self:brakeToStop()
     local actionController = self.rootVehicle.actionController
 
 	if actionController ~= nil then

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Aguardando a carreta:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="no silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="posição para estacionar"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Aguardando a carreta:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="no silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="posição para estacionar"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Čekání na vykladač:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="V silážní jámě"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Na parkovací pozici"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Čekání na vykladač:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="V silážní jámě"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Na parkovací pozici"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Venter på aflæsser:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="I silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Parkerings position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Venter på aflæsser:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="I silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Parkerings position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Warten auf Abfahrer:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="im Silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="bei Parkposition"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stoppen bei 99% verdichtet"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stoppen bei 99% verdichtet"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo Verdichtung:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Esperando por descargador:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="en Silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="en posición de estacionamiento"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Esperando por descargador:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="en Silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="en posición de estacionamiento"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Attente d'un déchargement:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="Dans le silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Sur l'emplacement d'attente"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Attente d'un déchargement:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="Dans le silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Sur l'emplacement d'attente"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="In attesa scarico:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="nel silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="in posizione di parcheggio"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="In attesa scarico:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="nel silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="in posizione di parcheggio"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Oczekiwanie na wyładowującego:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="W silosie"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Na pozycji postojowej"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Oczekiwanie na wyładowującego:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="W silosie"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="Na pozycji postojowej"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Esperar pela descarga:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="no silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="na posição de parque"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Esperar pela descarga:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="no silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="na posição de parque"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Ожидать разгружающего:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="в яме"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="на парковке"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Ожидать разгружающего:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="в яме"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="на парковке"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Waiting for unloader:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="in silo"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="at park position"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -92,8 +92,8 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Boşaltıcıyı bekliyorum:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="siloda"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="park konumunda"/>
-    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
-    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop at 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop at 99% compaction"/>
     <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -92,6 +92,9 @@
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_title" text="Boşaltıcıyı bekliyorum:"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_silo" text="siloda"/>
     <text name="CP_bunkerSiloJobParameters_waitAtParkPosition_parkPosition" text="park konumunda"/>
+    <text name="CP_bunkerSiloJobParameters_stopWithCompactedSilo_title" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSiloJobParameters_subTitle_stopWithCompactedSilo" text="Stop with 99% compaction"/>
+    <text name="CP_bunkerSilo_compactionPercentage" text="Silo compaction:"/>
     <!---->
     <!--AI silo lader worker job parameters-->
     <!---->


### PR DESCRIPTION
- Fixes the front/back markers for vehicles with a turned cabin (for example a claas xerion).
- Stops the driver, when the silo state is no longer filling (silo gets closed etc..).
- Added job parameter to stop the driver, when 99 % compaction is reached.
- Added compaction fill level percentage to cp status.

Test:
- [x] Bunker silo drivers forwards/backwards with and without turned cabin. (4 possibilities)
- [x] Check if the driver stops, when the silo gets closed
- [x] Check if the compaction job parameter works
- [x] Check translations
- [x] Start silo loader in bunker silo