### PR TITLE
feat: make room for a second unloader

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -868,6 +868,8 @@ function AIDriveStrategyCombineCourse:callUnloader(bestUnloader, tentativeRendez
     end
 end
 
+---@param vehicle table
+---@return boolean true if vehicle is an active Courseplay controlled combine/harvester
 function AIDriveStrategyCombineCourse.isActiveCpCombine(vehicle)
     if not (vehicle.getIsCpActive and vehicle:getIsCpActive()) then
         -- not driven by CP

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -868,17 +868,13 @@ function AIDriveStrategyCombineCourse:callUnloader(bestUnloader, tentativeRendez
     end
 end
 
-function AIDriveStrategyCombineCourse:isActiveCpUnloader(vehicle)
-    if vehicle.getIsCpCombineUnloaderActive and vehicle:getIsCpCombineUnloaderActive() then
-        local strategy = vehicle:getCpDriveStrategy()
-        if strategy then 
-            local unloadTargetType = strategy:getUnloadTargetType()
-            if unloadTargetType ~= nil then 
-                return unloadTargetType == AIDriveStrategyUnloadCombine.UNLOAD_TYPES.COMBINE
-            end
-        end
+function AIDriveStrategyCombineCourse.isActiveCpCombine(vehicle)
+    if not (vehicle.getIsCpActive and vehicle:getIsCpActive()) then
+        -- not driven by CP
+        return false
     end
-    return false
+    local driveStrategy = vehicle.getCpDriveStrategy and vehicle:getCpDriveStrategy()
+    return driveStrategy and driveStrategy.callUnloader ~= nil
 end
 
 --- Find an unloader to drive to the target, which may either be the combine itself (when stopped and waiting for unload)
@@ -891,7 +887,7 @@ function AIDriveStrategyCombineCourse:findUnloader(combine, waypoint)
     local bestScore = -math.huge
     local bestUnloader, bestEte
     for _, vehicle in pairs(g_currentMission.vehicles) do
-        if self:isActiveCpUnloader(vehicle) then
+        if AIDriveStrategyUnloadCombine.isActiveCpCombineUnloader(vehicle) then
             local x, _, z = getWorldTranslation(self.vehicle.rootNode)
             ---@type AIDriveStrategyUnloadCombine
             local driveStrategy = vehicle:getCpDriveStrategy()

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -385,15 +385,6 @@ function AIDriveStrategyCourse:getCurrentCourse()
     return self.ppc:getCourse() or self.course
 end
 
-function AIDriveStrategyCourse:isActiveCpCombine(vehicle)
-    if not (vehicle.getIsCpActive and vehicle:getIsCpActive()) then
-        -- not driven by CP
-        return false
-    end
-    local driveStrategy = vehicle.getCpDriveStrategy and vehicle:getCpDriveStrategy()
-    return driveStrategy and driveStrategy.callUnloader ~= nil
-end
-
 function AIDriveStrategyCourse:update()
     self.ppc:update()
     self:updatePathfinding()

--- a/scripts/ai/AIDriveStrategySiloLoader.lua
+++ b/scripts/ai/AIDriveStrategySiloLoader.lua
@@ -364,19 +364,6 @@ function AIDriveStrategySiloLoader:hold(periodMs)
     self.temporaryHold:set(true, math.min(math.max(0, periodMs), 30000))
 end
 
-function AIDriveStrategySiloLoader:isActiveCpUnloader(vehicle)
-    if vehicle.getIsCpCombineUnloaderActive and vehicle:getIsCpCombineUnloaderActive() then
-        local strategy = vehicle:getCpDriveStrategy()
-        if strategy then 
-            local unloadTargetType = strategy:getUnloadTargetType()
-            if unloadTargetType ~= nil then 
-                return unloadTargetType == AIDriveStrategyUnloadCombine.UNLOAD_TYPES.SILO_LOADER
-            end
-        end    
-    end
-    return false
-end
-
 function AIDriveStrategySiloLoader:callUnloaderWhenNeeded()
     if not self.timeToCallUnloader:get() then
         return
@@ -403,7 +390,7 @@ function AIDriveStrategySiloLoader:findUnloader()
     local bestScore = -math.huge
     local bestUnloader, bestEte
     for _, vehicle in pairs(g_currentMission.vehicles) do
-        if self:isActiveCpUnloader(vehicle) then
+        if AIDriveStrategyUnloadCombine.isActiveCpSiloLoader(vehicle) then
             local x, _, z = getWorldTranslation(self.vehicle.rootNode)
             ---@type AIDriveStrategyUnloadCombine
             local driveStrategy = vehicle:getCpDriveStrategy()

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1660,7 +1660,8 @@ function AIDriveStrategyUnloadCombine:onBlockingVehicle(blockingVehicle, isBack)
                 self.state.properties.dx = nil
                 course = self:createMoveAwayCourse(blockingVehicle)
             end
-        elseif AIDriveStrategyUnloadCombine.isActiveCpCombineUnloader(blockingVehicle) and
+        elseif (AIDriveStrategyUnloadCombine.isActiveCpCombineUnloader(blockingVehicle) or
+                AIDriveStrategyUnloadCombine.isActiveCpSiloLoader(blockingVehicle)) and
                 blockingVehicle:getCpDriveStrategy():isIdle() then
             self:debug('%s is an idle CP combine unloader, request it to move.', CpUtil.getName(blockingVehicle))
             blockingVehicle:getCpDriveStrategy():requestToMoveForward(self.vehicle)

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1617,7 +1617,7 @@ function AIDriveStrategyUnloadCombine:onBlockingVehicle(blockingVehicle, isBack)
             not self:isBeingHeld() then
         self:debug('%s has been blocking us for a while, move a bit', CpUtil.getName(blockingVehicle))
         local course
-        if self:isActiveCpCombine(blockingVehicle) then
+        if AIDriveStrategyCombineCourse.isActiveCpCombine(blockingVehicle) then
             -- except we are blocking our buddy, so set up a course parallel to the combine's direction,
             -- with an offset from the combine that makes sure we are clear. Use the trailer's root node (and not
             -- the tractor's) as when we reversing, it is easier when the trailer remains on the same side of the combine

--- a/scripts/ai/CollisionAvoidanceController.lua
+++ b/scripts/ai/CollisionAvoidanceController.lua
@@ -58,7 +58,7 @@ end
 
 function CollisionAvoidanceController:findPotentialCollisions()
     for _, vehicle in pairs(g_currentMission.vehicles) do
-        if self.strategy:isActiveCpCombine(vehicle) then
+        if AIDriveStrategyCombineCourse.isActiveCpCombine(vehicle) then
             local d = calcDistanceFrom(self.vehicle.rootNode, vehicle.rootNode)
             if d < self.range then
                 local myCourse = self.strategy:getCurrentCourse()


### PR DESCRIPTION
If an unloader in idle state blocking another unloader, we'll ask it to move as we are busy and it has
nothing to do anyway.

Such a situation can arise when the first unloader just finished overloading to a waiting trailer and pulled ahead a bit, waiting for a combine to call, when a second unloader arrives to the trailer to overload, but can't get close enough because it is blocked by the first, idle one.

#2568