### PR TITLE
Combine pocket fixes and disabled swath in pocket.

### DIFF
--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -89,8 +89,20 @@ function CombineController:updateBeaconLightsAndFullMessage()
     end
 end
 
+--- Callback from the drive strategy, if the swath needs to be disabled.
+function CombineController:isStrawSwathDisabled()
+    return self.driveStrategy.isStrawSwathDisabled and self.driveStrategy:isStrawSwathDisabled()
+end
 
 function CombineController:updateStrawSwath(isOnHeadland)
+    if self:isStrawSwathDisabled() then 
+        if self.combineSpec.isSwathActive then
+            self:debug("Straw swath force disabled.")
+            self:setStrawSwath(false)
+        end
+        return
+    end
+
     local strawMode = self.settings.strawSwath:getValue()
     if self.combineSpec.isSwathActive then
         if strawMode == CpVehicleSettings.STRAW_SWATH_OFF or isOnHeadland and strawMode == CpVehicleSettings.STRAW_SWATH_ONLY_CENTER then


### PR DESCRIPTION
- Fixes bug, where making a pocket failed, when the unloadInPocketIx was skipped for example in a turn maneuver
- While creating a pocket wait, if the combine is unloading, as a unloader might have reached the combine already before the pocket is created.
- Disabled straw swath in pockets. Test:
- A few pocket approaches with different combines.