### PR TITLE
Might help with issue #2295

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -21,9 +21,9 @@ Course = CpObject()
 
 --- Course constructor
 ---@param waypoints Waypoint[] table of waypoints of the course
----@param temporary boolean optional, default false is this a temporary course?
----@param first number optional, index of first waypoint to use
----@param last number optional, index of last waypoint to use to construct of the course
+---@param temporary boolean|nil optional, default false is this a temporary course?
+---@param first number|nil optional, index of first waypoint to use
+---@param last number|nil optional, index of last waypoint to use to construct of the course
 function Course:init(vehicle, waypoints, temporary, first, last)
 	-- add waypoints from current vehicle course
 	---@type Waypoint[]
@@ -1489,10 +1489,10 @@ function Course:calculateOffsetCourse(nVehicles, position, width, useSameTurnWid
 						offsetHeadlands[#offsetHeadlands].turnStart = true
 					end
 					addTurnsToCorners(offsetHeadlands, math.rad(60), true)
-					CourseGenerator.pointsToXzInPlace(offsetHeadlands)
+					local newHeadlandCourse = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(offsetHeadlands), true)
 					--- Applies the original field work course reference
-					Waypoint.applyOriginalMultiToolReference(offsetHeadlands, sIx, origHeadlandsCourse:getNumberOfWaypoints() )
-					offsetCourse:appendWaypoints(offsetHeadlands)
+					Waypoint.applyOriginalMultiToolReference(newHeadlandCourse.waypoints, sIx, origHeadlandsCourse:getNumberOfWaypoints() )
+					offsetCourse:append(newHeadlandCourse)
 					CpUtil.debugVehicle(CpDebug.DBG_COURSES, self.vehicle, 'Headland done %d', ix)
 				end
 			else

--- a/scripts/Waypoint.lua
+++ b/scripts/Waypoint.lua
@@ -101,6 +101,9 @@ function Waypoint:set(wp, cpIndex)
 	self.turnControls = table.copy(wp.turnControls)
 	self.dToNext = wp.dToNext
 	self.yRot = wp.yRot
+	--- Set, when generated for a multi tool course
+	self.originalMultiToolReference = wp.originalMultiToolReference
+	
 end
 
 --- Set from a generated waypoint (output of the course generator)
@@ -244,6 +247,31 @@ end
 function Waypoint:resetTurn()
 	self.turnEnd = false	
 	self.turnStart = false	
+end
+
+function Waypoint:setOriginalMultiToolReference(ix)
+	self.originalMultiToolReference = ix
+end
+
+--- Get's the reference waypoint of the original fieldwork course,
+--- if the waypoint is part of a multi tool course.
+---@return number|nil
+function Waypoint:getOriginalMultiToolReference()
+	return self.originalMultiToolReference
+end
+
+--- Makes sure the original fieldwork course waypoints are referenced here for multi tool course.
+--- The multi tool course might have more or less waypoints then the original.
+--- For a given section the closest reference point is linear interpolated.
+---@param wps table Waypoint section
+---@param sIx number First original field work course waypoint, that gets changed by this section
+---@param deltaIx number Number of waypoints of the original field work course section
+function Waypoint.applyOriginalMultiToolReference(wps, sIx, deltaIx)
+	local factor, dIx = deltaIx / #wps, 0
+	for ix=1, #wps do 
+		dIx = math.floor(ix * factor)
+		wps[ix]:setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
+	end
 end
 
 -- a node related to a waypoint

--- a/scripts/Waypoint.lua
+++ b/scripts/Waypoint.lua
@@ -270,7 +270,7 @@ function Waypoint.applyOriginalMultiToolReference(wps, sIx, deltaIx)
 	local factor, dIx = deltaIx / #wps, 0
 	for ix=1, #wps do 
 		dIx = math.floor(ix * factor)
-		wps[ix] = Waypoint.initFromGeneratedWp(wps[ix], ix):setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
+		wps[ix] = Waypoint.init(wps[ix], ix):setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
 	end
 end
 

--- a/scripts/Waypoint.lua
+++ b/scripts/Waypoint.lua
@@ -270,7 +270,7 @@ function Waypoint.applyOriginalMultiToolReference(wps, sIx, deltaIx)
 	local factor, dIx = deltaIx / #wps, 0
 	for ix=1, #wps do 
 		dIx = math.floor(ix * factor)
-		wps[ix] = Waypoint.init(wps[ix], ix):setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
+		wps[ix] = Waypoint(wps[ix], ix):setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
 	end
 end
 

--- a/scripts/Waypoint.lua
+++ b/scripts/Waypoint.lua
@@ -270,7 +270,7 @@ function Waypoint.applyOriginalMultiToolReference(wps, sIx, deltaIx)
 	local factor, dIx = deltaIx / #wps, 0
 	for ix=1, #wps do 
 		dIx = math.floor(ix * factor)
-		wps[ix] = Waypoint(wps[ix], ix):setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
+		wps[ix]:setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
 	end
 end
 

--- a/scripts/Waypoint.lua
+++ b/scripts/Waypoint.lua
@@ -270,7 +270,7 @@ function Waypoint.applyOriginalMultiToolReference(wps, sIx, deltaIx)
 	local factor, dIx = deltaIx / #wps, 0
 	for ix=1, #wps do 
 		dIx = math.floor(ix * factor)
-		wps[ix]:setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
+		wps[ix] = Waypoint.initFromGeneratedWp(wps[ix], ix):setOriginalMultiToolReference(math.max(1, dIx) + sIx-1)
 	end
 end
 

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -677,7 +677,16 @@ end
 function AIDriveStrategyFieldWorkCourse:updateCpStatus(status)
     ---@type Course
     if self.fieldWorkCourse then
-        status:setWaypointData(self.fieldWorkCourse:getCurrentWaypointIx(), self.fieldWorkCourse:getNumberOfWaypoints(), self.remainingTime:getText())
+        local ix = self.fieldWorkCourse:getCurrentWaypointIx()
+        local numWps = self.fieldWorkCourse:getNumberOfWaypoints()
+        if self.fieldWorkCourse:getMultiTools()>1 then 
+            numWps = self.vehicle:getFieldWorkCourse():getNumberOfWaypoints()
+            --- Find the closed waypoint to the vehicle
+            ix = self.fieldWorkCourse:getCurrentWaypointReferenceIx()
+           
+        end
+
+        status:setWaypointData(ix, numWps, self.remainingTime:getText())
     end
 end
 


### PR DESCRIPTION
Tries to hold onto an old reference ix from the original fieldwork waypoint, which should roughly be near the new offset waypoint for a multi tool course. This should prevent drifting of the field work course display, as the length for a multi tool course might be different of the original course used to display the progress.

Test: 
- Mutitool course with a lot of headlands