### PR TITLE
feat: recovery turn

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -991,10 +991,12 @@ end
 ---@param reverse boolean is this a reverse course?
 function Course.createFromNode(vehicle, referenceNode, xOffset, from, to, step, reverse)
 	local waypoints = {}
-	local nPoints = math.floor(math.abs((from - to) / step)) + 1
-	local dBetweenPoints = (to - from) / nPoints
+	local distance = math.abs(from - to)
+	-- if the distance < step, reduce step to the distance, so we have at least two waypoints.
+	local nPoints = math.floor(distance / math.min(distance, math.abs(step))) + 1
+	local dBetweenPoints = (to - from) / (nPoints - 1)
 	local dz = from
-	for i = 1, nPoints do
+	for i = 0, nPoints - 1 do
 		local x, _, z = localToWorld(referenceNode, xOffset, 0, dz + i * dBetweenPoints)
 		table.insert(waypoints, {x = x, z = z, rev = reverse})
 	end

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1321,13 +1321,13 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
             AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)
         elseif self.course:isOnOutermostHeadland(ix) and self:isTurnOnFieldActive() then
             self:debug('Creating a pocket in the corner so the combine stays on the field during the turn')
-            self.aiTurn = CombinePocketHeadlandTurn(self.vehicle, self, self.ppc, self.turnContext,
+            self.aiTurn = CombinePocketHeadlandTurn(self.vehicle, self, self.ppc, self.proximityController, self.turnContext,
                     self.course, self:getWorkWidth())
             self.state = self.states.TURNING
             self.ppc:setShortLookaheadDistance()
         else
             self:debug('Use combine headland turn.')
-            self.aiTurn = CombineHeadlandTurn(self.vehicle, self, self.ppc, self.turnContext)
+            self.aiTurn = CombineHeadlandTurn(self.vehicle, self, self.ppc, self.proximityController, self.turnContext)
             self.state = self.states.TURNING
         end
     else

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -490,12 +490,14 @@ end
 --- Attempt to recover from a turn where the vehicle got blocked. This replaces the current turn with a
 --- RecoveryTurn, which just backs up a bit and then uses the pathfinder to create a turn back to the
 --- start of the next row.
+---@param reverseDistance number|nil distance to back up before retrying pathfinding (default 10 m)
+---@param retryCount number|nil how many times have we tried to recover so far? (to limit the number of retries)
 ---@return boolean true if a recovery turn could be created
-function AIDriveStrategyFieldWorkCourse:startRecoveryTurn()
+function AIDriveStrategyFieldWorkCourse:startRecoveryTurn(reverseDistance, retryCount)
     self:debug('Blocked in a turn, attempt to recover')
     if self.turnContext then
         self.aiTurn = RecoveryTurn(self.vehicle, self, self.ppc, self.proximityController, self.turnContext,
-                self.course, self.workWidth)
+                self.course, self.workWidth, reverseDistance, retryCount)
         self.state = self.states.TURNING
         return true
     else

--- a/scripts/ai/AIDriveStrategyVineFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyVineFieldWorkCourse.lua
@@ -73,6 +73,6 @@ function AIDriveStrategyVineFieldWorkCourse:startTurn(ix)
 
     self.turnContext = TurnContext(self.vehicle, self.course, ix, ix + 1, self.turnNodes, self:getWorkWidth(),
             frontMarkerDistance, -backMarkerDistance, 0, 0)
-    self.aiTurn = VineTurn(self.vehicle, self, self.ppc, self.turnContext, self.course, self.workWidth)
+    self.aiTurn = VineTurn(self.vehicle, self, self.ppc, self.proximityController, self.turnContext, self.course, self.workWidth)
     self.state = self.states.TURNING
 end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -46,219 +46,229 @@ AITurn.debugChannel = CpDebug.DBG_TURN
 
 ---@field ppc PurePursuitController
 ---@field turnContext TurnContext
-function AITurn:init(vehicle, driveStrategy, ppc, turnContext, workWidth, name)
-	self:addState('INITIALIZING')
-	self:addState('FINISHING_ROW')
-	self:addState('TURNING')
-	self:addState('ENDING_TURN')
-	self:addState('REVERSING_AFTER_BLOCKED')
-	self:addState('FORWARDING_AFTER_BLOCKED')
-	self:addState('WAITING_FOR_PATHFINDER')
-	self.vehicle = vehicle
-	self.settings = vehicle:getCpSettings()
-	self.turningRadius = AIUtil.getTurningRadius(self.vehicle)
-	---@type PurePursuitController
-	self.ppc = ppc
-	self.workWidth = workWidth
-	---@type AIDriveStrategyFieldWorkCourse
-	self.driveStrategy = driveStrategy
-	-- turn handles its own waypoint changes
-	self.ppc:registerListeners(self, 'onWaypointPassed', 'onWaypointChange')
-	---@type TurnContext
-	self.turnContext = turnContext
-	self.reversingImplement, self.steeringLength = AIUtil.getSteeringParameters(self.vehicle)
-	self.state = self.states.INITIALIZING
-	self.name = name or 'AITurn'
+function AITurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext, workWidth, name)
+    self:addState('INITIALIZING')
+    self:addState('FINISHING_ROW')
+    self:addState('TURNING')
+    self:addState('ENDING_TURN')
+    self:addState('REVERSING_AFTER_BLOCKED')
+    self:addState('WAITING_FOR_PATHFINDER')
+    self.vehicle = vehicle
+    self.settings = vehicle:getCpSettings()
+    self.turningRadius = AIUtil.getTurningRadius(self.vehicle)
+    ---@type PurePursuitController
+    self.ppc = ppc
+    self.workWidth = workWidth
+    ---@type AIDriveStrategyFieldWorkCourse
+    self.driveStrategy = driveStrategy
+    ---@type ProximityController
+    self.proximityController = proximityController
+    self.proximityController:registerBlockingObjectListener(self, AITurn.onBlocked)
+    -- turn handles its own waypoint changes
+    self.ppc:registerListeners(self, 'onWaypointPassed', 'onWaypointChange')
+    ---@type TurnContext
+    self.turnContext = turnContext
+    self.reversingImplement, self.steeringLength = AIUtil.getSteeringParameters(self.vehicle)
+    self.state = self.states.INITIALIZING
+    self.name = name or 'AITurn'
+    self.blocked = false
 end
 
 function AITurn:addState(state)
-	if not self.states then self.states = {} end
-	self.states[state] = {name = state}
+    if not self.states then
+        self.states = {}
+    end
+    self.states[state] = { name = state }
 end
 
 function AITurn:debug(...)
-	CpUtil.debugVehicle(self.debugChannel, self.vehicle, self.name .. ' state: ' .. self.state.name .. ' ' .. string.format( ... ))
+    CpUtil.debugVehicle(self.debugChannel, self.vehicle, self.name .. ' state: ' .. self.state.name .. ' ' .. string.format(...))
 end
 
 --- Start the actual turn maneuver after the row is finished
 function AITurn:startTurn()
-	-- implement in derived classes
-	-- self.vehicle:raiseAIEvent("onAIFieldWorkerStartTurn", "onAIImplementStartTurn", self.turnContext:isLeftTurn(), turnStrategy)
+    -- implement in derived classes
+    -- self.vehicle:raiseAIEvent("onAIFieldWorkerStartTurn", "onAIImplementStartTurn", self.turnContext:isLeftTurn(), turnStrategy)
 end
 
 --- Stuff we need to do during the turn no matter what turn type we are using
 function AITurn:turn()
-	-- TODO_22: the giants combine strategy should probably handle this too
-	--if self.driveStrategy:holdInTurnManeuver(false, self.turnContext:isHeadlandCorner()) then
-		-- tell driver to stop if unloading or whatever
-	--	self.driveStrategy:setSpeed(0)
-	--end
-	return nil, nil, nil, self:getForwardSpeed()
+    return nil, nil, nil, self:getForwardSpeed()
 end
 
 function AITurn:onBlocked()
-	self:debug('onBlocked()')
+    -- will only try to recover once, so unregister here
+    self.proximityController:unregisterBlockingObjectListener()
+    self.driveStrategy:startRecoveryTurn()
 end
 
 function AITurn:onWaypointChange(ix)
-	self:debug('onWaypointChange %d', ix)
-	if self.driveStrategy and self.driveStrategy.isWorking and self.driveStrategy:isWorking() then
-		-- make sure to set the proper X offset if applicable (for turning plows for example)
-		self.driveStrategy:setOffsetX()
-	end
+    self:debug('onWaypointChange %d', ix)
+    if self.driveStrategy and self.driveStrategy.isWorking and self.driveStrategy:isWorking() then
+        -- make sure to set the proper X offset if applicable (for turning plows for example)
+        self.driveStrategy:setOffsetX()
+    end
 end
 
 function AITurn:onWaypointPassed(ix, course)
-	self:debug('onWaypointPassed %d', ix)
-	if ix == course:getNumberOfWaypoints() and self.state == self.states.ENDING_TURN then
-		self:debug('Last waypoint reached, resuming fieldwork')
-		self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
-	end
+    self:debug('onWaypointPassed %d', ix)
+    if ix == course:getNumberOfWaypoints() and self.state == self.states.ENDING_TURN then
+        self:debug('Last waypoint reached, resuming fieldwork')
+        self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+    end
 end
 
 --- Is a K turn allowed.
----@param vehicle Vehicle
+---@param vehicle table
 ---@param turnContext TurnContext
 ---@param workWidth number
 ---@param turnOnField boolean is turn on field allowed
 ---@return boolean
 function AITurn.canMakeKTurn(vehicle, turnContext, workWidth, turnOnField)
-	if turnContext:isHeadlandCorner() then
-		CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Headland turn, not doing a 3 point turn.')
-		return false
-	end
-	local turningRadius = AIUtil.getTurningRadius(vehicle)
-	if math.abs(turnContext.dx) > 2 * turningRadius then
-		CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Next row is too far (%.1f, turning radius is %.1f), no 3 point turn',
-			turnContext.dx, turningRadius)
-		return false
-	end
-	if not AIVehicleUtil.getAttachedImplementsAllowTurnBackward(vehicle) then
-		CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Not all attached implements allow for reversing, use generated course turn')
-		return false
-	end
-	if SpecializationUtil.hasSpecialization(ArticulatedAxis, vehicle.specializations) then
-		CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Has articulated axis, use generated course turn')
-		return false
-	end
-	local reversingImplement, _ = AIUtil.getSteeringParameters(vehicle)
-	if reversingImplement then
-		CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Have a towed implement, use generated course turn')
-		return false
-	end
+    if turnContext:isHeadlandCorner() then
+        CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Headland turn, not doing a 3 point turn.')
+        return false
+    end
+    local turningRadius = AIUtil.getTurningRadius(vehicle)
+    if math.abs(turnContext.dx) > 2 * turningRadius then
+        CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Next row is too far (%.1f, turning radius is %.1f), no 3 point turn',
+                turnContext.dx, turningRadius)
+        return false
+    end
+    if not AIVehicleUtil.getAttachedImplementsAllowTurnBackward(vehicle) then
+        CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Not all attached implements allow for reversing, use generated course turn')
+        return false
+    end
+    if SpecializationUtil.hasSpecialization(ArticulatedAxis, vehicle.specializations) then
+        CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Has articulated axis, use generated course turn')
+        return false
+    end
+    local reversingImplement, _ = AIUtil.getSteeringParameters(vehicle)
+    if reversingImplement then
+        CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Have a towed implement, use generated course turn')
+        return false
+    end
 
-	if turnOnField and
-			not AITurn.canTurnOnField(turnContext, vehicle, workWidth, turningRadius) then
-		CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Turn on field is on but there is not enough room to stay on field with a 3 point turn')
-		return false
-	end
-	CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Can make a 3 point turn')
-	return true
+    if turnOnField and
+            not AITurn.canTurnOnField(turnContext, vehicle, workWidth, turningRadius) then
+        CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Turn on field is on but there is not enough room to stay on field with a 3 point turn')
+        return false
+    end
+    CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Can make a 3 point turn')
+    return true
 end
 
 ---@param turnContext TurnContext
 ---@return boolean, number True if there's enough space to make a forward turn on the field. Also return the
 ---distance to reverse in order to be able to just make the turn on the field
 function AITurn.canTurnOnField(turnContext, vehicle, workWidth, turningRadius)
-	local spaceNeededOnFieldForTurn = turningRadius + workWidth / 2
-	local distanceToFieldEdge = turnContext:getDistanceToFieldEdge(turnContext.vehicleAtTurnStartNode)
-	CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Space needed to turn on field %.1f m', spaceNeededOnFieldForTurn)
-	if distanceToFieldEdge then
-		return (distanceToFieldEdge > spaceNeededOnFieldForTurn), spaceNeededOnFieldForTurn - distanceToFieldEdge
-	else
-		return false, 0
-	end
+    local spaceNeededOnFieldForTurn = turningRadius + workWidth / 2
+    local distanceToFieldEdge = turnContext:getDistanceToFieldEdge(turnContext.vehicleAtTurnStartNode)
+    CpUtil.debugVehicle(AITurn.debugChannel, vehicle, 'Space needed to turn on field %.1f m', spaceNeededOnFieldForTurn)
+    if distanceToFieldEdge then
+        return (distanceToFieldEdge > spaceNeededOnFieldForTurn), spaceNeededOnFieldForTurn - distanceToFieldEdge
+    else
+        return false, 0
+    end
 end
 
 function AITurn:getForwardSpeed()
-	return self.settings.turnSpeed:getValue()
+    return self.settings.turnSpeed:getValue()
 end
 
 function AITurn:getReverseSpeed()
-	return self.settings.reverseSpeed:getValue()
+    return self.settings.reverseSpeed:getValue()
 end
 
 function AITurn:isForwardOnly()
-	return false
+    return false
 end
 
 function AITurn:isFinishingRow()
-	return self.state == self.states.FINISHING_ROW
+    return self.state == self.states.FINISHING_ROW
 end
 
 function AITurn:isEndingTurn()
-	-- include the direction too because some turns go to the ENDING_TURN state very early, while still driving
-	-- perpendicular to the row. This way this returns true really only when we are about to end the turn
-	return self.state == self.states.ENDING_TURN and self.turnContext:isDirectionCloseToEndDirection(self.vehicle:getAIDirectionNode(), 15)
+    -- include the direction too because some turns go to the ENDING_TURN state very early, while still driving
+    -- perpendicular to the row. This way this returns true really only when we are about to end the turn
+    return self.state == self.states.ENDING_TURN and self.turnContext:isDirectionCloseToEndDirection(self.vehicle:getAIDirectionNode(), 15)
 end
 
 -- get a virtual goal point position for a turn performed with full steering angle to the left or right (or straight)
 ---@param moveForwards boolean move forward when true, backwards otherwise
 ---@param isLeftTurn boolean turn to the right or left, or straight when nil
 function AITurn:getGoalPointForTurn(moveForwards, isLeftTurn)
-	local dx, dz
-	if isLeftTurn == nil then
-		dx = 0
-		dz = moveForwards and self.ppc:getLookaheadDistance() or -self.ppc:getLookaheadDistance()
-	else
-		dx = isLeftTurn and self.ppc:getLookaheadDistance() or -self.ppc:getLookaheadDistance()
-		dz = moveForwards and 1 or -1
-	end
-	local gx, _, gz = localToWorld(self.vehicle:getAIDirectionNode(), dx, 0, dz)
-	return gx, gz
+    local dx, dz
+    if isLeftTurn == nil then
+        dx = 0
+        dz = moveForwards and self.ppc:getLookaheadDistance() or -self.ppc:getLookaheadDistance()
+    else
+        dx = isLeftTurn and self.ppc:getLookaheadDistance() or -self.ppc:getLookaheadDistance()
+        dz = moveForwards and 1 or -1
+    end
+    local gx, _, gz = localToWorld(self.vehicle:getAIDirectionNode(), dx, 0, dz)
+    return gx, gz
 end
 
 function AITurn:getDriveData(dt)
-	local maxSpeed = self:getForwardSpeed()
-	local gx, gz, moveForwards
-	if self.state == self.states.INITIALIZING then
-		local rowFinishingCourse = self.turnContext:createFinishingRowCourse(self.vehicle)
-		self.ppc:setCourse(rowFinishingCourse)
-		self.ppc:initialize(1)
-		self.state = self.states.FINISHING_ROW
-		-- Finishing the current row
-	elseif self.state == self.states.FINISHING_ROW then
-		self:finishRow(dt)
-	elseif self.state == self.states.ENDING_TURN then
-		-- Ending the turn (starting next row)
-		local allowedToDrive = self:endTurn(dt)
-		if not allowedToDrive then
-			maxSpeed = 0
-		end
-	elseif self.state == self.states.WAITING_FOR_PATHFINDER then
-		maxSpeed = 0
-	else
-		-- Performing the actual turn
-		gx, gz, moveForwards, maxSpeed = self:turn(dt)
-	end
-	return gx, gz, moveForwards, maxSpeed
+    local maxSpeed = self:getForwardSpeed()
+    local gx, gz, moveForwards
+    if self.state == self.states.INITIALIZING then
+        local rowFinishingCourse = self.turnContext:createFinishingRowCourse(self.vehicle)
+        self.ppc:setCourse(rowFinishingCourse)
+        self.ppc:initialize(1)
+        self.state = self.states.FINISHING_ROW
+        -- Finishing the current row
+    elseif self.state == self.states.FINISHING_ROW then
+        self:finishRow(dt)
+    elseif self.state == self.states.ENDING_TURN then
+        -- Ending the turn (starting next row)
+        local allowedToDrive = self:endTurn(dt)
+        if not allowedToDrive then
+            maxSpeed = 0
+        end
+    elseif self.state == self.states.WAITING_FOR_PATHFINDER then
+        maxSpeed = 0
+    else
+        -- Performing the actual turn
+        gx, gz, moveForwards, maxSpeed = self:turn(dt)
+    end
+    return gx, gz, moveForwards, maxSpeed
 end
 
 -- default for 180 turns: we need to raise the implement (when finishing a row) when we reach the
 -- workEndNode.
 function AITurn:getRaiseImplementNode()
-	return self.turnContext.workEndNode
+    return self.turnContext.workEndNode
 end
 
 function AITurn:finishRow(dt)
-	-- keep driving straight until we need to raise our implements
-	if self.driveStrategy:shouldRaiseImplements(self:getRaiseImplementNode()) then
-		self.driveStrategy:raiseImplements()
-		self:debug('Row finished, starting turn.')
-		self:startTurn()
-	end
+    -- keep driving straight until we need to raise our implements
+    if self.driveStrategy:shouldRaiseImplements(self:getRaiseImplementNode()) then
+        self.driveStrategy:raiseImplements()
+        self:debug('Row finished, starting turn.')
+        self:startTurn()
+    end
 end
 
 ---@return boolean true if it is ok the continue driving, false when the vehicle should stop
 function AITurn:endTurn(dt)
-	-- keep driving on the turn ending temporary course until we need to lower our implements
-	-- check implements only if we are more or less in the right direction (next row's direction)
-	if self.turnContext:isDirectionCloseToEndDirection(self.vehicle:getAIDirectionNode(), 30) and
-		self.driveStrategy:shouldLowerImplements(self.turnContext.turnEndWpNode.node, false) then
-		self:debug('Turn ended, resume fieldwork')
-		self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
-	end
-	return true
+    -- keep driving on the turn ending temporary course until we need to lower our implements
+    -- check implements only if we are more or less in the right direction (next row's direction)
+    if self.turnContext:isDirectionCloseToEndDirection(self.vehicle:getAIDirectionNode(), 30) and
+            self.driveStrategy:shouldLowerImplements(self.turnContext.turnEndWpNode.node, false) then
+        self:debug('Turn ended, resume fieldwork')
+        self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+    end
+    return true
+end
+
+--- Give back control the the drive strategy
+function AITurn:resumeFieldworkAfterTurn(ix, forceIx)
+    if self.proximityController then
+        self.proximityController:unregisterBlockingObjectListener()
+    end
+    self.driveStrategy:resumeFieldworkAfterTurn(ix, forceIx)
 end
 
 function AITurn:drawDebug()
@@ -273,126 +283,90 @@ in the turn end phase.
 ---@class KTurn : AITurn
 KTurn = CpObject(AITurn)
 
-function KTurn:init(vehicle, strategy, ppc, turnContext, workWidth)
-	AITurn.init(self, vehicle, strategy, ppc, turnContext, workWidth, 'KTurn')
-	self:addState('FORWARD')
-	self:addState('REVERSE')
-	self:addState('FORWARD_ARC')
-	self.blocked = CpTemporaryObject(false)
-	self.blocked:set(false, 1)
+function KTurn:init(vehicle, strategy, ppc, proximityController, turnContext, workWidth)
+    AITurn.init(self, vehicle, strategy, ppc, proximityController, turnContext, workWidth, 'KTurn')
+    self:addState('FORWARD')
+    self:addState('REVERSE')
+    self:addState('FORWARD_ARC')
 end
 
 function KTurn:onWaypointChange(ix)
-	-- ending part of the K turn is driving on the course end, so revert to the default
-	if self.state == self.states.ENDING_TURN then
-		AITurn.onWaypointChange(self, ix)
-	end
+    -- ending part of the K turn is driving on the course end, so revert to the default
+    if self.state == self.states.ENDING_TURN then
+        AITurn.onWaypointChange(self, ix)
+    end
 end
 
 function KTurn:onWaypointPassed(ix, course)
-	-- ending part of the K turn is driving on the course end, so revert to the default
-	if self.state == self.states.ENDING_TURN then
-		AITurn.onWaypointPassed(self, ix, course)
-	end
+    -- ending part of the K turn is driving on the course end, so revert to the default
+    if self.state == self.states.ENDING_TURN then
+        AITurn.onWaypointPassed(self, ix, course)
+    end
 end
 
 function KTurn:startTurn()
-	AITurn.startTurn(self)
-	self.state = self.states.FORWARD
-	self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", 0, self.turnContext:isLeftTurn())
-	self:debug('Turn progress 0')
+    AITurn.startTurn(self)
+    self.state = self.states.FORWARD
+    self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", 0, self.turnContext:isLeftTurn())
+    self:debug('Turn progress 0')
 end
 
 function KTurn:turn(dt)
-	-- we end the K turn with a temporary course leading straight into the next row. During this turn the
-	-- AI driver's state remains TURNING and thus calls AITurn:drive() which wil take care of raising the implements
-	local endTurn = function(course)
-		self:debug('Turn progress 100')
-		self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", 100, self.turnContext:isLeftTurn())
-		self.state = self.states.ENDING_TURN
-		self.ppc:setCourse(course)
-		self.ppc:initialize(1)
-	end
+    -- we end the K turn with a temporary course leading straight into the next row. During this turn the
+    -- AI driver's state remains TURNING and thus calls AITurn:drive() which wil take care of raising the implements
+    local endTurn = function(course)
+        self:debug('Turn progress 100')
+        self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", 100, self.turnContext:isLeftTurn())
+        self.state = self.states.ENDING_TURN
+        self.ppc:setCourse(course)
+        self.ppc:initialize(1)
+    end
 
-	local gx, gz, maxSpeed, moveForwards
-	if self.state == self.states.FORWARD then
-		local dx, _, dz = self.turnContext:getLocalPositionFromTurnEnd(self.vehicle:getAIDirectionNode())
-		maxSpeed = self:getForwardSpeed()
-		moveForwards = true
-		if dz > -math.max(0, math.max(2, self.turnContext.frontMarkerDistance)) then
-			-- drive straight until we are beyond the turn end (or, if the implement is mounted on the front,
-			-- make sure we end up at least 2 meters before the row start to have time to straighten out, so there
-			-- is no fruit missed)
-			gx, gz = self:getGoalPointForTurn(moveForwards, nil)
-		elseif not self.turnContext:isDirectionPerpendicularToTurnEndDirection(self.vehicle:getAIDirectionNode()) then
-			-- full turn towards the turn end waypoint
-			gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
-		else
-			-- drive straight ahead until we cross turn end line
-			gx, gz = self:getGoalPointForTurn(moveForwards, nil)
-			if self.turnContext:isLateralDistanceGreater(dx, self.turningRadius * 1.05) then
-				-- no need to reverse from here, we can make the turn
-				self.endingTurnCourse = TurnEndingManeuver(self.vehicle, self.turnContext,
-						self.vehicle:getAIDirectionNode(), self.turningRadius, self.workWidth, 0):getCourse()
-				self:debug('K Turn: dx = %.1f, r = %.1f, no need to reverse.', dx, self.turningRadius)
-				endTurn(self.endingTurnCourse)
-			else
-				-- reverse until we can make turn to the turn end point
-				self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", 50, self.turnContext:isLeftTurn())
-				self:debug('Turn progress 50')
-				self.state = self.states.REVERSE
-				self.endingTurnCourse = TurnEndingManeuver(self.vehicle, self.turnContext,
-						self.vehicle:getAIDirectionNode(), self.turningRadius, self.workWidth, 0):getCourse()
-				self:debug('K Turn: dx = %.1f, r = %.1f, reversing now.', dx, self.turningRadius)
-			end
-		end
-	elseif self.state == self.states.REVERSE then
-		-- reversing parallel to the direction between the turn start and turn end waypoints
-		moveForwards = false
-		maxSpeed = self:getReverseSpeed()
-		gx, gz = self:getGoalPointForTurn(moveForwards, nil)
-		local _, _, dz = self.endingTurnCourse:getWaypointLocalPosition(self.vehicle:getAIDirectionNode(), 1)
-		if dz > 0  then
-			-- we can make the turn from here
-			self:debug('K Turn ending turn')
-			endTurn(self.endingTurnCourse)
-		end
-	elseif self.state == self.states.REVERSING_AFTER_BLOCKED then
-		moveForwards = false
-		maxSpeed = self:getReverseSpeed()
-		-- TODO_22 here we should not fully steer to recover, see if this is still needed
-		gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
-		if not self.blocked:get() then
-			self.state = self.stateAfterBlocked
-			self:debug('Trying again after reversed due to being blocked')
-		end
-	elseif self.state == self.states.FORWARDING_AFTER_BLOCKED then
-		maxSpeed = self:getForwardSpeed()
-		moveForwards = true
-		-- TODO_22 here we should not fully steer to recover, see if this is still needed
-		gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
-		if not self.blocked:get() then
-			self.state = self.stateAfterBlocked
-			self:debug('Trying again after forwarded due to being blocked')
-		end
-	end
-	return gx, gz, moveForwards, maxSpeed
-end
-
-function KTurn:onBlocked()
-	if self.driveStrategy:holdInTurnManeuver(false, self.turnContext:isHeadlandCorner()) then
-		-- not really blocked just waiting for the straw for example
-		return
-	end
-	self.stateAfterBlocked = self.state
-	self.blocked:set(true, 3500)
-	if self.state == self.states.REVERSE then
-		self.state = self.states.FORWARDING_AFTER_BLOCKED
-		self:debug('Blocked, try forwarding a bit')
-	elseif self.state == self.states.FORWARD then
-		self.state = self.states.REVERSING_AFTER_BLOCKED
-		self:debug('Blocked, try reversing a bit')
-	end
+    local gx, gz, maxSpeed, moveForwards
+    if self.state == self.states.FORWARD then
+        local dx, _, dz = self.turnContext:getLocalPositionFromTurnEnd(self.vehicle:getAIDirectionNode())
+        maxSpeed = self:getForwardSpeed()
+        moveForwards = true
+        if dz > -math.max(0, math.max(2, self.turnContext.frontMarkerDistance)) then
+            -- drive straight until we are beyond the turn end (or, if the implement is mounted on the front,
+            -- make sure we end up at least 2 meters before the row start to have time to straighten out, so there
+            -- is no fruit missed)
+            gx, gz = self:getGoalPointForTurn(moveForwards, nil)
+        elseif not self.turnContext:isDirectionPerpendicularToTurnEndDirection(self.vehicle:getAIDirectionNode()) then
+            -- full turn towards the turn end waypoint
+            gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
+        else
+            -- drive straight ahead until we cross turn end line
+            gx, gz = self:getGoalPointForTurn(moveForwards, nil)
+            if self.turnContext:isLateralDistanceGreater(dx, self.turningRadius * 1.05) then
+                -- no need to reverse from here, we can make the turn
+                self.endingTurnCourse = TurnEndingManeuver(self.vehicle, self.turnContext,
+                        self.vehicle:getAIDirectionNode(), self.turningRadius, self.workWidth, 0):getCourse()
+                self:debug('K Turn: dx = %.1f, r = %.1f, no need to reverse.', dx, self.turningRadius)
+                endTurn(self.endingTurnCourse)
+            else
+                -- reverse until we can make turn to the turn end point
+                self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", 50, self.turnContext:isLeftTurn())
+                self:debug('Turn progress 50')
+                self.state = self.states.REVERSE
+                self.endingTurnCourse = TurnEndingManeuver(self.vehicle, self.turnContext,
+                        self.vehicle:getAIDirectionNode(), self.turningRadius, self.workWidth, 0):getCourse()
+                self:debug('K Turn: dx = %.1f, r = %.1f, reversing now.', dx, self.turningRadius)
+            end
+        end
+    elseif self.state == self.states.REVERSE then
+        -- reversing parallel to the direction between the turn start and turn end waypoints
+        moveForwards = false
+        maxSpeed = self:getReverseSpeed()
+        gx, gz = self:getGoalPointForTurn(moveForwards, nil)
+        local _, _, dz = self.endingTurnCourse:getWaypointLocalPosition(self.vehicle:getAIDirectionNode(), 1)
+        if dz > 0 then
+            -- we can make the turn from here
+            self:debug('K Turn ending turn')
+            endTurn(self.endingTurnCourse)
+        end
+    end
+    return gx, gz, moveForwards, maxSpeed
 end
 
 --[[
@@ -408,109 +382,78 @@ CombineHeadlandTurn = CpObject(AITurn)
 
 ---@param driveStrategy AIDriveStrategyFieldWorkCourse
 ---@param turnContext TurnContext
-function CombineHeadlandTurn:init(vehicle, driveStrategy, ppc, turnContext)
-	AITurn.init(self, vehicle, driveStrategy, ppc, turnContext, 'CombineHeadlandTurn')
-	self:addState('FORWARD')
-	self:addState('REVERSE_STRAIGHT')
-	self:addState('REVERSE_ARC')
-	self.turningRadius = AIUtil.getTurningRadius(self.vehicle)
-	self.cornerAngleToTurn = turnContext:getCornerAngleToTurn()
-	-- half the turn angle but not less than 45
-	self.angleToTurnInReverse = math.max(math.pi / 4, math.abs(self.cornerAngleToTurn / 2))
-	self.dxToStartReverseTurn = self.turningRadius - math.abs(self.turningRadius - self.turningRadius * math.cos(self.cornerAngleToTurn))
-	self.blocked = CpTemporaryObject(false)
-	self.blocked:set(false, 1)
+function CombineHeadlandTurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext)
+    AITurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, 'CombineHeadlandTurn')
+    self:addState('FORWARD')
+    self:addState('REVERSE_STRAIGHT')
+    self:addState('REVERSE_ARC')
+    self.turningRadius = AIUtil.getTurningRadius(self.vehicle)
+    self.cornerAngleToTurn = turnContext:getCornerAngleToTurn()
+    -- half the turn angle but not less than 45
+    self.angleToTurnInReverse = math.max(math.pi / 4, math.abs(self.cornerAngleToTurn / 2))
+    self.dxToStartReverseTurn = self.turningRadius - math.abs(self.turningRadius - self.turningRadius * math.cos(self.cornerAngleToTurn))
 end
 
 function CombineHeadlandTurn:startTurn()
-	self.state = self.states.FORWARD
-	self:debug('Starting combine headland turn')
+    self.state = self.states.FORWARD
+    self:debug('Starting combine headland turn')
 end
 
 function CombineHeadlandTurn:onWaypointChange(ix, course)
-	-- nothing to do
+    -- nothing to do
 end
 
 function CombineHeadlandTurn:onWaypointPassed(ix, course)
-	-- nothing to do, especially because the row finishing course is still active in the PPC and we may
-	-- pass the last waypoint which causes the turn to end and return to field work
+    -- nothing to do, especially because the row finishing course is still active in the PPC and we may
+    -- pass the last waypoint which causes the turn to end and return to field work
 end
 
 -- in a combine headland turn we want to raise the header after it reached the field edge (or headland edge on an inner
 -- headland.
 function CombineHeadlandTurn:getRaiseImplementNode()
-	return self.turnContext.lateWorkEndNode
+    return self.turnContext.lateWorkEndNode
 end
 
 function CombineHeadlandTurn:turn(dt)
-	local gx, gz, moveForwards, maxSpeed = AITurn.turn(self)
-	local dx, _, dz = self.turnContext:getLocalPositionFromTurnEnd(self.vehicle:getAIDirectionNode())
-	local angleToTurnEnd = math.abs(self.turnContext:getAngleToTurnEndDirection(self.vehicle:getAIDirectionNode()))
-	if self.state == self.states.FORWARD then
-		maxSpeed = self:getForwardSpeed()
-		moveForwards = true
-		if angleToTurnEnd > self.angleToTurnInReverse then --and not self.turnContext:isLateralDistanceLess(dx, self.dxToStartReverseTurn) then
-			-- full turn towards the turn end direction
-			gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
-		else
-			-- reverse until we can make turn to the turn end point
-			self.state = self.states.REVERSE_STRAIGHT
-			self:debug('Combine headland turn start reversing straight')
-		end
+    local gx, gz, moveForwards, maxSpeed = AITurn.turn(self)
+    local dx, _, dz = self.turnContext:getLocalPositionFromTurnEnd(self.vehicle:getAIDirectionNode())
+    local angleToTurnEnd = math.abs(self.turnContext:getAngleToTurnEndDirection(self.vehicle:getAIDirectionNode()))
+    if self.state == self.states.FORWARD then
+        maxSpeed = self:getForwardSpeed()
+        moveForwards = true
+        if angleToTurnEnd > self.angleToTurnInReverse then
+            --and not self.turnContext:isLateralDistanceLess(dx, self.dxToStartReverseTurn) then
+            -- full turn towards the turn end direction
+            gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
+        else
+            -- reverse until we can make turn to the turn end point
+            self.state = self.states.REVERSE_STRAIGHT
+            self:debug('Combine headland turn start reversing straight')
+        end
 
-	elseif self.state == self.states.REVERSE_STRAIGHT then
-		maxSpeed = self:getReverseSpeed()
-		moveForwards = false
-		gx, gz = self:getGoalPointForTurn(moveForwards, nil)
-		if math.abs(dx) < 0.2  then
-			self.state = self.states.REVERSE_ARC
-			self:debug('Combine headland turn start reversing arc')
-		end
+    elseif self.state == self.states.REVERSE_STRAIGHT then
+        maxSpeed = self:getReverseSpeed()
+        moveForwards = false
+        gx, gz = self:getGoalPointForTurn(moveForwards, nil)
+        if math.abs(dx) < 0.2 then
+            self.state = self.states.REVERSE_ARC
+            self:debug('Combine headland turn start reversing arc')
+        end
 
-	elseif self.state == self.states.REVERSE_ARC then
-		maxSpeed = self:getReverseSpeed()
-		moveForwards = false
-		gx, gz = self:getGoalPointForTurn(moveForwards, not self.turnContext:isLeftTurn())
-		if angleToTurnEnd < math.rad(20) then
-			self.state = self.states.ENDING_TURN
-			self:debug('Combine headland turn forwarding again')
-			-- lower implements here unconditionally (regardless of the direction, self:endTurn() would wait until we
-			-- are pointing to the turn target direction)
-			self.driveStrategy:lowerImplements()
-			self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
-		end
-	elseif self.state == self.states.REVERSING_AFTER_BLOCKED then
-		maxSpeed = self:getReverseSpeed()
-		moveForwards = false
-		-- TODO: may need to steer less...
-		gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
-		if not self.blocked:get() then
-			self.state = self.stateAfterBlocked
-			self:debug('Trying again after reversed due to being blocked')
-		end
-	elseif self.state == self.states.FORWARDING_AFTER_BLOCKED then
-		maxSpeed = self:getForwardSpeed()
-		moveForwards = true
-		-- TODO: may need to steer less...
-		gx, gz = self:getGoalPointForTurn(moveForwards, self.turnContext:isLeftTurn())
-		if not self.blocked:get() then
-			self.state = self.stateAfterBlocked
-			self:debug('Trying again after forwarded due to being blocked')
-		end
-	end
-	return gx, gz, moveForwards, maxSpeed
-end
-
-function CombineHeadlandTurn:onBlocked()
-	self.stateAfterBlocked = self.state
-	self.blocked:set(true, 3500)
-	if self.state == self.states.REVERSE_ARC or self.state == self.states.REVERSE_STRAIGHT then
-		self.state = self.states.FORWARDING_AFTER_BLOCKED
-		self:debug('Blocked, try forwarding a bit')
-	else
-		self.state = self.states.REVERSING_AFTER_BLOCKED
-		self:debug('Blocked, try reversing a bit')
-	end
+    elseif self.state == self.states.REVERSE_ARC then
+        maxSpeed = self:getReverseSpeed()
+        moveForwards = false
+        gx, gz = self:getGoalPointForTurn(moveForwards, not self.turnContext:isLeftTurn())
+        if angleToTurnEnd < math.rad(20) then
+            self.state = self.states.ENDING_TURN
+            self:debug('Combine headland turn forwarding again')
+            -- lower implements here unconditionally (regardless of the direction, self:endTurn() would wait until we
+            -- are pointing to the turn target direction)
+            self.driveStrategy:lowerImplements()
+            self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+        end
+    end
+    return gx, gz, moveForwards, maxSpeed
 end
 
 --[[
@@ -520,27 +463,27 @@ A turn maneuver following a course (waypoints created by turn.lua)
 ---@class CourseTurn : AITurn
 CourseTurn = CpObject(AITurn)
 ---@param fieldWorkCourse Course needed only when generating a pathfinder turn, this is where it gets the headland
-function CourseTurn:init(vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, name)
-	AITurn.init(self, vehicle, driveStrategy, ppc, turnContext, workWidth, name or 'CourseTurn')
+function CourseTurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, name)
+    AITurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, workWidth, name or 'CourseTurn')
 
-	self.forceTightTurnOffset = false
-	self.enableTightTurnOffset = false
-	self.fieldWorkCourse = fieldWorkCourse
+    self.forceTightTurnOffset = false
+    self.enableTightTurnOffset = false
+    self.fieldWorkCourse = fieldWorkCourse
 end
 
 function CourseTurn:getForwardSpeed()
-	if self.turnCourse then
-		local currentWpIx = self.turnCourse:getCurrentWaypointIx()
-		if self.turnCourse:getDistanceFromFirstWaypoint(currentWpIx) > 10 and
-			-- TODO: Instead of a fixed value for DistanceToLastWaypoint, consider the radius of the waypoints to calculate the maximum speed.
-				self.turnCourse:getDistanceToLastWaypoint(currentWpIx) > 20 then
-			-- in the middle of a long turn maneuver we can drive faster...
-			return self.settings.fieldSpeed:getValue()
-		else
-			return AITurn.getForwardSpeed(self)
-		end
-	end
-	return AITurn.getForwardSpeed(self)
+    if self.turnCourse then
+        local currentWpIx = self.turnCourse:getCurrentWaypointIx()
+        if self.turnCourse:getDistanceFromFirstWaypoint(currentWpIx) > 10 and
+                -- TODO: Instead of a fixed value for DistanceToLastWaypoint, consider the radius of the waypoints to calculate the maximum speed.
+                self.turnCourse:getDistanceToLastWaypoint(currentWpIx) > 20 then
+            -- in the middle of a long turn maneuver we can drive faster...
+            return self.settings.fieldSpeed:getValue()
+        else
+            return AITurn.getForwardSpeed(self)
+        end
+    end
+    return AITurn.getForwardSpeed(self)
 end
 
 -- this turn starts when the vehicle reached the point where the implements are raised.
@@ -580,130 +523,130 @@ end
 --      = if turn on field setting is off, use pathfinder turns if enabled in settings, calculated turns otherwise
 --
 function CourseTurn:startTurn()
-	AITurn.startTurn(self)
-	local canTurnOnField = AITurn.canTurnOnField(self.turnContext, self.vehicle, self.workWidth, self.turningRadius)
-	if self.turnContext:isHeadlandCorner() then
-		self:debug('Starting a headland corner turn')
-		self:generateCalculatedTurn()
-		self.state = self.states.TURNING
-	elseif self.turnContext:isPathfinderTurn(2 * self.turningRadius, self.workWidth) then
-		self:debug('Starting a pathfinder turn on headland')
-		self:generatePathfinderTurn(true)
-	elseif canTurnOnField then
-		if self.settings.allowPathfinderTurns:getValue() then
-			self:debug('Starting a pathfinder turn: plenty of room on field to turn and pathfinder turns are enabled')
-			self:generatePathfinderTurn(false)
-		else
-			self:debug('Starting a calculated turn: plenty of room on field to turn and pathfinder turns are disabled')
-			self:generateCalculatedTurn()
-			self.state = self.states.TURNING
-		end
-	else
-		if self.driveStrategy:isTurnOnFieldActive() then
-			self:debug('Starting a calculated turn: not enough room on field to turn but turn on field is on')
-			self:generateCalculatedTurn()
-			self.state = self.states.TURNING
-		elseif not self.settings.allowPathfinderTurns:getValue() then
-			self:debug('Starting a calculated turn: not enough room on field to turn but turn on field is off and pathfinder turns are disabled')
-			self:generateCalculatedTurn()
-			self.state = self.states.TURNING
-		else
-			self:debug('Starting a pathfinder turn: not enough room on field to turn, turn on field is or pathfinder turns are enabled')
-			self:generatePathfinderTurn(false)
-		end
-	end
-	if self.state == self.states.TURNING then
-		self.ppc:setCourse(self.turnCourse)
-		self.ppc:initialize(1)
-	end
+    AITurn.startTurn(self)
+    local canTurnOnField = AITurn.canTurnOnField(self.turnContext, self.vehicle, self.workWidth, self.turningRadius)
+    if self.turnContext:isHeadlandCorner() then
+        self:debug('Starting a headland corner turn')
+        self:generateCalculatedTurn()
+        self.state = self.states.TURNING
+    elseif self.turnContext:isPathfinderTurn(2 * self.turningRadius, self.workWidth) then
+        self:debug('Starting a pathfinder turn on headland')
+        self:generatePathfinderTurn(true)
+    elseif canTurnOnField then
+        if self.settings.allowPathfinderTurns:getValue() then
+            self:debug('Starting a pathfinder turn: plenty of room on field to turn and pathfinder turns are enabled')
+            self:generatePathfinderTurn(false)
+        else
+            self:debug('Starting a calculated turn: plenty of room on field to turn and pathfinder turns are disabled')
+            self:generateCalculatedTurn()
+            self.state = self.states.TURNING
+        end
+    else
+        if self.driveStrategy:isTurnOnFieldActive() then
+            self:debug('Starting a calculated turn: not enough room on field to turn but turn on field is on')
+            self:generateCalculatedTurn()
+            self.state = self.states.TURNING
+        elseif not self.settings.allowPathfinderTurns:getValue() then
+            self:debug('Starting a calculated turn: not enough room on field to turn but turn on field is off and pathfinder turns are disabled')
+            self:generateCalculatedTurn()
+            self.state = self.states.TURNING
+        else
+            self:debug('Starting a pathfinder turn: not enough room on field to turn, turn on field is or pathfinder turns are enabled')
+            self:generatePathfinderTurn(false)
+        end
+    end
+    if self.state == self.states.TURNING then
+        self.ppc:setCourse(self.turnCourse)
+        self.ppc:initialize(1)
+    end
 end
 
 function CourseTurn:isForwardOnly()
-	return self.turnCourse and self.turnCourse:isForwardOnly()
+    return self.turnCourse and self.turnCourse:isForwardOnly()
 end
 
 function CourseTurn:getCourse()
-	return self.turnCourse
+    return self.turnCourse
 end
 
 function CourseTurn:turn()
 
-	local gx, gz, moveForwards, maxSpeed = AITurn.turn(self)
+    local gx, gz, moveForwards, maxSpeed = AITurn.turn(self)
 
-	self:updateTurnProgress()
+    self:updateTurnProgress()
 
-	self:changeDirectionWhenAligned()
-	self:changeToFwdWhenWaypointReached()
+    self:changeDirectionWhenAligned()
+    self:changeToFwdWhenWaypointReached()
 
-	-- TODO keep only the turn control, remove this turnEnd thing as it overlaps with turnStart/turnEnd
-	if TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(),
-			TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END) then
-		self.state = self.states.ENDING_TURN
-		self:debug('About to end turn')
-	end
-	return gx, gz, moveForwards, maxSpeed
+    -- TODO keep only the turn control, remove this turnEnd thing as it overlaps with turnStart/turnEnd
+    if TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(),
+            TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END) then
+        self.state = self.states.ENDING_TURN
+        self:debug('About to end turn')
+    end
+    return gx, gz, moveForwards, maxSpeed
 end
 
 ---@return boolean true if it is ok the continue driving, false when the vehicle should stop
 function CourseTurn:endTurn(dt)
-	-- keep driving on the turn course until we need to lower our implements
-	local shouldLower, dz = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode, self.ppc:isReversing())
-	if shouldLower then
-		if not self.implementsLowered then
-			-- have not started lowering implements yet
-			self:debug('Turn ending, lowering implements')
-			self.driveStrategy:lowerImplements()
-			self.implementsLowered = true
-			if self.ppc:isReversing() then
-				-- when ending a turn in reverse, don't drive the rest of the course, switch right back to fieldwork
-				self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
-			end
-		else
-			-- implements already lowering, making sure we check if they are lowered, the faster we go, the earlier,
-			-- for those people who set insanely high turn speeds...
-			local implementCheckDistance = math.max(1, 0.1 * self.vehicle:getLastSpeed())
-			if dz and dz > - implementCheckDistance then
-				if self.vehicle:getCanAIFieldWorkerContinueWork() then
-					self:debug("implements lowered, resume fieldwork")
-					self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
-				else
-					self:debug('waiting for lower at dz=%.1f', dz)
-					-- we are almost at the start of the row but still not lowered everything,
-					-- hold.
-					return false
-				end
-			end
-		end
-	end
-	return true
+    -- keep driving on the turn course until we need to lower our implements
+    local shouldLower, dz = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode, self.ppc:isReversing())
+    if shouldLower then
+        if not self.implementsLowered then
+            -- have not started lowering implements yet
+            self:debug('Turn ending, lowering implements')
+            self.driveStrategy:lowerImplements()
+            self.implementsLowered = true
+            if self.ppc:isReversing() then
+                -- when ending a turn in reverse, don't drive the rest of the course, switch right back to fieldwork
+                self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+            end
+        else
+            -- implements already lowering, making sure we check if they are lowered, the faster we go, the earlier,
+            -- for those people who set insanely high turn speeds...
+            local implementCheckDistance = math.max(1, 0.1 * self.vehicle:getLastSpeed())
+            if dz and dz > -implementCheckDistance then
+                if self.vehicle:getCanAIFieldWorkerContinueWork() then
+                    self:debug("implements lowered, resume fieldwork")
+                    self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+                else
+                    self:debug('waiting for lower at dz=%.1f', dz)
+                    -- we are almost at the start of the row but still not lowered everything,
+                    -- hold.
+                    return false
+                end
+            end
+        end
+    end
+    return true
 end
 
 function CourseTurn:updateTurnProgress()
-	if self.turnCourse and not self.turnContext:isHeadlandCorner() then
-		-- turn progress is for example rotating plows, no need to worry about that during headland turns
-		local progress = self.turnCourse:getCurrentWaypointIx() / self.turnCourse:getNumberOfWaypoints()
-		if (progress - (self.lastProgress or 0)) > 0.1 then
-			-- just send 0 and 1 as it looks like some plows won't turn fully if they receive something in between
-			-- also, start turning a bit before we reach the middle of the turn to make sure it is ready
-			local progressToSend = progress <= 0.3 and 0 or 1
-			self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", progressToSend, self.turnContext:isLeftTurn())
-			self:debug('progress %.1f (left: %s)', progressToSend, self.turnContext:isLeftTurn())
-			self.lastProgress = progress
-		end
-	end
+    if self.turnCourse and not self.turnContext:isHeadlandCorner() then
+        -- turn progress is for example rotating plows, no need to worry about that during headland turns
+        local progress = self.turnCourse:getCurrentWaypointIx() / self.turnCourse:getNumberOfWaypoints()
+        if (progress - (self.lastProgress or 0)) > 0.1 then
+            -- just send 0 and 1 as it looks like some plows won't turn fully if they receive something in between
+            -- also, start turning a bit before we reach the middle of the turn to make sure it is ready
+            local progressToSend = progress <= 0.3 and 0 or 1
+            self.vehicle:raiseAIEvent("onAIFieldWorkerTurnProgress", "onAIImplementTurnProgress", progressToSend, self.turnContext:isLeftTurn())
+            self:debug('progress %.1f (left: %s)', progressToSend, self.turnContext:isLeftTurn())
+            self.lastProgress = progress
+        end
+    end
 end
 
 function CourseTurn:onWaypointChange(ix)
-	AITurn.onWaypointChange(self, ix)
-	if self.turnCourse then
-		if self.forceTightTurnOffset or (self.enableTightTurnOffset and self.turnCourse:useTightTurnOffset(ix)) then
-			-- adjust the course a bit to the outside in a curve to keep a towed implement on the course
-			-- TODO_22
-			self.tightTurnOffset = AIUtil.calculateTightTurnOffset(self.vehicle, self.turningRadius, self.turnCourse,
-					self.tightTurnOffset, true)
-			self.turnCourse:setOffset(self.tightTurnOffset, 0)
-		end
-	end
+    AITurn.onWaypointChange(self, ix)
+    if self.turnCourse then
+        if self.forceTightTurnOffset or (self.enableTightTurnOffset and self.turnCourse:useTightTurnOffset(ix)) then
+            -- adjust the course a bit to the outside in a curve to keep a towed implement on the course
+            -- TODO_22
+            self.tightTurnOffset = AIUtil.calculateTightTurnOffset(self.vehicle, self.turningRadius, self.turnCourse,
+                    self.tightTurnOffset, true)
+            self.turnCourse:setOffset(self.tightTurnOffset, 0)
+        end
+    end
 end
 
 --- When switching direction during a turn, especially when switching to reverse we want to make sure
@@ -713,123 +656,147 @@ end
 --- change direction as soon as the implement is aligned.
 --- So check that here and force a direction change when possible.
 function CourseTurn:changeDirectionWhenAligned()
-	if TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(), TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED) then
-		local aligned = self.driveStrategy:areAllImplementsAligned(self.turnContext.turnEndWpNode.node)
-		self:debug('aligned: %s', tostring(aligned))
-		if aligned then
-			-- find the next direction switch and continue course from there
-			local nextDirectionChangeIx = self.turnCourse:getNextDirectionChangeFromIx(self.turnCourse:getCurrentWaypointIx())
-			if nextDirectionChangeIx then
-				self:debug('skipping to next direction change at %d', nextDirectionChangeIx + 1)
-				self.ppc:initialize(nextDirectionChangeIx + 1)
-			end
-		end
-	end
+    if TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(), TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED) then
+        local aligned = self.driveStrategy:areAllImplementsAligned(self.turnContext.turnEndWpNode.node)
+        self:debug('aligned: %s', tostring(aligned))
+        if aligned then
+            -- find the next direction switch and continue course from there
+            local nextDirectionChangeIx = self.turnCourse:getNextDirectionChangeFromIx(self.turnCourse:getCurrentWaypointIx())
+            if nextDirectionChangeIx then
+                self:debug('skipping to next direction change at %d', nextDirectionChangeIx + 1)
+                self.ppc:initialize(nextDirectionChangeIx + 1)
+            end
+        end
+    end
 end
 
 --- Check if we reached a waypoint where we should change to forward. This is useful when backing up to reach a point
 --- where we can start driving on an arc, for example in a headland corner of when backing up from the field edge
 --- before we make a U turn
 function CourseTurn:changeToFwdWhenWaypointReached()
-	local changeWpIx =
-		TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(), TurnManeuver.CHANGE_TO_FWD_WHEN_REACHED)
-	if changeWpIx and self.ppc:isReversing() then
-		local _, _, dz = self.turnCourse:getWaypointLocalPosition(self.vehicle:getAIDirectionNode(), changeWpIx)
-		-- is the change waypoint now in front of us?
-		if dz > 0 then
-			-- find the next direction switch and continue course from there
-			local getNextFwdWaypointIx = self.turnCourse:getNextFwdWaypointIx(self.turnCourse:getCurrentWaypointIx())
-			if getNextFwdWaypointIx then
-				self:debug('skipping to next forward waypoint at %d (dz: %.1f)', getNextFwdWaypointIx, dz)
-				self.ppc:initialize(getNextFwdWaypointIx)
-			end
-		end
-	end
+    local changeWpIx = TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(), TurnManeuver.CHANGE_TO_FWD_WHEN_REACHED)
+    if changeWpIx and self.ppc:isReversing() then
+        local _, _, dz = self.turnCourse:getWaypointLocalPosition(self.vehicle:getAIDirectionNode(), changeWpIx)
+        -- is the change waypoint now in front of us?
+        if dz > 0 then
+            -- find the next direction switch and continue course from there
+            local getNextFwdWaypointIx = self.turnCourse:getNextFwdWaypointIx(self.turnCourse:getCurrentWaypointIx())
+            if getNextFwdWaypointIx then
+                self:debug('skipping to next forward waypoint at %d (dz: %.1f)', getNextFwdWaypointIx, dz)
+                self.ppc:initialize(getNextFwdWaypointIx)
+            end
+        end
+    end
 end
 
 function CourseTurn:generateCalculatedTurn()
-	local turnManeuver
-	if self.turnContext:isHeadlandCorner() then
-		-- TODO_22
-		self:debug('This is a headland turn')
-		turnManeuver = HeadlandCornerTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
-			self.turningRadius, self.workWidth, self.reversingImplement, self.steeringLength)
-		-- adjust turn course for tight turns only for headland corners by default
-		self.forceTightTurnOffset = self.steeringLength > 0
-	else
-		local distanceToFieldEdge = self.turnContext:getDistanceToFieldEdge(self.vehicle:getAIDirectionNode())
-		local turnOnField = self.driveStrategy:isTurnOnFieldActive()
-		-- if don't have to turn on field then pretend we have a lot of space
-		distanceToFieldEdge = turnOnField and distanceToFieldEdge or math.huge
-		self:debug('This is NOT a headland turn, turnOnField=%s distanceToFieldEdge=%.1f', turnOnField, distanceToFieldEdge)
-		if distanceToFieldEdge > self.workWidth or self.steeringLength > 0 then
-			-- if there's plenty of space or it is a towed implement, stick with Dubins, that's easier
-			turnManeuver = DubinsTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
-				self.turningRadius, self.workWidth, self.steeringLength, distanceToFieldEdge)
-		else
-			turnManeuver = ReedsSheppTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
-				self.turningRadius, self.workWidth, self.steeringLength, distanceToFieldEdge)
-		end
-		-- only use tight turn offset if we are towing something and not an articulated axis or track vehicle
-		-- as those usually have a very small turn radius anyway, causing jackknifing
-		if self.steeringLength > 0 and not (SpecializationUtil.hasSpecialization(ArticulatedAxis, self.vehicle.specializations) or
-				SpecializationUtil.hasSpecialization(Crawler, self.vehicle.specializations)) then
-			self:debug('Enabling tight turn offset')
-			self.enableTightTurnOffset = true
-		end
-	end
-	self.turnCourse = turnManeuver:getCourse()
+    local turnManeuver
+    if self.turnContext:isHeadlandCorner() then
+        -- TODO_22
+        self:debug('This is a headland turn')
+        turnManeuver = HeadlandCornerTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
+                self.turningRadius, self.workWidth, self.reversingImplement, self.steeringLength)
+        -- adjust turn course for tight turns only for headland corners by default
+        self.forceTightTurnOffset = self.steeringLength > 0
+    else
+        local distanceToFieldEdge = self.turnContext:getDistanceToFieldEdge(self.vehicle:getAIDirectionNode())
+        local turnOnField = self.driveStrategy:isTurnOnFieldActive()
+        -- if don't have to turn on field then pretend we have a lot of space
+        distanceToFieldEdge = turnOnField and distanceToFieldEdge or math.huge
+        self:debug('This is NOT a headland turn, turnOnField=%s distanceToFieldEdge=%.1f', turnOnField, distanceToFieldEdge)
+        if distanceToFieldEdge > self.workWidth or self.steeringLength > 0 then
+            -- if there's plenty of space or it is a towed implement, stick with Dubins, that's easier
+            turnManeuver = DubinsTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
+                    self.turningRadius, self.workWidth, self.steeringLength, distanceToFieldEdge)
+        else
+            turnManeuver = ReedsSheppTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
+                    self.turningRadius, self.workWidth, self.steeringLength, distanceToFieldEdge)
+        end
+        -- only use tight turn offset if we are towing something and not an articulated axis or track vehicle
+        -- as those usually have a very small turn radius anyway, causing jackknifing
+        if self.steeringLength > 0 and not (SpecializationUtil.hasSpecialization(ArticulatedAxis, self.vehicle.specializations) or
+                SpecializationUtil.hasSpecialization(Crawler, self.vehicle.specializations)) then
+            self:debug('Enabling tight turn offset')
+            self.enableTightTurnOffset = true
+        end
+    end
+    self.turnCourse = turnManeuver:getCourse()
 end
 
 function CourseTurn:generatePathfinderTurn(useHeadland)
-	self.pathfindingStartedAt = g_currentMission.time
-	local done, path
-	local turnEndNode, startOffset, goalOffset = self.turnContext:getTurnEndNodeAndOffsets(self.steeringLength)
-	local _, backMarkerDistance = self.driveStrategy:getFrontAndBackMarkers()
-	self:debug('Pathfinder turn (useHeadland: %s): generate turn with hybrid A*, start offset %.1f, goal offset %.1f',
-			useHeadland, startOffset, goalOffset)
-	self.driveStrategy.pathfinder, done, path = PathfinderUtil.findPathForTurn(self.vehicle, startOffset, turnEndNode, goalOffset,
-			self.turningRadius, self.driveStrategy:getAllowReversePathfinding(),
-			useHeadland and self.fieldWorkCourse or nil,
-			self.driveStrategy:getWorkWidth(), backMarkerDistance,
-			self.driveStrategy:isTurnOnFieldActive())
-	if done then
-		return self:onPathfindingDone(path)
-	else
-		self.state = self.states.WAITING_FOR_PATHFINDER
-		self.driveStrategy:setPathfindingDoneCallback(self, self.onPathfindingDone)
-	end
+    self.pathfindingStartedAt = g_currentMission.time
+    local done, path
+    local turnEndNode, goalOffset = self.turnContext:getTurnEndNodeAndOffsets(self.steeringLength)
+    local _, backMarkerDistance = self.driveStrategy:getFrontAndBackMarkers()
+    self:debug('Pathfinder turn (useHeadland: %s): generate turn with hybrid A*, goal offset %.1f', useHeadland, goalOffset)
+    self.driveStrategy.pathfinder, done, path = PathfinderUtil.findPathForTurn(self.vehicle, 0, turnEndNode, goalOffset,
+            self.turningRadius, self.driveStrategy:getAllowReversePathfinding(),
+            useHeadland and self.fieldWorkCourse or nil,
+            self.driveStrategy:getWorkWidth(), backMarkerDistance,
+            self.driveStrategy:isTurnOnFieldActive())
+    if done then
+        return self:onPathfindingDone(path)
+    else
+        self.state = self.states.WAITING_FOR_PATHFINDER
+        self.driveStrategy:setPathfindingDoneCallback(self, self.onPathfindingDone)
+    end
 end
 
 function CourseTurn:onPathfindingDone(path)
-	if path and #path > 2 then
-		self:debug('Pathfinding finished with %d waypoints (%d ms)', #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
-		if self.reverseBeforeStartingTurnWaypoints and #self.reverseBeforeStartingTurnWaypoints > 0 then
-			self.turnCourse = Course(self.vehicle, self.reverseBeforeStartingTurnWaypoints, true)
-			self.turnCourse:appendWaypoints(CourseGenerator.pointsToXzInPlace(path))
-		else
-			self.turnCourse = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
-		end
-
-		self.turnCourse:adjustForTowedImplements( 2)
-
-		-- make sure we use tight turn offset towards the end of the course so a towed implement is aligned with the new row
-		self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
-		local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, nil, true)
-		TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
-	else
-		self:debug('No path found in %d ms, falling back to normal turn course generator', g_currentMission.time - (self.pathfindingStartedAt or 0))
-		self:generateCalculatedTurn()
-	end
-	self.ppc:setCourse(self.turnCourse)
-	self.ppc:initialize(1)
-	self.state = self.states.TURNING
+    if path and #path > 2 then
+        self:debug('Pathfinding finished with %d waypoints (%d ms)', #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
+        self.turnCourse = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
+        self.turnCourse:adjustForTowedImplements(2)
+        -- make sure we use tight turn offset towards the end of the course so a towed implement is aligned with the new row
+        self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
+        local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, nil, true)
+        TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
+    else
+        self:debug('No path found in %d ms, falling back to normal turn course generator', g_currentMission.time - (self.pathfindingStartedAt or 0))
+        self:generateCalculatedTurn()
+    end
+    self.ppc:setCourse(self.turnCourse)
+    self.ppc:initialize(1)
+    self.state = self.states.TURNING
 end
 
 function CourseTurn:drawDebug()
-	if self.turnCourse and self.turnCourse:isTemporary() and CpDebug:isChannelActive(CpDebug.DBG_TURN, self.vehicle) then
-		self.turnCourse:draw()
-	end
+    if self.turnCourse and self.turnCourse:isTemporary() and CpDebug:isChannelActive(CpDebug.DBG_TURN, self.vehicle) then
+        self.turnCourse:draw()
+    end
+end
+
+--- A turn maneuver to recover when the vehicle is blocked by an object (tree, fence, etc) during the turn
+--- This should only be initiated when the state is TURNING, so after the row is finished and before starting
+--- the new row.
+--- The recovery turn will back up the vehicle a bit and then attempt to find a path to the work start node
+--- of the turn context, just as a pathfinder turn would do.
+---@class RecoveryTurn : CourseTurn
+RecoveryTurn = CpObject(CourseTurn)
+function RecoveryTurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, name)
+    CourseTurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, name or 'RecoveryTurn')
+    self.state = self.states.REVERSING_AFTER_BLOCKED
+    self.turnCourse = Course.createStraightReverseCourse(self.vehicle, 10)
+    self.ppc:setCourse(self.turnCourse)
+    self.ppc:initialize(1)
+end
+
+function RecoveryTurn:turn()
+    if self.state == self.states.REVERSING_AFTER_BLOCKED then
+        return AITurn.turn(self)
+    else
+        return CourseTurn.turn(self)
+    end
+end
+
+function RecoveryTurn:onWaypointChange(ix)
+    AITurn.onWaypointChange(self, ix)
+    if self.turnCourse then
+        if self.turnCourse:isLastWaypointIx(ix) then
+            self:debug('Starting a pathfinder turn: plenty of room on field to turn and pathfinder turns are enabled')
+            self:generatePathfinderTurn(false)
+        end
+    end
 end
 
 --- Combines (in general, when harvesting) in headland corners we want to work the corner first, then back up and then
@@ -838,14 +805,14 @@ end
 CombineCourseTurn = CpObject(CourseTurn)
 
 ---@param turnContext TurnContext
-function CombineCourseTurn:init(vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, name)
-	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse,workWidth, name or 'CombineCourseTurn')
+function CombineCourseTurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, name)
+    CourseTurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, name or 'CombineCourseTurn')
 end
 
 -- in a combine headland turn we want to raise the header after it reached the field edge (or headland edge on an inner
 -- headland.
 function CombineCourseTurn:getRaiseImplementNode()
-	return self.turnContext.lateWorkEndNode
+    return self.turnContext.lateWorkEndNode
 end
 
 --[[
@@ -857,99 +824,98 @@ end
   4. forward to the turn start to continue on headland
 ]]
 ---@class CombinePocketHeadlandTurn : CombineCourseTurn
-	CombinePocketHeadlandTurn = CpObject(CombineCourseTurn)
+CombinePocketHeadlandTurn = CpObject(CombineCourseTurn)
 
 ---@param driveStrategy AIDriveStrategyCombineCourse
 ---@param turnContext TurnContext
-function CombinePocketHeadlandTurn:init(vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth)
-	CombineCourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse,
-			workWidth, 'CombinePocketHeadlandTurn')
+function CombinePocketHeadlandTurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth)
+    CombineCourseTurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse,
+            workWidth, 'CombinePocketHeadlandTurn')
 end
 
 --- Create a pocket in the next row at the corner to stay on the field during the turn maneuver.
 ---@param turnContext TurnContext
 function CombinePocketHeadlandTurn:generatePocketHeadlandTurn(turnContext)
-	local cornerWaypoints = {}
-	-- this is how far we have to cut into the next headland (the position where the header will be after the turn)
-	local offset = math.min(self.turningRadius + turnContext.frontMarkerDistance, self.workWidth)
-	local corner = turnContext:createCorner(self.vehicle, self.turningRadius)
-	local d = -self.workWidth / 2 + turnContext.frontMarkerDistance
-	local reverseDistance = 2 * offset
-	local wp
-	if reverseDistance / 2 > d + 2 then
-		-- drive forward only if we aren't there yet
-		wp = corner:getPointAtDistanceFromCornerStart(d + 2)
-		table.insert(cornerWaypoints, wp)
-		-- drive forward up to the field edge
-		wp = corner:getPointAtDistanceFromCornerStart(d)
-		table.insert(cornerWaypoints, wp)
-	end
-	-- drive back to prepare for making a pocket
-	wp = corner:getPointAtDistanceFromCornerStart(reverseDistance / 2)
-	wp.rev = true
-	table.insert(cornerWaypoints, wp)
-	wp = corner:getPointAtDistanceFromCornerStart(reverseDistance)
-	wp.rev = true
-	table.insert(cornerWaypoints, wp)
-	-- now make a pocket in the inner headland to make room to turn
-	wp = corner:getPointAtDistanceFromCornerStart(reverseDistance * 0.75, -offset * 0.6)
-	table.insert(cornerWaypoints, wp)
-	wp = corner:getPointAtDistanceFromCornerStart(reverseDistance * 0.5, -offset * 0.7)
-	if not CpFieldUtil.isOnField(wp.x, wp.z) then
-		self:debug('No field where the pocket would be, this seems to be a 270 corner')
-		corner:delete()
-		return nil
-	end
-	table.insert(cornerWaypoints, wp)
-	-- drive forward to the field edge on the inner headland
-	wp = corner:getPointAtDistanceFromCornerStart(d, -offset * 0.7)
-	table.insert(cornerWaypoints, wp)
-	wp = corner:getPointAtDistanceFromCornerStart(reverseDistance / 1.5)
-	wp.rev = true
-	table.insert(cornerWaypoints, wp)
-	wp = corner:getPointAtDistanceFromCornerEnd(self.turningRadius / 3, self.turningRadius / 2)
-	table.insert(cornerWaypoints, wp)
-	wp = corner:getPointAtDistanceFromCornerEnd(self.turningRadius, self.turningRadius / 4)
-	table.insert(cornerWaypoints, wp)
-	corner:delete()
-	return Course(self.vehicle, cornerWaypoints, true), turnContext.turnEndWpIx
+    local cornerWaypoints = {}
+    -- this is how far we have to cut into the next headland (the position where the header will be after the turn)
+    local offset = math.min(self.turningRadius + turnContext.frontMarkerDistance, self.workWidth)
+    local corner = turnContext:createCorner(self.vehicle, self.turningRadius)
+    local d = -self.workWidth / 2 + turnContext.frontMarkerDistance
+    local reverseDistance = 2 * offset
+    local wp
+    if reverseDistance / 2 > d + 2 then
+        -- drive forward only if we aren't there yet
+        wp = corner:getPointAtDistanceFromCornerStart(d + 2)
+        table.insert(cornerWaypoints, wp)
+        -- drive forward up to the field edge
+        wp = corner:getPointAtDistanceFromCornerStart(d)
+        table.insert(cornerWaypoints, wp)
+    end
+    -- drive back to prepare for making a pocket
+    wp = corner:getPointAtDistanceFromCornerStart(reverseDistance / 2)
+    wp.rev = true
+    table.insert(cornerWaypoints, wp)
+    wp = corner:getPointAtDistanceFromCornerStart(reverseDistance)
+    wp.rev = true
+    table.insert(cornerWaypoints, wp)
+    -- now make a pocket in the inner headland to make room to turn
+    wp = corner:getPointAtDistanceFromCornerStart(reverseDistance * 0.75, -offset * 0.6)
+    table.insert(cornerWaypoints, wp)
+    wp = corner:getPointAtDistanceFromCornerStart(reverseDistance * 0.5, -offset * 0.7)
+    if not CpFieldUtil.isOnField(wp.x, wp.z) then
+        self:debug('No field where the pocket would be, this seems to be a 270 corner')
+        corner:delete()
+        return nil
+    end
+    table.insert(cornerWaypoints, wp)
+    -- drive forward to the field edge on the inner headland
+    wp = corner:getPointAtDistanceFromCornerStart(d, -offset * 0.7)
+    table.insert(cornerWaypoints, wp)
+    wp = corner:getPointAtDistanceFromCornerStart(reverseDistance / 1.5)
+    wp.rev = true
+    table.insert(cornerWaypoints, wp)
+    wp = corner:getPointAtDistanceFromCornerEnd(self.turningRadius / 3, self.turningRadius / 2)
+    table.insert(cornerWaypoints, wp)
+    wp = corner:getPointAtDistanceFromCornerEnd(self.turningRadius, self.turningRadius / 4)
+    table.insert(cornerWaypoints, wp)
+    corner:delete()
+    return Course(self.vehicle, cornerWaypoints, true), turnContext.turnEndWpIx
 end
 
-
 function CombinePocketHeadlandTurn:startTurn()
-	self.turnCourse = self:generatePocketHeadlandTurn(self.turnContext)
-	if not self.turnCourse then
-		self:debug('Could not create pocket course, falling back to normal headland corner')
-		self:generateCalculatedTurn()
-	end
-	self.ppc:setCourse(self.turnCourse)
-	self.ppc:initialize(1)
-	self.state = self.states.TURNING
+    self.turnCourse = self:generatePocketHeadlandTurn(self.turnContext)
+    if not self.turnCourse then
+        self:debug('Could not create pocket course, falling back to normal headland corner')
+        self:generateCalculatedTurn()
+    end
+    self.ppc:setCourse(self.turnCourse)
+    self.ppc:initialize(1)
+    self.state = self.states.TURNING
 end
 
 --- When making a pocket we need to lower the header whenever driving forward
 function CombinePocketHeadlandTurn:turn(dt)
-	local gx, gy, moveForwards, maxSpeed = AITurn.turn(self)
-	if self.ppc:isReversing() then
-		self.driveStrategy:raiseImplements()
-		self.implementsLowered = nil
-	elseif not self.implementsLowered then
-		self.driveStrategy:lowerImplements()
-		self.implementsLowered = true
-	end
-	return gx, gy, moveForwards, maxSpeed
+    local gx, gy, moveForwards, maxSpeed = AITurn.turn(self)
+    if self.ppc:isReversing() then
+        self.driveStrategy:raiseImplements()
+        self.implementsLowered = nil
+    elseif not self.implementsLowered then
+        self.driveStrategy:lowerImplements()
+        self.implementsLowered = true
+    end
+    return gx, gy, moveForwards, maxSpeed
 end
 
 --- No turn ending phase here, we just have one course for the entire turn and when it ends, we are done
 function CombinePocketHeadlandTurn:onWaypointPassed(ix, course)
-	if ix == course:getNumberOfWaypoints() then
-		self:debug('onWaypointPassed %d', ix)
-		self:debug('Last waypoint reached, resuming fieldwork')
-		self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
-	end
+    if ix == course:getNumberOfWaypoints() then
+        self:debug('onWaypointPassed %d', ix)
+        self:debug('Last waypoint reached, resuming fieldwork')
+        self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+    end
 end
 
-
+-- TODO: This is not used, and has not been updated with all the AITurn changes for a while
 --- A turn type which isn't really a turn, we only use this to finish a row (drive straight until the implement
 --- reaches the end of the row, don't drive towards the next waypoint until then)
 --- This is to make sure the last row before transitioning to the headland is properly finished, otherwise
@@ -959,16 +925,16 @@ end
 FinishRowOnly = CpObject(AITurn)
 
 function FinishRowOnly:init(vehicle, driver, turnContext)
-	AITurn.init(self, vehicle, driver, turnContext, 'FinishRowOnly')
+    AITurn.init(self, vehicle, driver, turnContext, 'FinishRowOnly')
 end
 
 function FinishRowOnly:finishRow()
-	-- keep driving straight until we need to raise our implements
-	if self.driveStrategy:shouldRaiseImplements(self:getRaiseImplementNode()) then
-		self:debug('Row finished, returning to fieldwork.')
-		self.driveStrategy:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx, true)
-	end
-	return false
+    -- keep driving straight until we need to raise our implements
+    if self.driveStrategy:shouldRaiseImplements(self:getRaiseImplementNode()) then
+        self:debug('Row finished, returning to fieldwork.')
+        self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx, true)
+    end
+    return false
 end
 
 --- A turn which really isn't a turn just a course to start a field work row using the supplied course and
@@ -978,35 +944,35 @@ StartRowOnly = CpObject(CourseTurn)
 ---@param startRowCourse Course course leading to the first waypoint of the row to start
 ---@param fieldWorkCourse Course field work course
 ---@param workWidth number
-function StartRowOnly:init(vehicle, driveStrategy, ppc, turnContext, startRowCourse, fieldWorkCourse, workWidth)
-	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, 'StartRow')
-	self.turnCourse = startRowCourse
-	self.enableTightTurnOffset = true
-	self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
-	-- add a turn ending section into the row to make sure the implements are lowered correctly
-	local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, 3, true)
-	TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
-	self.ppc:setCourse(self.turnCourse)
-	self.ppc:initialize(1)
-	self.state = self.states.TURNING
+function StartRowOnly:init(vehicle, driveStrategy, ppc, proximityController, turnContext, startRowCourse, fieldWorkCourse, workWidth)
+    CourseTurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, 'StartRow')
+    self.turnCourse = startRowCourse
+    self.enableTightTurnOffset = true
+    self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
+    -- add a turn ending section into the row to make sure the implements are lowered correctly
+    local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, 3, true)
+    TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
+    self.ppc:setCourse(self.turnCourse)
+    self.ppc:initialize(1)
+    self.state = self.states.TURNING
 end
 
 function StartRowOnly:updateTurnProgress()
-	-- do nothing since this isn't really a turn
+    -- do nothing since this isn't really a turn
 end
 
 --- A turn for working between vine rows.
 ---@class VineTurn : CourseTurn
 VineTurn = CpObject(CourseTurn)
-function VineTurn:init(vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth)
-	CourseTurn.init(self, vehicle, driveStrategy, ppc, turnContext, fieldWorkCourse, workWidth, 'VineTurn')
+function VineTurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth)
+    CourseTurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, 'VineTurn')
 end
 
 function VineTurn:startTurn()
-	local turnManeuver = VineTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
-			self.turningRadius, self.workWidth)
-	self.turnCourse = turnManeuver:getCourse()
-	self.ppc:setCourse(self.turnCourse)
-	self.ppc:initialize(1)
-	self.state = self.states.TURNING
+    local turnManeuver = VineTurnManeuver(self.vehicle, self.turnContext, self.vehicle:getAIDirectionNode(),
+            self.turningRadius, self.workWidth)
+    self.turnCourse = turnManeuver:getCourse()
+    self.ppc:setCourse(self.turnCourse)
+    self.ppc:initialize(1)
+    self.state = self.states.TURNING
 end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -798,10 +798,10 @@ function RecoveryTurn:turn()
     end
 end
 
-function RecoveryTurn:onWaypointChange(ix)
-    AITurn.onWaypointChange(self, ix)
+function RecoveryTurn:onWaypointPassed(ix)
+    AITurn.onWaypointPassed(self, ix)
     if self.turnCourse and self.turnCourse:isLastWaypointIx(ix) then
-        if self.states == self.state.REVERSING_AFTER_BLOCKED then
+        if self.state == self.states.REVERSING_AFTER_BLOCKED then
             self:debug('Starting a pathfinder turn: plenty of room on field to turn and pathfinder turns are enabled')
             self:generatePathfinderTurn(false)
         end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -783,8 +783,10 @@ function RecoveryTurn:init(vehicle, driveStrategy, ppc, proximityController, tur
     -- blocked too, indicating that we give up.
     self.proximityController:registerBlockingObjectListener(self, RecoveryTurn.onBlocked)
     self.retryCount = retryCount or 0
+    reverseDistance = reverseDistance or 10
+    self:debug('retry count %d, reverse distance %.1f', self.retryCount, reverseDistance)
     self.state = self.states.REVERSING_AFTER_BLOCKED
-    self.turnCourse = Course.createStraightReverseCourse(self.vehicle, reverseDistance or 10)
+    self.turnCourse = Course.createStraightReverseCourse(self.vehicle, reverseDistance)
     self.ppc:setCourse(self.turnCourse)
     self.ppc:initialize(1)
 end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -775,6 +775,9 @@ end
 RecoveryTurn = CpObject(CourseTurn)
 function RecoveryTurn:init(vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, name)
     CourseTurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, name or 'RecoveryTurn')
+    -- we could also just unregister, but this way we'll have a log entry in case the recovery is
+    -- blocked too, indicating that we give up.
+    self.proximityController:registerBlockingObjectListener(self, RecoveryTurn.onBlocked)
     self.state = self.states.REVERSING_AFTER_BLOCKED
     self.turnCourse = Course.createStraightReverseCourse(self.vehicle, 10)
     self.ppc:setCourse(self.turnCourse)
@@ -802,7 +805,7 @@ end
 function RecoveryTurn:onBlocked()
     -- unregister here before the AITurn object is destructed
     self.proximityController:unregisterBlockingObjectListener()
-    self:debug('Recovering from blocked turn unsuccessful.')
+    self:debug('Recovering from blocked turn unsuccessful, giving up.')
 end
 
 --- Combines (in general, when harvesting) in headland corners we want to work the corner first, then back up and then

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -804,8 +804,8 @@ function RecoveryTurn:turn()
     end
 end
 
-function RecoveryTurn:onWaypointPassed(ix)
-    AITurn.onWaypointPassed(self, ix)
+function RecoveryTurn:onWaypointPassed(ix, course)
+    AITurn.onWaypointPassed(self, ix, course)
     if self.turnCourse and self.turnCourse:isLastWaypointIx(ix) then
         if self.state == self.states.REVERSING_AFTER_BLOCKED then
             self:debug('Starting a pathfinder turn to recover after being blocked')

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -578,7 +578,6 @@ function CourseTurn:turn()
     self:changeDirectionWhenAligned()
     self:changeToFwdWhenWaypointReached()
 
-    -- TODO keep only the turn control, remove this turnEnd thing as it overlaps with turnStart/turnEnd
     if TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(),
             TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END) then
         self.state = self.states.ENDING_TURN
@@ -801,8 +800,8 @@ end
 
 function RecoveryTurn:onWaypointChange(ix)
     AITurn.onWaypointChange(self, ix)
-    if self.turnCourse then
-        if self.turnCourse:isLastWaypointIx(ix) then
+    if self.turnCourse and self.turnCourse:isLastWaypointIx(ix) then
+        if self.states == self.state.REVERSING_AFTER_BLOCKED then
             self:debug('Starting a pathfinder turn: plenty of room on field to turn and pathfinder turns are enabled')
             self:generatePathfinderTurn(false)
         end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -97,7 +97,7 @@ function AITurn:turn()
 end
 
 function AITurn:onBlocked()
-    -- will only try to recover once, so unregister here
+    -- unregister here before the AITurn object is destructed
     self.proximityController:unregisterBlockingObjectListener()
     self.driveStrategy:startRecoveryTurn()
 end
@@ -543,7 +543,7 @@ function CourseTurn:startTurn()
         end
     else
         if self.driveStrategy:isTurnOnFieldActive() then
-            self:debug('Starting a calculated turn: not enough room on field to turn but turn on field is on')
+            self:debug('Starting a calculated turn: not enough room on field to turn but turn on field is on, can not use pathfinder turn, even if it is enabled')
             self:generateCalculatedTurn()
             self.state = self.states.TURNING
         elseif not self.settings.allowPathfinderTurns:getValue() then
@@ -551,7 +551,7 @@ function CourseTurn:startTurn()
             self:generateCalculatedTurn()
             self.state = self.states.TURNING
         else
-            self:debug('Starting a pathfinder turn: not enough room on field to turn, turn on field is or pathfinder turns are enabled')
+            self:debug('Starting a pathfinder turn: not enough room on field to turn, turn on field is off, and pathfinder turns are enabled')
             self:generatePathfinderTurn(false)
         end
     end
@@ -797,6 +797,12 @@ function RecoveryTurn:onWaypointChange(ix)
             self:generatePathfinderTurn(false)
         end
     end
+end
+
+function RecoveryTurn:onBlocked()
+    -- unregister here before the AITurn object is destructed
+    self.proximityController:unregisterBlockingObjectListener()
+    self:debug('Recovering from blocked turn unsuccessful.')
 end
 
 --- Combines (in general, when harvesting) in headland corners we want to work the corner first, then back up and then

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -449,21 +449,18 @@ end
 
 --- Assuming a vehicle just finished a row, provide parameters for calculating a path to the start
 --- of the next row, making sure that the vehicle and the implement arrives there aligned with the row direction
----@return number, number, number the node where the turn ends, z offset to use with the start node, which should be
---- the vehicle's direction node, and lastly, z offset to use with the end node
+---@return number, number the node where the turn ends, z offset to use with the end node
 function TurnContext:getTurnEndNodeAndOffsets(steeringLength)
-    local turnEndNode, startOffset, goalOffset
+    local turnEndNode, goalOffset
     if self.frontMarkerDistance > 0 then
         -- implement in front of vehicle. Turn should end with the implement at the work start position, this is where
         -- the vehicle's root node is on the vehicleAtTurnEndNode
         turnEndNode = self.vehicleAtTurnEndNode
-        startOffset = 0
         goalOffset = 0
     else
         -- implement behind vehicle. Since we are turning, we want to be aligned with the next row with our vehicle
         -- on the work start node so by the time the implement reaches it, it is also aligned
         turnEndNode = self.workStartNode
-        startOffset = 0
         -- vehicle is about frontMarkerDistance before the work end when finishing the turn
         if steeringLength > 0 then
             -- giving enough time for the implement to align, the vehicle will reach the next row about the
@@ -478,7 +475,7 @@ function TurnContext:getTurnEndNodeAndOffsets(steeringLength)
             goalOffset = self.frontMarkerDistance + self.turnEndForwardOffset
         end
     end
-    return turnEndNode, startOffset, goalOffset
+    return turnEndNode, goalOffset
 end
 
 function TurnContext:debug(...)

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -307,9 +307,9 @@ function AnalyticTurnManeuver:init(vehicle, turnContext, vehicleDirectionNode, t
 	self:debug('r=%.1f, w=%.1f, steeringLength=%.1f, distanceToFieldEdge=%.1f',
 		turningRadius, workWidth, steeringLength, distanceToFieldEdge)
 
-	local turnEndNode, startOffset, goalOffset = self.turnContext:getTurnEndNodeAndOffsets(self.steeringLength)
+	local turnEndNode, goalOffset = self.turnContext:getTurnEndNodeAndOffsets(self.steeringLength)
 
-	self.course = self:findAnalyticPath(vehicleDirectionNode, startOffset, turnEndNode, 0, goalOffset, self.turningRadius)
+	self.course = self:findAnalyticPath(vehicleDirectionNode, 0, turnEndNode, 0, goalOffset, self.turningRadius)
 
 	-- make sure we use tight turn offset towards the end of the course so a towed implement is aligned with the new row
 	self.course:setUseTightTurnOffsetForLastWaypoints(10)
@@ -536,8 +536,9 @@ function VineTurnManeuver:init(vehicle, turnContext, vehicleDirectionNode, turni
 
 	self:debug('Start generating')
 
-	local turnEndNode, startOffset, goalOffset = self.turnContext:getTurnEndNodeAndOffsets(0)
+	local turnEndNode, goalOffset = self.turnContext:getTurnEndNodeAndOffsets(0)
 	local _, _, dz = turnContext:getLocalPositionOfTurnEnd(vehicle:getAIDirectionNode())
+	local startOffset = 0
 	if dz > 0 then
 		startOffset = startOffset + dz
 	else


### PR DESCRIPTION
Attempt to recover from a turn where the vehicle got blocked. 
This replaces the current turn with a RecoveryTurn, which just
backs up a bit and then uses the pathfinder to create a turn 
back to the start of the next row.