### PR TITLE
fix: multitool unloader call

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1076,7 +1076,10 @@ function AIDriveStrategyCombineCourse:findBestWaypointToUnloadOnUpDownRows(ix, i
     if pipeInFruit and not isPipeInFruitAllowed then
         --if the pipe is in fruit AND the user selects 'avoid fruit'
         if ixAtRowStart then
-            if ixAtRowStart > currentIx then
+            if self.course:getMultiTools() > 1 then
+                self:debug('Pipe may be in fruit at waypoint %d, we have no reliable information as multitool active, rejecting rendezvous', ix)
+                newWpIx = nil
+            elseif ixAtRowStart > currentIx then
                 -- have not started the previous row yet
                 self:debug('Pipe would be in fruit at waypoint %d. Check previous row', ix)
                 pipeInFruit, _ = self:isPipeInFruitAt(ixAtRowStart - 2) -- wp before the turn start


### PR DESCRIPTION
In multitool mode, do not arrange a rendezvous with an unloader at the end of a row just because it appears that the unloader would be full in the next row.

With multitool, we have no reliable information if there would be fruit at a given waypoint in the future.

#2373