### PR TITLE
WIP Combine unloader improvements

### DIFF
--- a/config/jobParameters/CombineUnloaderJobParameterSetup.xml
+++ b/config/jobParameters/CombineUnloaderJobParameterSetup.xml
@@ -27,12 +27,12 @@
 	<SettingSubTitle title="giantsUnloader">
 		<!-- Is the giants ai unloader wanted for unloading? -->
 		<Setting classType="AIParameterBooleanSetting" name="useGiantsUnload" defaultBool="false" isDisabled ="isGiantsUnloadDisabled"/>
-		<Setting classType="CpAIParameterUnloadingStation" name="unloadingStation" isDisabled ="isGiantsUnloadDisabled" generateValuesFunction="generateUnloadingStations"/>
+		<Setting classType="CpAIParameterUnloadingStation" name="unloadingStation" isDisabled ="isUnloadStationSelectorDisabled" generateValuesFunction="generateUnloadingStations"/>
 	</SettingSubTitle>
 	<SettingSubTitle title="fieldUnload">
 		<!-- Is unloading onto the field allowed? -->
 		<Setting classType="AIParameterBooleanSetting" name="useFieldUnload" defaultBool="false" isDisabled ="isFieldUnloadDisabled"/>
-		<Setting classType="CpAIParameterPositionAngle" name="fieldUnloadPosition" positionParameterType="UNLOAD" isDisabled ="isFieldUnloadDisabled"/>
+		<Setting classType="CpAIParameterPositionAngle" name="fieldUnloadPosition" positionParameterType="UNLOAD" isDisabled ="isFieldUnloadPositionSelectorDisabled"/>
 		<Setting classType="AIParameterSettingList" name="unloadingTipSide" isDisabled ="isFieldUnloadTipSideDisabled" generateValuesFunction="generateTipSides"/>
 	</SettingSubTitle>
 </Settings>

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -998,9 +998,9 @@ end
 
 --- Create a straight, forward course for the vehicle.
 ---@param vehicle table the course will start at the root node of the vehicle
----@param length number optional length of the course in meters, default is 100 meters
----@param xOffset number optional side offset for the course
----@param lastNode number optional force direction node
+---@param length number|nil optional length of the course in meters, default is 100 meters
+---@param xOffset number|nil optional side offset for the course
+---@param directionNode number|nil optional force direction node
 function Course.createStraightForwardCourse(vehicle, length, xOffset, directionNode)
 	local l = length or 100
 	return Course.createFromNode(vehicle, directionNode or vehicle.rootNode, xOffset or 0, 0, l, 5, false)

--- a/scripts/ai/AIDriveStrategySiloLoader.lua
+++ b/scripts/ai/AIDriveStrategySiloLoader.lua
@@ -69,6 +69,8 @@ end
 
 function AIDriveStrategySiloLoader:startWithoutCourse(jobParameters)
     -- to always have a valid course (for the traffic conflict detector mainly)
+    self:startCourse(Course.createStraightForwardCourse(self.vehicle, 5, 0, nil), 1)
+
     self.jobParameters = jobParameters
 
     local x, z, dx, dz

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -2169,6 +2169,7 @@ function AIDriveStrategyUnloadCombine:onFieldUnloadPositionReached()
         self.fieldUnloadPositionNode, 0, CpAIJobCombineUnloader.maxHeapLength, -10)
     if found and heapSilo then 
         self:updateFieldPositionByHeapSilo(heapSilo)
+        self.fieldUnloadData.heapSilo = heapSilo
     end
 
     if self.fieldUnloadData.isReverseUnloading then 

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1763,7 +1763,7 @@ function AIDriveStrategyUnloadCombine:startPathfindingToInvertedGoalPositionMark
         self.onPathfindingDoneToInvertedGoalPositionMarker)
 end
 
---- Path to the field unloading position was found.
+--- Path to the goal position was found.
 ---@param path table
 ---@param goalNodeInvalid boolean
 function AIDriveStrategyUnloadCombine:onPathfindingDoneToInvertedGoalPositionMarker(path, goalNodeInvalid)
@@ -1772,7 +1772,7 @@ function AIDriveStrategyUnloadCombine:onPathfindingDoneToInvertedGoalPositionMar
         self:setNewState(self.states.DRIVING_TO_INVERTED_GOAL_POSITION_MARKER)
         local course = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
 
-        --- Append straight alignment segment
+        --- Append a straight alignment segment
         local x, _, z = course:getWaypointPosition(course:getNumberOfWaypoints())
         local dx, _, dz = localToWorld(self.invertedGoalPositionMarkerNode, self.invertedGoalPositionOffset, 0, 0)
     
@@ -1781,7 +1781,6 @@ function AIDriveStrategyUnloadCombine:onPathfindingDoneToInvertedGoalPositionMar
         self:startCourse(course, 1)
      else 
         self:debug("Could not find a path to the goal position marker, pass over to the job!")
-        --- The job instance decides if the job has to quit.
         self.vehicle:getJob():onTrailerFull(self.vehicle, self)
     end
 end
@@ -2149,12 +2148,13 @@ function AIDriveStrategyUnloadCombine:waitingUntilFieldUnloadIsAllowed()
         if unloader ~= self.vehicle then
             ---@type AIDriveStrategyUnloadCombine
             local strategy = unloader:getCpDriveStrategy()
-            if strategy and strategy:isUnloadingOnTheField(true) then 
-                if self.fieldUnloadData.heapSilo and self.fieldUnloadData.heapSilo:isOverlappingWith(strategy:getFieldUnloadHeap()) then 
-                    self:debug("Is waiting for unloader: %s", CpUtil.getName(unloader))
-                    return 
+            if strategy then
+                if strategy:isUnloadingOnTheField(true) then 
+                    if self.fieldUnloadData.heapSilo and self.fieldUnloadData.heapSilo:isOverlappingWith(strategy:getFieldUnloadHeap()) then 
+                        self:debug("Is waiting for unloader: %s", CpUtil.getName(unloader))
+                        return 
+                    end
                 end
-
             end
         end
     end

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1768,10 +1768,10 @@ function AIDriveStrategyUnloadCombine:onPathfindingDoneToInvertedGoalPositionMar
 
         --- Append straight alignment segment
         local x, _, z = course:getWaypointPosition(course:getNumberOfWaypoints())
-        local dx, _, dz = getWorldTranslation(self.invertedGoalPositionMarkerNode)
+        local dx, _, dz = localToWorld(self.invertedGoalPositionMarkerNode, self.invertedGoalPositionOffset, 0, 0)
     
         course:append(Course.createFromTwoWorldPositions(self.vehicle, x, z, dx, dz, 
-            self.invertedGoalPositionOffset, 0, 0, 3, false))
+            0, 0, 0, 3, false))
         self:startCourse(course, 1)
      else 
         self:debug("Could not find a path to the goal position marker, pass over to the job!")

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -2146,12 +2146,14 @@ end
 function AIDriveStrategyUnloadCombine:waitingUntilFieldUnloadIsAllowed()
     self:setMaxSpeed(0)
     for _, unloader in pairs(CpAICombineUnloader.activeUnloaders) do 
-        ---@type AIDriveStrategyUnloadCombine
-        local strategy = unloader:getCpDriveStrategy()
-        if strategy and strategy:isUnloadingOnTheField(true) then 
-            if self.fieldUnloadData.heapSilo and self.fieldUnloadData.heapSilo:isOverlappingWith(strategy:getFieldUnloadHeap()) then 
-                self:debug("Is waiting for unloader: %s", CpUtil.getName(unloader))
-                return 
+        if unloader ~= self.vehicle then
+            ---@type AIDriveStrategyUnloadCombine
+            local strategy = unloader:getCpDriveStrategy()
+            if strategy and strategy:isUnloadingOnTheField(true) then 
+                if self.fieldUnloadData.heapSilo and self.fieldUnloadData.heapSilo:isOverlappingWith(strategy:getFieldUnloadHeap()) then 
+                    self:debug("Is waiting for unloader: %s", CpUtil.getName(unloader))
+                    return 
+                end
             end
         end
     end

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -2149,7 +2149,7 @@ function AIDriveStrategyUnloadCombine:waitingUntilFieldUnloadIsAllowed()
         ---@type AIDriveStrategyUnloadCombine
         local strategy = unloader:getCpDriveStrategy()
         if strategy and strategy:isUnloadingOnTheField(true) then 
-            if self.fieldUnloadData.heapSilo:isOverlappingWith(strategy:getFieldUnloadHeap()) then 
+            if self.fieldUnloadData.heapSilo and self.fieldUnloadData.heapSilo:isOverlappingWith(strategy:getFieldUnloadHeap()) then 
                 self:debug("Is waiting for unloader: %s", CpUtil.getName(unloader))
                 return 
             end

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1421,11 +1421,7 @@ function AIDriveStrategyUnloadCombine:unloadStoppedCombine()
                 self:debug('Finished unloading combine at end of fieldwork, changing to unload course')
                 self.ppc:setNormalLookaheadDistance()
                 self:releaseCombine()
-                if self.unloadTargetType == self.UNLOAD_TYPES.SILO_LOADER then 
-                    self:setNewState(self.states.IDLE)
-                else
-                    self:startMovingBackFromCombine(self.states.MOVING_BACK_WITH_TRAILER_FULL, self.combineJustUnloaded)
-                end
+                self:startMovingBackFromCombine(self.states.MOVING_BACK_WITH_TRAILER_FULL, self.combineJustUnloaded)
             else
                 self:driveBesideCombine()
             end
@@ -1511,6 +1507,12 @@ end
 -- Start moving back from empty combine
 ------------------------------------------------------------------------------------------------------------------------
 function AIDriveStrategyUnloadCombine:startMovingBackFromCombine(newState, combine)
+    if self.unloadTargetType == self.UNLOAD_TYPES.SILO_LOADER then 
+        --- Finished unloading of silo unloader. Moving back is not needed.
+        self:setNewState(self.states.IDLE)
+        return
+    end
+
     local reverseCourse = Course.createStraightReverseCourse(self.vehicle, 15)
     self:startCourse(reverseCourse, 1)
     self:setNewState(newState)

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -2063,7 +2063,7 @@ function AIDriveStrategyUnloadCombine:startUnloadingOnField(controller, allowRev
     --- for reverse unloading or to make sure the pathfinding
     --- is not crossing the heap area.
     local found, heapSilo = BunkerSiloManagerUtil.createHeapBunkerSilo(
-        self.fieldUnloadPositionNode, 0, 50, -10)
+        self.fieldUnloadPositionNode, 0, CpAIJobCombineUnloader.maxHeapLength, -10)
 
     if found and heapSilo then 
         --- Heap was found
@@ -2154,6 +2154,7 @@ function AIDriveStrategyUnloadCombine:waitingUntilFieldUnloadIsAllowed()
                     self:debug("Is waiting for unloader: %s", CpUtil.getName(unloader))
                     return 
                 end
+
             end
         end
     end
@@ -2162,6 +2163,14 @@ end
 
 --- Called when the driver reaches the field unloading position.
 function AIDriveStrategyUnloadCombine:onFieldUnloadPositionReached()
+
+    --- Re-scan heap, as another unloader might have deformed it
+    local found, heapSilo = BunkerSiloManagerUtil.createHeapBunkerSilo(
+        self.fieldUnloadPositionNode, 0, CpAIJobCombineUnloader.maxHeapLength, -10)
+    if found and heapSilo then 
+        self:updateFieldPositionByHeapSilo(heapSilo)
+    end
+
     if self.fieldUnloadData.isReverseUnloading then 
 
         --- Trying to unload at the back of the trailer.
@@ -2277,7 +2286,7 @@ function AIDriveStrategyUnloadCombine:onFieldUnloadingFinished()
         --- after creating the heap for the first time.
         --- This makes sure that the park position doesn't cross the heap. 
         local found, heapSilo = BunkerSiloManagerUtil.createHeapBunkerSilo(
-            self.fieldUnloadPositionNode, 0, 50, -2)
+            self.fieldUnloadPositionNode, 0, CpAIJobCombineUnloader.maxHeapLength, -2)
     
         if found and heapSilo then 
             self:updateFieldPositionByHeapSilo(heapSilo)

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -848,6 +848,7 @@ function AIDriveStrategyUnloadCombine:startUnloadingTrailers()
         --- Trailer attached
         if self.invertedStartPositionMarkerNode then 
             --- The start position is valid, so drive in there before releasing and giving control to giants or AD.
+            self:debug('Trailer is full and a valid start position is set, so drive there before AD or giants can take over.')
             self:startPathfindingToInvertedGoalPositionMarker()
         else 
             --- No valid start position was set, so release the driver and give control to giants or AD.

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -256,7 +256,11 @@ function AIDriveStrategyUnloadCombine:setJobParameterValues(jobParameters)
             self.invertedGoalPositionMarkerNode = CpUtil.createNode("Inverted goal position marker", 
                 x, z, angle + math.pi)
             self:debug("Valid goal position marker was set.")
-        end     
+        else
+            self:debug("Goal position is to far away from the field!")
+        end
+    else
+        self:debug("Invalid start position found!")
     end
     if jobParameters.useFieldUnload:getValue() then 
         local fieldUnloadPosition = jobParameters.fieldUnloadPosition
@@ -1761,7 +1765,7 @@ end
 ---@param path table
 ---@param goalNodeInvalid boolean
 function AIDriveStrategyUnloadCombine:onPathfindingDoneToInvertedGoalPositionMarker(path, goalNodeInvalid)
-    if self:isPathFound(path, goalNodeInvalid, "Field unload position", false) and self.state == self.states.WAITING_FOR_PATHFINDER then
+    if self:isPathFound(path, goalNodeInvalid, "Inverted goal position", false) and self.state == self.states.WAITING_FOR_PATHFINDER then
         self:debug("Found a path to the inverted goal position marker. Appending the missing straight segment.")
         self:setNewState(self.states.DRIVING_TO_INVERTED_GOAL_POSITION_MARKER)
         local course = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)

--- a/scripts/ai/jobs/CpAIJobCombineUnloader.lua
+++ b/scripts/ai/jobs/CpAIJobCombineUnloader.lua
@@ -4,7 +4,8 @@ CpAIJobCombineUnloader = {
 	name = "COMBINE_UNLOADER_CP",
 	jobName = "CP_job_combineUnload",
 	minStartDistanceToField = 20,
-	minFieldUnloadDistanceToField = 20
+	minFieldUnloadDistanceToField = 20,
+	maxHeapLength = 150
 }
 
 local AIJobCombineUnloaderCp_mt = Class(CpAIJobCombineUnloader, CpAIJob)
@@ -206,7 +207,7 @@ function CpAIJobCombineUnloader:validate(farmId)
 		local angle = self.cpJobParameters.fieldUnloadPosition:getAngle()
 		setTranslation(self.heapNode, x, 0, z)
 		setRotation(self.heapNode, 0, angle, 0)
-		local found, heapSilo = BunkerSiloManagerUtil.createHeapBunkerSilo(self.heapNode, 0, 50, -10)
+		local found, heapSilo = BunkerSiloManagerUtil.createHeapBunkerSilo(self.heapNode, 0, self.maxHeapLength, -10)
 		if found then	
 			self.heapPlot:setArea(heapSilo:getArea())
 			self.heapPlot:setVisible(true)

--- a/scripts/ai/jobs/CpAIJobSiloLoader.lua
+++ b/scripts/ai/jobs/CpAIJobSiloLoader.lua
@@ -5,6 +5,7 @@
 CpAIJobSiloLoader = {
 	name = "SILO_LOADER_CP",
 	jobName = "CP_job_siloLoader",
+	maxHeapLength = 150
 }
 local AIJobCombineUnloaderCp_mt = Class(CpAIJobSiloLoader, CpAIJob)
 
@@ -141,7 +142,7 @@ function CpAIJobSiloLoader:getBunkerSiloOrHeap(loadPosition, node)
 	if found then 
 		return true, bunkerSilo
 	end
-	local found, heapSilo = BunkerSiloManagerUtil.createHeapBunkerSilo(node, 0, 50, -10)
+	local found, heapSilo = BunkerSiloManagerUtil.createHeapBunkerSilo(node, 0, self.maxHeapLength, -10)
 	return found, nil, heapSilo
 end
 

--- a/scripts/ai/jobs/CpJobParameters.lua
+++ b/scripts/ai/jobs/CpJobParameters.lua
@@ -144,6 +144,9 @@ function CpJobParameters:__tostring()
     end
 end
 
+--- Are the setting values roughly equal.
+---@param otherParameters CpJobParameters
+---@return boolean
 function CpJobParameters:areAlmostEqualTo(otherParameters)
     for i, param in pairs(self.settings) do 
         if not param:isAlmostEqualTo(otherParameters[param:getName()]) then 

--- a/scripts/ai/jobs/CpJobParameters.lua
+++ b/scripts/ai/jobs/CpJobParameters.lua
@@ -80,7 +80,7 @@ end
 function CpJobParameters:getAiTargetMapHotspotParameters()
     local parameters = {}
     for i, setting in ipairs(self.settings) do
-        if setting:is_a(CpAIParameterPosition) then
+        if setting:is_a(CpAIParameterPosition) or setting:is_a(CpAIParameterUnloadingStation) then
             table.insert(parameters, setting)
         end
     end
@@ -172,8 +172,9 @@ end
 
 --- AI parameters for the bale finder job.
 ---@class CpCombineUnloaderJobParameters : CpJobParameters
+---@field useGiantsUnload AIParameterBooleanSetting
+---@field useFieldUnload AIParameterBooleanSetting
 CpCombineUnloaderJobParameters = CpObject(CpJobParameters)
-
 
 function CpCombineUnloaderJobParameters:init(job)
     self.job = job
@@ -193,8 +194,17 @@ function CpCombineUnloaderJobParameters:isFieldUnloadDisabled()
     return self.useGiantsUnload:getValue()
 end
 
+function CpCombineUnloaderJobParameters:isUnloadStationSelectorDisabled()
+    return self:isGiantsUnloadDisabled() or not self.useGiantsUnload:getValue() 
+end
+
+function CpCombineUnloaderJobParameters:isFieldUnloadPositionSelectorDisabled()
+    return self:isFieldUnloadDisabled() or not self.useFieldUnload:getValue() 
+end
+
+
 function CpCombineUnloaderJobParameters:isFieldUnloadTipSideDisabled()
-    return self:isFieldUnloadDisabled() or self:hasPipe()
+    return self:isFieldUnloadDisabled() or self:hasPipe() or not self.useFieldUnload:getValue() 
 end
 
 

--- a/scripts/ai/jobs/CpJobParameters.lua
+++ b/scripts/ai/jobs/CpJobParameters.lua
@@ -144,6 +144,16 @@ function CpJobParameters:__tostring()
     end
 end
 
+function CpJobParameters:areAlmostEqualTo(otherParameters)
+    for i, param in pairs(self.settings) do 
+        if not param:isAlmostEqualTo(otherParameters[param:getName()]) then 
+            CpUtil.debugFormat(CpDebug.DBG_HUD, "Parameter: %s not equal!", param:getName())
+            return false
+        end
+    end
+    return true
+end
+
 --- AI parameters for the bale finder job.
 ---@class CpBaleFinderJobParameters : CpJobParameters
 CpBaleFinderJobParameters = CpObject(CpJobParameters)

--- a/scripts/ai/parameters/AIParameterSettingInterface.lua
+++ b/scripts/ai/parameters/AIParameterSettingInterface.lua
@@ -131,6 +131,10 @@ function AIParameterSettingInterface:copy(setting)
 
 end
 
+function AIParameterSettingInterface:isAlmostEqualTo(other)
+	
+end
+
 --- Applies title/tooltip texts for the gui element.
 function AIParameterSettingInterface:setGenericGuiElementValues(guiElement)
 	

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -140,6 +140,10 @@ function AIParameterSettingList:is(value)
 	return self:getValue() == value
 end
 
+function AIParameterSettingList:isAlmostEqualTo(other)
+	return self:getValue() == other:getValue()
+end
+
 -- Get the current text key (for the logs, for example)
 function AIParameterSettingList:__tostring()
 	return string.format("AIParameterSettingList(name=%s, value=%s, text=%s)", self.name, tostring(self:getValue()), self:getString())

--- a/scripts/ai/parameters/CpAIParameterPositionAngle.lua
+++ b/scripts/ai/parameters/CpAIParameterPositionAngle.lua
@@ -88,6 +88,9 @@ end
 
 --- Applies the current position to the map hotspot.
 function CpAIParameterPosition:applyToMapHotspot(mapHotspot)
+	if not self:getCanBeChanged() then 
+		return false
+	end
 	local x, z = self:getPosition()
 	if x ~= nil then
 		mapHotspot:setWorldPosition(x, z)
@@ -207,6 +210,9 @@ end
 
 --- Applies the current position and angle to the map hotspot.
 function CpAIParameterPositionAngle:applyToMapHotspot(mapHotspot)
+	if not self:getCanBeChanged() then 
+		return false
+	end
 	if self.angle ~=nil and CpAIParameterPosition.applyToMapHotspot(self, mapHotspot) then
 		mapHotspot:setWorldRotation(self.angle + math.pi)
 		return true

--- a/scripts/ai/parameters/CpAIParameterPositionAngle.lua
+++ b/scripts/ai/parameters/CpAIParameterPositionAngle.lua
@@ -100,6 +100,17 @@ function CpAIParameterPosition:getPositionType()
 	return self.positionType
 end
 
+--- Is the Position within 1m distance?
+---@param otherPosition CpAIParameterPosition
+---@return boolean
+function CpAIParameterPosition:isAlmostEqualTo(otherPosition)
+	local x, z = otherPosition:getPosition()
+	if x ~= nil and self.x ~= nil then
+		return MathUtil.vector2Length(self.x - x, self.z - z)	<= 1
+	end
+	return false
+end
+
 --- Position with angle in the AI Menu.
 ---@class CpAIParameterPositionAngle : CpAIParameterPosition
 CpAIParameterPositionAngle = CpObject(CpAIParameterPosition)
@@ -212,6 +223,18 @@ end
 
 function CpAIParameterPositionAngle:getValue()
 	return self.x, self.z, self.angle
+end
+
+--- Is the Position within 1m distance and angle within 1° degree?
+---@param otherPosition CpAIParameterPositionAngle
+---@return boolean
+function CpAIParameterPositionAngle:isAlmostEqualTo(otherPosition)
+	local angle = otherPosition.getAngle and otherPosition:getAngle()
+	if angle ~= nil and self.angle ~= nil then
+		return math.deg(MathUtil.getAngleDifference(angle, self.angle)) < 1 
+			and CpAIParameterPosition.isAlmostEqualTo(self, otherPosition)
+	end
+	return false
 end
 
 function CpAIParameterPositionAngle:getString()

--- a/scripts/ai/parameters/CpAIParameterPositionAngle.lua
+++ b/scripts/ai/parameters/CpAIParameterPositionAngle.lua
@@ -237,7 +237,7 @@ end
 function CpAIParameterPositionAngle:isAlmostEqualTo(otherPosition)
 	local angle = otherPosition.getAngle and otherPosition:getAngle()
 	if angle ~= nil and self.angle ~= nil then
-		return math.deg(MathUtil.getAngleDifference(angle, self.angle)) < 1 
+		return math.abs(math.deg(MathUtil.getAngleDifference(angle, self.angle))) < 1 
 			and CpAIParameterPosition.isAlmostEqualTo(self, otherPosition)
 	end
 	return false

--- a/scripts/ai/parameters/CpAIParameterUnloadingStation.lua
+++ b/scripts/ai/parameters/CpAIParameterUnloadingStation.lua
@@ -4,7 +4,7 @@ CpAIParameterUnloadingStation = CpObject(AIParameterSettingList)
 
 function CpAIParameterUnloadingStation:init(data, vehicle, class)
 	AIParameterSettingList.init(self, data, vehicle, class)
-	self.type = AIParameterType.UNLOADING_STATION
+	self.guiParameterType = AIParameterType.UNLOADING_STATION
 	return self
 end
 
@@ -38,6 +38,27 @@ function CpAIParameterUnloadingStation:validateUnloadingStation(fillTypeIndex, f
 	end
 	return true, nil
 end
+
+--- Applies the current position to the map hotspot.
+function CpAIParameterUnloadingStation:applyToMapHotspot(mapHotspot)
+	if not self:getCanBeChanged() then 
+		return false
+	end
+	local unloadingStation = self:getUnloadingStation()
+	if unloadingStation ~= nil then
+		local placeable = unloadingStation.owningPlaceable
+		if placeable ~= nil and placeable.getHotspot ~= nil then
+			local hotspot = placeable:getHotspot(1)
+			if hotspot ~= nil then
+				local x, z = hotspot:getWorldPosition()
+				mapHotspot:setWorldPosition(x, z)
+				return true
+			end
+		end
+	end
+	return false
+end
+
 
 function CpAIParameterUnloadingStation:__tostring()
 	return string.format("CpAIParameterUnloadingStation(name=%s, value=%s, text=%s)", self.name, tostring(self:getValue()), self:getString())

--- a/scripts/ai/tasks/CpAITaskCombineUnloader.lua
+++ b/scripts/ai/tasks/CpAITaskCombineUnloader.lua
@@ -31,6 +31,6 @@ function CpAITaskCombineUnloader:stop()
 	CpAITaskCombineUnloader:superClass().stop(self)
 
 	if self.isServer then
-		self.vehicle:stopFieldWorker()
+		self.vehicle:stopCpCombineUnloader()
 	end
 end

--- a/scripts/gui/CpAIFrameExtended.lua
+++ b/scripts/gui/CpAIFrameExtended.lua
@@ -334,17 +334,24 @@ function CpInGameMenuAIFrameExtended:setMapSelectionItem(hotspot)
 					if job.getCpJobParameters ~= nil then
 						local parameters = job:getCpJobParameters():getAiTargetMapHotspotParameters()
 						for i, param in pairs(parameters) do 
-							if param:getPositionType() == CpAIParameterPositionAngle.POSITION_TYPES.DRIVE_TO then 
-								if param:applyToMapHotspot(self.aiTargetMapHotspot) then 
-									g_currentMission:addMapHotspot(self.aiTargetMapHotspot)
+							if param:is_a(CpAIParameterPosition) then
+								if param:getPositionType() == CpAIParameterPositionAngle.POSITION_TYPES.DRIVE_TO then 
+									if param:applyToMapHotspot(self.aiTargetMapHotspot) then 
+										g_currentMission:addMapHotspot(self.aiTargetMapHotspot)
+									end
+								elseif param:getPositionType() == CpAIParameterPositionAngle.POSITION_TYPES.FIELD_OR_SILO then 
+									if param:applyToMapHotspot(self.fieldSiloAiTargetMapHotspot) then
+										g_currentMission:addMapHotspot(self.fieldSiloAiTargetMapHotspot)
+									end
+								elseif param:getPositionType() == CpAIParameterPositionAngle.POSITION_TYPES.UNLOAD then 
+									if param:applyToMapHotspot(self.unloadAiTargetMapHotspot) then
+										g_currentMission:addMapHotspot(self.unloadAiTargetMapHotspot)
+									end
 								end
-							elseif param:getPositionType() == CpAIParameterPositionAngle.POSITION_TYPES.FIELD_OR_SILO then 
-								if param:applyToMapHotspot(self.fieldSiloAiTargetMapHotspot) then
-									g_currentMission:addMapHotspot(self.fieldSiloAiTargetMapHotspot)
-								end
-							elseif param:getPositionType() == CpAIParameterPositionAngle.POSITION_TYPES.UNLOAD then 
-								if param:applyToMapHotspot(self.unloadAiTargetMapHotspot) then
-									g_currentMission:addMapHotspot(self.unloadAiTargetMapHotspot)
+							elseif param:is_a(CpAIParameterUnloadingStation) then 
+								g_currentMission:removeMapHotspot(self.aiUnloadingMarkerHotspot)
+								if param:applyToMapHotspot(self.aiUnloadingMarkerHotspot) then 
+									g_currentMission:addMapHotspot(self.aiUnloadingMarkerHotspot)
 								end
 							end
 						end
@@ -562,26 +569,13 @@ function CpInGameMenuAIFrameExtended:updateParameterValueTexts(superFunc, ...)
 			element:updateTitle()
 
 			if parameterType == AIParameterType.UNLOADING_STATION then
-				local unloadingStation = parameter:getUnloadingStation()
-
-				if unloadingStation ~= nil then
-					local placeable = unloadingStation.owningPlaceable
-
-					if placeable ~= nil and placeable.getHotspot ~= nil then
-						local hotspot = placeable:getHotspot(1)
-
-						if hotspot ~= nil then
-							local x, z = hotspot:getWorldPosition()
-
-							self.aiUnloadingMarkerHotspot:setWorldPosition(x, z)
-							g_currentMission:addMapHotspot(self.aiUnloadingMarkerHotspot)
-						end
-					end
+				if parameter:applyToMapHotspot(self.aiUnloadingMarkerHotspot) then 
+					g_currentMission:addMapHotspot(self.aiUnloadingMarkerHotspot)
 				end
 			elseif parameterType == AIParameterType.LOADING_STATION then
 				local loadingStation = parameter:getLoadingStation()
 
-				if loadingStation ~= nil then
+				if loadingStation ~= nil and parameter:getCanBeChanged() then
 					local placeable = loadingStation.owningPlaceable
 
 					if placeable ~= nil and placeable.getHotspot ~= nil then

--- a/scripts/gui/CpAIFrameExtended.lua
+++ b/scripts/gui/CpAIFrameExtended.lua
@@ -569,8 +569,27 @@ function CpInGameMenuAIFrameExtended:updateParameterValueTexts(superFunc, ...)
 			element:updateTitle()
 
 			if parameterType == AIParameterType.UNLOADING_STATION then
-				if parameter:applyToMapHotspot(self.aiUnloadingMarkerHotspot) then 
-					g_currentMission:addMapHotspot(self.aiUnloadingMarkerHotspot)
+				if parameter.applyToMapHotspot then
+					if parameter:applyToMapHotspot(self.aiUnloadingMarkerHotspot) then 
+						g_currentMission:addMapHotspot(self.aiUnloadingMarkerHotspot)
+					end
+				else 
+					local unloadingStation = parameter:getUnloadingStation()
+
+					if unloadingStation ~= nil then
+						local placeable = unloadingStation.owningPlaceable
+
+						if placeable ~= nil and placeable.getHotspot ~= nil then
+							local hotspot = placeable:getHotspot(1)
+
+							if hotspot ~= nil then
+								local x, z = hotspot:getWorldPosition()
+
+								self.aiUnloadingMarkerHotspot:setWorldPosition(x, z)
+								g_currentMission:addMapHotspot(self.aiUnloadingMarkerHotspot)
+							end
+						end
+					end
 				end
 			elseif parameterType == AIParameterType.LOADING_STATION then
 				local loadingStation = parameter:getLoadingStation()

--- a/scripts/gui/CpGuiUtil.lua
+++ b/scripts/gui/CpGuiUtil.lua
@@ -249,6 +249,7 @@ function CpGuiUtil.setCameraRotation(vehicle, enableRotation, savedRotatableInfo
 	end
 end
 
+--- Adds the copy/paste button line to the hud layout with copy,paste and clear button.
 ---@param layout table
 ---@param baseHud CpBaseHud
 ---@param vehicle table

--- a/scripts/gui/CpGuiUtil.lua
+++ b/scripts/gui/CpGuiUtil.lua
@@ -249,8 +249,51 @@ function CpGuiUtil.setCameraRotation(vehicle, enableRotation, savedRotatableInfo
 	end
 end
 
+---@param layout table
+---@param baseHud CpBaseHud
+---@param vehicle table
+---@param lines table
+---@param wMargin number
+---@param hMargin number
+---@param line number
+function CpGuiUtil.addCopyAndPasteButtons(layout, baseHud, vehicle, lines, wMargin, hMargin, line)
+	local imageFilename = Utils.getFilename('img/ui_courseplay.dds', g_Courseplay.BASE_DIRECTORY)
+    local imageFilename2 = Utils.getFilename('img/iconSprite.dds', g_Courseplay.BASE_DIRECTORY)
+                                      
+	local leftX, leftY = unpack(lines[line].left)
+    local rightX, rightY = unpack(lines[line].right)
+    local btnYOffset = hMargin*0.2
+	local width, height = getNormalizedScreenValues(22, 22)
+
+	local copyOverlay = CpGuiUtil.createOverlay({width, height},
+	{imageFilename, GuiUtils.getUVs(unpack(CpBaseHud.uvs.copySymbol))}, 
+	CpBaseHud.OFF_COLOR,
+	CpBaseHud.alignments.bottomRight)
+
+	local pasteOverlay = CpGuiUtil.createOverlay({width, height},
+		{imageFilename, GuiUtils.getUVs(unpack(CpBaseHud.uvs.pasteSymbol))}, 
+		CpBaseHud.OFF_COLOR,
+		CpBaseHud.alignments.bottomRight)
+
+	local clearCourseOverlay = CpGuiUtil.createOverlay({width, height},
+		{imageFilename2, GuiUtils.getUVs(unpack(CpBaseHud.uvs.clearCourseSymbol))}, 
+		CpBaseHud.OFF_COLOR,
+		CpBaseHud.alignments.bottomRight)
+
+	layout.copyButton = CpHudButtonElement.new(copyOverlay, layout)
+	layout.copyButton:setPosition(rightX, rightY-btnYOffset)
+
+	layout.pasteButton = CpHudButtonElement.new(pasteOverlay, layout)
+    layout.pasteButton:setPosition(rightX, rightY-btnYOffset)
+
+	layout.clearCacheBtn = CpHudButtonElement.new(clearCourseOverlay, layout)
+    layout.clearCacheBtn:setPosition(rightX - width - wMargin/2, rightY - btnYOffset)
+
+	layout.copyCacheText = CpTextHudElement.new(layout, leftX, leftY, CpBaseHud.defaultFontSize)
+end
+
 --- Setup for the copy course btn.
----@param layout CpHudPageElement
+---@param layout table
 ---@param baseHud CpBaseHud
 ---@param vehicle table
 ---@param lines table
@@ -258,57 +301,24 @@ end
 ---@param hMargin number
 ---@param line number
 function CpGuiUtil.addCopyCourseBtn(layout, baseHud, vehicle, lines, wMargin, hMargin, line)    
-    local imageFilename = Utils.getFilename('img/ui_courseplay.dds', g_Courseplay.BASE_DIRECTORY)
-    local imageFilename2 = Utils.getFilename('img/iconSprite.dds', g_Courseplay.BASE_DIRECTORY)
-    --- Copy course btn.                                          
-    layout.copyCourseElements = {}
-    layout.copyCourseIx = 1
-    layout.courseVehicles = {}
-    local leftX, leftY = unpack(lines[line].left)
-    local rightX, rightY = unpack(lines[line].right)
-    local btnYOffset = hMargin*0.2
-
-    local width, height = getNormalizedScreenValues(22, 22)
     
-    local copyOverlay = CpGuiUtil.createOverlay({width, height},
-                                                        {imageFilename, GuiUtils.getUVs(unpack(CpBaseHud.uvs.copySymbol))}, 
-                                                        CpBaseHud.OFF_COLOR,
-                                                        CpBaseHud.alignments.bottomRight)
+	CpGuiUtil.addCopyAndPasteButtons(layout, baseHud, vehicle, lines, wMargin, hMargin, line)
 
-    local pasteOverlay = CpGuiUtil.createOverlay({width, height},
-                                                        {imageFilename, GuiUtils.getUVs(unpack(CpBaseHud.uvs.pasteSymbol))}, 
-                                                        CpBaseHud.OFF_COLOR,
-                                                        CpBaseHud.alignments.bottomRight)
-
-   
-    local clearCourseOverlay = CpGuiUtil.createOverlay({width, height},
-                                                        {imageFilename2, GuiUtils.getUVs(unpack(CpBaseHud.uvs.clearCourseSymbol))}, 
-                                                        CpBaseHud.OFF_COLOR,
-                                                        CpBaseHud.alignments.bottomRight)
-
-    layout.copyButton = CpHudButtonElement.new(copyOverlay, layout)
-    layout.copyButton:setPosition(rightX, rightY-btnYOffset)
     layout.copyButton:setCallback("onClickPrimary", vehicle, function (vehicle)
         if not CpBaseHud.courseCache and vehicle:hasCpCourse() then 
             CpBaseHud.courseCache = vehicle:getFieldWorkCourse()
         end
     end)
 
-    layout.pasteButton = CpHudButtonElement.new(pasteOverlay, layout)
-    layout.pasteButton:setPosition(rightX, rightY-btnYOffset)
     layout.pasteButton:setCallback("onClickPrimary", vehicle, function (vehicle)
         if CpBaseHud.courseCache and not vehicle:hasCpCourse() then 
             vehicle:cpCopyCourse(CpBaseHud.courseCache)
         end
     end)
 
-    layout.clearCacheBtn = CpHudButtonElement.new(clearCourseOverlay, layout)
-    layout.clearCacheBtn:setPosition(rightX - width - wMargin/2, rightY - btnYOffset)
     layout.clearCacheBtn:setCallback("onClickPrimary", vehicle, function (vehicle)
         CpBaseHud.courseCache = nil
     end)
-
-    layout.copyCacheText = CpTextHudElement.new(layout, leftX, leftY, CpBaseHud.defaultFontSize)
 
 end
 

--- a/scripts/gui/hud/CpBaseHud.lua
+++ b/scripts/gui/hud/CpBaseHud.lua
@@ -498,6 +498,10 @@ function CpBaseHud:updateContent(vehicle, status)
     if activeLayout.isStartingPointBtnDisabled then 
         self.startingPointBtn:setDisabled(activeLayout:isStartingPointBtnDisabled(vehicle))
     end
+    self.startingPointBtn:setVisible(true)
+    if activeLayout.isStartingPointBtnVisible then 
+        self.startingPointBtn:setVisible(activeLayout:isStartingPointBtnVisible(vehicle))
+    end
     self.startingPointBtn:setTextDetails(vehicle:getCpStartText())
     if activeLayout.getStartingPointBtnText then 
         self.startingPointBtn:setTextDetails(activeLayout:getStartingPointBtnText(vehicle))

--- a/scripts/gui/hud/CpBaseHud.lua
+++ b/scripts/gui/hud/CpBaseHud.lua
@@ -102,6 +102,11 @@ CpBaseHud.automaticText = g_i18n:getText("CP_automatic")
 CpBaseHud.copyText = g_i18n:getText("CP_copy")
 
 CpBaseHud.courseCache = nil
+CpBaseHud.copyPasteCache = {
+    siloLoaderVehicle = nil,
+    combineUnloaderVehicle = nil,
+    hasVehicle = false
+}
 
 function CpBaseHud.registerXmlSchema(xmlSchema, baseKey)
     xmlSchema:register(XMLValueType.FLOAT, baseKey..CpBaseHud.xmlKey.."#posX", "Hud position x.")

--- a/scripts/gui/hud/CpCombineUnloaderHudPage.lua
+++ b/scripts/gui/hud/CpCombineUnloaderHudPage.lua
@@ -29,8 +29,15 @@ function CpCombineUnloaderHudPageElement:setupElements(baseHud, vehicle, lines, 
     self.fullThresholdBtn = baseHud:addLineTextButton(self, 4, CpBaseHud.defaultFontSize, 
                                                 vehicle:getCpSettings().fullThreshold)              
 
+    
+    --- Unloading combine or silo loader ?
+    self.unloadModeBtn = baseHud:addLeftLineTextButton(self, 6, CpBaseHud.defaultFontSize, 
+                            function (vehicle)
+                                vehicle:getCpCombineUnloaderJobParameters().unloadTarget:setNextItem()
+                            end, vehicle)
+
     --- Giants unloading station
-    local x, y = unpack(lines[4].left)
+    local x, y = unpack(lines[5].left)
     self.giantsUnloadStationText = CpTextHudElement.new(self , x , y, CpBaseHud.defaultFontSize)                 
     self.giantsUnloadStationText:setCallback("onClickPrimary", vehicle, 
     function(vehicle)
@@ -117,6 +124,11 @@ function CpCombineUnloaderHudPageElement:update(dt)
 end
 
 function CpCombineUnloaderHudPageElement:updateContent(vehicle, status)
+
+    self.unloadModeBtn:setDisabled(vehicle:getIsCpActive())
+    local text = vehicle:getCpCombineUnloaderJobParameters().unloadTarget:getString()
+    self.unloadModeBtn:setTextDetails(text)
+
     local toolOffsetX = vehicle:getCpSettings().toolOffsetX
     local text = toolOffsetX:getIsDisabled() and CpBaseHud.automaticText or toolOffsetX:getString()
     self.toolOffsetXBtn:setTextDetails(toolOffsetX:getTitle(), text)
@@ -206,14 +218,6 @@ function CpCombineUnloaderHudPageElement:arePositionEqual(parameters, otherParam
     return true 
 end
 
-function CpCombineUnloaderHudPageElement:isStartingPointBtnDisabled(vehicle)
-    return vehicle:getIsCpActive()
-end
-
-function CpCombineUnloaderHudPageElement:getStartingPointBtnText(vehicle)
-    return vehicle:getCpCombineUnloaderJobParameters().unloadTarget:getString()
-end
-
-function CpCombineUnloaderHudPageElement:executeStartingPointBtnCallback(vehicle)
-    vehicle:getCpCombineUnloaderJobParameters().unloadTarget:setNextItem()
+function CpCombineUnloaderHudPageElement:isStartingPointBtnVisible()
+    return false
 end

--- a/scripts/gui/hud/CpCombineUnloaderHudPage.lua
+++ b/scripts/gui/hud/CpCombineUnloaderHudPage.lua
@@ -166,37 +166,44 @@ function CpCombineUnloaderHudPageElement:updateContent(vehicle, status)
 
 end
 
+--- Updates the copy, paste and clear buttons.
 function CpCombineUnloaderHudPageElement:updateCopyButtons(vehicle)
     if CpBaseHud.copyPasteCache.hasVehicle then 
-        local copyCacheVehicle, arePositionEqual
-        if CpBaseHud.copyPasteCache.combineUnloaderVehicle then 
-            copyCacheVehicle = CpBaseHud.copyPasteCache.combineUnloaderVehicle
-            arePositionEqual = self:arePositionEqual(vehicle:getCpCombineUnloaderJobParameters(), 
-                copyCacheVehicle:getCpCombineUnloaderJobParameters())
-        else
-            copyCacheVehicle = CpBaseHud.copyPasteCache.siloLoaderVehicle
-            local loadPosition = copyCacheVehicle:getCpSiloLoaderWorkerJobParameters().loadPosition
-            local unloadPosition = vehicle:getCpCombineUnloaderJobParameters().fieldUnloadPosition
-            arePositionEqual = unloadPosition:isAlmostEqualTo(loadPosition)
-        end
+        self.clearCacheBtn:setVisible(true)
+        self.pasteButton:setVisible(true)
+        self.copyButton:setVisible(false)
+        local copyCacheVehicle = CpBaseHud.copyPasteCache.siloLoaderVehicle or CpBaseHud.copyPasteCache.combineUnloaderVehicle
         local fieldNum = CpFieldUtil.getFieldNumUnderVehicle(copyCacheVehicle)
         local text = CpUtil.getName(copyCacheVehicle)
         if fieldNum then 
             text = string.format("%s(%s)", text, fieldNum)
         end
         self.copyCacheText:setTextDetails(text)
-        self.clearCacheBtn:setVisible(true)
-        self.pasteButton:setVisible(true)
-        self.copyButton:setVisible(false)
-        if vehicle:getIsCpActive() or arePositionEqual then 
-            self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.OFF_COLOR))
-            self.pasteButton:setColor(unpack(CpBaseHud.OFF_COLOR))
-            self.pasteButton:setDisabled(true)
-        else 
-            self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.WHITE_COLOR))
-            self.pasteButton:setColor(unpack(CpBaseHud.ON_COLOR))
-            self.pasteButton:setDisabled(false)
+        self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.OFF_COLOR))
+        self.pasteButton:setColor(unpack(CpBaseHud.OFF_COLOR))
+        self.pasteButton:setDisabled(true)
+        if copyCacheVehicle == vehicle or vehicle:getIsCpActive() then 
+            --- Paste disabled
+            return
         end
+
+        local arePositionEqual
+        if CpBaseHud.copyPasteCache.combineUnloaderVehicle then 
+            arePositionEqual = self:arePositionEqual(vehicle:getCpCombineUnloaderJobParameters(), 
+                copyCacheVehicle:getCpCombineUnloaderJobParameters())
+        else
+            local loadPosition = copyCacheVehicle:getCpSiloLoaderWorkerJobParameters().loadPosition
+            local unloadPosition = vehicle:getCpCombineUnloaderJobParameters().fieldUnloadPosition
+            arePositionEqual = unloadPosition:isAlmostEqualTo(loadPosition)
+        end
+        if arePositionEqual then 
+            --- Paste disabled
+            return
+        end
+        self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.WHITE_COLOR))
+        self.pasteButton:setColor(unpack(CpBaseHud.ON_COLOR))
+        self.pasteButton:setDisabled(false)
+
     else
         self.copyCacheText:setTextDetails("")
         self.clearCacheBtn:setVisible(false)

--- a/scripts/gui/hud/CpSiloLoaderWorkerHudPage.lua
+++ b/scripts/gui/hud/CpSiloLoaderWorkerHudPage.lua
@@ -77,38 +77,44 @@ function CpSiloLoaderWorkerHudPageElement:updateContent(vehicle, status)
     self:updateCopyButtons(vehicle)
 end
 
+--- Updates the copy, paste and clear buttons.
 function CpSiloLoaderWorkerHudPageElement:updateCopyButtons(vehicle)
     if CpBaseHud.copyPasteCache.hasVehicle then 
-        local copyCacheVehicle, arePositionEqual
-        if CpBaseHud.copyPasteCache.siloLoaderVehicle then 
-            copyCacheVehicle = CpBaseHud.copyPasteCache.siloLoaderVehicle
-            arePositionEqual = self:arePositionEqual(vehicle:getCpSiloLoaderWorkerJobParameters(), 
-                copyCacheVehicle:getCpSiloLoaderWorkerJobParameters())
-        else
-            copyCacheVehicle = CpBaseHud.copyPasteCache.combineUnloaderVehicle
-            local unloadPosition = copyCacheVehicle:getCpCombineUnloaderJobParameters().fieldUnloadPosition
-            local loadPosition = vehicle:getCpSiloLoaderWorkerJobParameters().loadPosition
-            arePositionEqual = unloadPosition:isAlmostEqualTo(loadPosition)
-
-        end
+        self.clearCacheBtn:setVisible(true)
+        self.pasteButton:setVisible(true)
+        self.copyButton:setVisible(false)
+        local copyCacheVehicle = CpBaseHud.copyPasteCache.siloLoaderVehicle or CpBaseHud.copyPasteCache.combineUnloaderVehicle
         local fieldNum = CpFieldUtil.getFieldNumUnderVehicle(copyCacheVehicle)
         local text = CpUtil.getName(copyCacheVehicle)
         if fieldNum then 
             text = string.format("%s(%s)", text, fieldNum)
         end
         self.copyCacheText:setTextDetails(text)
-        self.clearCacheBtn:setVisible(true)
-        self.pasteButton:setVisible(true)
-        self.copyButton:setVisible(false)
-        if vehicle:getIsCpActive() or arePositionEqual then 
-            self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.OFF_COLOR))
-            self.pasteButton:setColor(unpack(CpBaseHud.OFF_COLOR))
-            self.pasteButton:setDisabled(true)
-        else 
-            self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.WHITE_COLOR))
-            self.pasteButton:setColor(unpack(CpBaseHud.ON_COLOR))
-            self.pasteButton:setDisabled(false)
+        self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.OFF_COLOR))
+        self.pasteButton:setColor(unpack(CpBaseHud.OFF_COLOR))
+        self.pasteButton:setDisabled(true)
+        if copyCacheVehicle == vehicle or vehicle:getIsCpActive() then 
+            --- Paste disabled
+            return
         end
+
+        local arePositionEqual
+        if CpBaseHud.copyPasteCache.siloLoaderVehicle then 
+            arePositionEqual = self:arePositionEqual(vehicle:getCpSiloLoaderWorkerJobParameters(), 
+                copyCacheVehicle:getCpSiloLoaderWorkerJobParameters())
+        else
+            local unloadPosition = copyCacheVehicle:getCpCombineUnloaderJobParameters().fieldUnloadPosition
+            local loadPosition = vehicle:getCpSiloLoaderWorkerJobParameters().loadPosition
+            arePositionEqual = unloadPosition:isAlmostEqualTo(loadPosition)
+
+        end
+        if arePositionEqual then 
+            --- Paste disabled
+            return
+        end
+        self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.WHITE_COLOR))
+        self.pasteButton:setColor(unpack(CpBaseHud.ON_COLOR))
+        self.pasteButton:setDisabled(false)
     else
         self.copyCacheText:setTextDetails("")
         self.clearCacheBtn:setVisible(false)

--- a/scripts/gui/hud/CpSiloLoaderWorkerHudPage.lua
+++ b/scripts/gui/hud/CpSiloLoaderWorkerHudPage.lua
@@ -1,9 +1,14 @@
 --- Bale finder Hud page
----@class CpSiloLoaderWorkerHudPageElement : CpHudElement
+---@class CpSiloLoaderWorkerHudPageElement : CpHudPageElement
 CpSiloLoaderWorkerHudPageElement = {}
 local CpSiloLoaderWorkerHudPageElement_mt = Class(CpSiloLoaderWorkerHudPageElement, CpHudPageElement)
 
 function CpSiloLoaderWorkerHudPageElement.new(overlay, parentHudElement, customMt)
+    ---@class CpSiloLoaderWorkerHudPageElement : CpHudPageElement
+    ---@field copyButton CpHudButtonElement
+    ---@field pasteButton CpHudButtonElement
+    ---@field clearCacheBtn CpHudButtonElement
+    ---@field copyCacheText CpTextHudElement
     local self = CpHudPageElement.new(overlay, parentHudElement, customMt or CpSiloLoaderWorkerHudPageElement_mt)
         
     return self
@@ -29,7 +34,33 @@ function CpSiloLoaderWorkerHudPageElement:setupElements(baseHud, vehicle, lines,
         baseHud:openCourseGeneratorGui(vehicle)
     end)
 
-    CpGuiUtil.addCopyCourseBtn(self, baseHud, vehicle, lines, wMargin, hMargin, 1)
+    CpGuiUtil.addCopyAndPasteButtons(self, baseHud, 
+    vehicle, lines, wMargin, hMargin, 1)
+
+    self.copyButton:setCallback("onClickPrimary", vehicle, function (vehicle)
+        if not CpBaseHud.copyPasteCache.hasVehicle and vehicle.getCpCombineUnloaderJob then 
+            CpBaseHud.copyPasteCache.siloLoaderVehicle = vehicle
+            CpBaseHud.copyPasteCache.hasVehicle = true
+        end
+    end)
+
+
+    self.pasteButton:setCallback("onClickPrimary", vehicle, function (vehicle)
+        if CpBaseHud.copyPasteCache.hasVehicle and not vehicle:getIsCpActive() then 
+            if CpBaseHud.copyPasteCache.siloLoaderVehicle then 
+                vehicle:applyCpSiloLoaderWorkerJobParameters(CpBaseHud.copyPasteCache.siloLoaderVehicle:getCpSiloLoaderWorkerJob())
+            else 
+                local parameters = CpBaseHud.copyPasteCache.combineUnloaderVehicle:getCpCombineUnloaderJobParameters()
+                vehicle:getCpSiloLoaderWorkerJobParameters().loadPosition:copy(parameters.fieldUnloadPosition)
+            end
+        end
+    end)
+
+    self.clearCacheBtn:setCallback("onClickPrimary", vehicle, function (vehicle)
+        CpBaseHud.copyPasteCache.hasVehicle = false
+        CpBaseHud.copyPasteCache.siloLoaderVehicle = nil 
+        CpBaseHud.copyPasteCache.combineUnloaderVehicle = nil
+    end)
 end
 
 function CpSiloLoaderWorkerHudPageElement:update(dt)
@@ -42,6 +73,56 @@ function CpSiloLoaderWorkerHudPageElement:updateContent(vehicle, status)
     self.workWidthBtn:setTextDetails(workWidth:getTitle(), workWidth:getString())
     self.workWidthBtn:setVisible(workWidth:getIsVisible())
 
+    --- Update copy and paste buttons
+    self:updateCopyButtons(vehicle)
+end
 
-    CpGuiUtil.updateCopyBtn(self, vehicle, status)
+function CpSiloLoaderWorkerHudPageElement:updateCopyButtons(vehicle)
+    if CpBaseHud.copyPasteCache.hasVehicle then 
+        local copyCacheVehicle, arePositionEqual
+        if CpBaseHud.copyPasteCache.siloLoaderVehicle then 
+            copyCacheVehicle = CpBaseHud.copyPasteCache.siloLoaderVehicle
+            arePositionEqual = self:arePositionEqual(vehicle:getCpSiloLoaderWorkerJobParameters(), 
+                copyCacheVehicle:getCpSiloLoaderWorkerJobParameters())
+        else
+            copyCacheVehicle = CpBaseHud.copyPasteCache.combineUnloaderVehicle
+            local unloadPosition = copyCacheVehicle:getCpCombineUnloaderJobParameters().fieldUnloadPosition
+            local loadPosition = vehicle:getCpSiloLoaderWorkerJobParameters().loadPosition
+            arePositionEqual = unloadPosition:isAlmostEqualTo(loadPosition)
+
+        end
+        local fieldNum = CpFieldUtil.getFieldNumUnderVehicle(copyCacheVehicle)
+        local text = CpUtil.getName(copyCacheVehicle)
+        if fieldNum then 
+            text = string.format("%s(%s)", text, fieldNum)
+        end
+        self.copyCacheText:setTextDetails(text)
+        self.clearCacheBtn:setVisible(true)
+        self.pasteButton:setVisible(true)
+        self.copyButton:setVisible(false)
+        if vehicle:getIsCpActive() or arePositionEqual then 
+            self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.OFF_COLOR))
+            self.pasteButton:setColor(unpack(CpBaseHud.OFF_COLOR))
+            self.pasteButton:setDisabled(true)
+        else 
+            self.copyCacheText:setTextColorChannels(unpack(CpBaseHud.WHITE_COLOR))
+            self.pasteButton:setColor(unpack(CpBaseHud.ON_COLOR))
+            self.pasteButton:setDisabled(false)
+        end
+    else
+        self.copyCacheText:setTextDetails("")
+        self.clearCacheBtn:setVisible(false)
+        self.pasteButton:setVisible(false)
+        self.copyButton:setVisible(true)
+    end
+end
+
+function CpSiloLoaderWorkerHudPageElement:arePositionEqual(parameters, otherParameters)
+    if not parameters.loadPosition:isAlmostEqualTo(otherParameters.loadPosition) then 
+        return false
+    end 
+    if not parameters.startPosition:isAlmostEqualTo(otherParameters.startPosition) then 
+        return false
+    end
+    return true 
 end

--- a/scripts/silo/BunkerSiloWrapper.lua
+++ b/scripts/silo/BunkerSiloWrapper.lua
@@ -93,6 +93,11 @@ function CpSilo:getWidthDirection()
 	return self.dirXWidth, self.dirZWidth
 end
 
+function CpSilo:getCenter()
+	local cx, cz = self:getFrontCenter()
+	return cx + self.dirXLength * self.length/2, cz + self.dirZLength * self.length/2
+end
+
 function CpSilo:getFrontCenter()
 	local width = self:getWidth()
 	return self.sx + self.dirXWidth * width/2, self.sz + self.dirZWidth * width/2
@@ -145,6 +150,16 @@ function CpSilo:drawArea(area)
 	local y = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, area[1].x, 0, area[1].z) + 2
 	DebugUtil.drawDebugAreaRectangle(area[1].x, y, area[1].z, area[2].x, y, area[2].z, area[4].x, y, area[4].z, false, 1, 0, 0)
 end
+
+--- Are the two silo overlapping 
+function CpSilo:isOverlappingWith(otherSilo)
+	if not otherSilo then 
+		return false
+	end
+	local cx, cz = otherSilo:getCenter()
+	return self:isPointInArea(cx, cz, self.area)
+end
+
 
 --- Heap Bunker Silo
 --- Wrapper for a heap.

--- a/scripts/specializations/CpAIWorker.lua
+++ b/scripts/specializations/CpAIWorker.lua
@@ -377,29 +377,29 @@ function CpAIWorker:onUpdate(dt)
         if not spec.driveStrategy then 
             return
         end
-        if g_updateLoopIndex % 4 == 0 then
-            local tX, tZ, moveForwards, maxSpeed =  spec.driveStrategy:getDriveData(dt)
-            if not spec.driveStrategy then 
-                return
-            end
-            -- same as AIFieldWorker:updateAIFieldWorker(), do the actual driving
-            local tY = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, tX, 0, tZ)
-            local pX, _, pZ = worldToLocal(self:getAISteeringNode(), tX, tY, tZ)
-
-            if not moveForwards and self.spec_articulatedAxis ~= nil and
-                    self.spec_articulatedAxis.aiRevereserNode ~= nil then
-                pX, _, pZ = worldToLocal(self.spec_articulatedAxis.aiRevereserNode, tX, tY, tZ)
-            end
-
-            if not moveForwards and self:getAIReverserNode() ~= nil then
-                pX, _, pZ = worldToLocal(self:getAIReverserNode(), tX, tY, tZ)
-            end
-
-            local acceleration = 1
-            local isAllowedToDrive = maxSpeed ~= 0
-
-            AIVehicleUtil.driveToPoint(self, dt, acceleration, isAllowedToDrive, moveForwards, pX, pZ, maxSpeed)
+        
+        local tX, tZ, moveForwards, maxSpeed =  spec.driveStrategy:getDriveData(dt)
+        if not spec.driveStrategy then 
+            return
         end
+        -- same as AIFieldWorker:updateAIFieldWorker(), do the actual driving
+        local tY = getTerrainHeightAtWorldPos(g_currentMission.terrainRootNode, tX, 0, tZ)
+        local pX, _, pZ = worldToLocal(self:getAISteeringNode(), tX, tY, tZ)
+
+        if not moveForwards and self.spec_articulatedAxis ~= nil and
+                self.spec_articulatedAxis.aiRevereserNode ~= nil then
+            pX, _, pZ = worldToLocal(self.spec_articulatedAxis.aiRevereserNode, tX, tY, tZ)
+        end
+
+        if not moveForwards and self:getAIReverserNode() ~= nil then
+            pX, _, pZ = worldToLocal(self:getAIReverserNode(), tX, tY, tZ)
+        end
+
+        local acceleration = 1
+        local isAllowedToDrive = maxSpeed ~= 0
+
+        AIVehicleUtil.driveToPoint(self, dt, acceleration, isAllowedToDrive, moveForwards, pX, pZ, maxSpeed)
+    
     end
 
 end

--- a/scripts/specializations/CpAIWorker.lua
+++ b/scripts/specializations/CpAIWorker.lua
@@ -371,6 +371,7 @@ function CpAIWorker:onUpdate(dt)
         end
     end
     local spec = self.spec_cpAIWorker
+    --- TODO: Check if a tick delay should be used for performance similar to AIFieldWorker or not.
     if spec.driveStrategy then 
         --- Should drive all CP modes, except fieldwork here.
         spec.driveStrategy:update(dt)


### PR DESCRIPTION
- [x] Before giving the control over to AD or Giants drive to the goal position marker. 
- [x] After unloading of an silo unloader skip the reverse driving part. 
- [x] Make sure no traffic conflict happens for unloading to the heap with multiple unloaders. 
- [x] Copy/paste job parameters(unloader, siloloader worker) for heap position and so on.