### PR TITLE
fix: do not move forward before returning from pullback

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -342,18 +342,10 @@ function AIDriveStrategyCombineCourse:driveUnloadOnField()
         -- TODO: instead of just wait a few seconds we could check if the unloader has actually left
         if self.waitingForUnloaderSince + 5000 < g_currentMission.time then
             if self.stateBeforeWaitingForUnloaderToLeave == self.states.WAITING_FOR_UNLOAD_AFTER_PULLED_BACK then
-                local pullBackReturnCourse = self:createPullBackReturnCourse()
-                if pullBackReturnCourse then
-                    self.unloadState = self.states.RETURNING_FROM_PULL_BACK
-                    self:debug('Unloading finished, returning to fieldwork on return course')
-                    self:startCourse(pullBackReturnCourse, 1)
-                    self:rememberCourse(self.courseAfterPullBack, self.ixAfterPullBack)
-                else
-                    self:debug('Unloading finished, returning to fieldwork directly')
-                    self:startCourse(self.courseAfterPullBack, self.ixAfterPullBack)
-                    self.ppc:setNormalLookaheadDistance()
-                    self:changeToFieldWork()
-                end
+                self:debug('Unloading after pulled back finished, returning to fieldwork')
+                self:startCourse(self.courseAfterPullBack, self.ixAfterPullBack)
+                self.ppc:setNormalLookaheadDistance()
+                self:changeToFieldWork()
             elseif self.stateBeforeWaitingForUnloaderToLeave == self.states.WAITING_FOR_UNLOAD_IN_POCKET then
                 self:debug('Unloading in pocket finished, returning to fieldwork')
                 self.fillLevelFullPercentage = self.normalFillLevelFullPercentage
@@ -1171,12 +1163,6 @@ function AIDriveStrategyCombineCourse:getAreaToAvoid()
         local width = self.pullBackRightSideOffset
         return PathfinderUtil.NodeArea(AIUtil.getDirectionNode(self.vehicle), xOffset, zOffset, width, length)
     end
-end
-
-function AIDriveStrategyCombineCourse:createPullBackReturnCourse()
-    -- nothing fancy here either, just move forward a few meters before returning to the fieldwork course
-    local referenceNode = AIUtil.getDirectionNode(self.vehicle)
-    return Course.createFromNode(self.vehicle, referenceNode, 0, 0, 6, 2, false)
 end
 
 --- Create a temporary course to make a pocket in the fruit on the right (or left), so we can move into that pocket and

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -342,10 +342,18 @@ function AIDriveStrategyCombineCourse:driveUnloadOnField()
         -- TODO: instead of just wait a few seconds we could check if the unloader has actually left
         if self.waitingForUnloaderSince + 5000 < g_currentMission.time then
             if self.stateBeforeWaitingForUnloaderToLeave == self.states.WAITING_FOR_UNLOAD_AFTER_PULLED_BACK then
-                self:debug('Unloading after pulled back finished, returning to fieldwork')
-                self:startCourse(self.courseAfterPullBack, self.ixAfterPullBack)
-                self.ppc:setNormalLookaheadDistance()
-                self:changeToFieldWork()
+                local pullBackReturnCourse = self:createPullBackReturnCourse()
+                if pullBackReturnCourse then
+                    self.unloadState = self.states.RETURNING_FROM_PULL_BACK
+                    self:debug('Unloading finished, returning to fieldwork on return course')
+                    self:startCourse(pullBackReturnCourse, 1)
+                    self:rememberCourse(self.courseAfterPullBack, self.ixAfterPullBack)
+                else
+                    self:debug('Unloading finished, returning to fieldwork directly')
+                    self:startCourse(self.courseAfterPullBack, self.ixAfterPullBack)
+                    self.ppc:setNormalLookaheadDistance()
+                    self:changeToFieldWork()
+                end
             elseif self.stateBeforeWaitingForUnloaderToLeave == self.states.WAITING_FOR_UNLOAD_IN_POCKET then
                 self:debug('Unloading in pocket finished, returning to fieldwork')
                 self.fillLevelFullPercentage = self.normalFillLevelFullPercentage
@@ -1163,6 +1171,12 @@ function AIDriveStrategyCombineCourse:getAreaToAvoid()
         local width = self.pullBackRightSideOffset
         return PathfinderUtil.NodeArea(AIUtil.getDirectionNode(self.vehicle), xOffset, zOffset, width, length)
     end
+end
+
+function AIDriveStrategyCombineCourse:createPullBackReturnCourse()
+    -- nothing fancy here either, just move forward a few meters before returning to the fieldwork course
+    local referenceNode = AIUtil.getDirectionNode(self.vehicle)
+    return Course.createFromNode(self.vehicle, referenceNode, 0, 0, 6, 2, false)
 end
 
 --- Create a temporary course to make a pocket in the fruit on the right (or left), so we can move into that pocket and

--- a/scripts/pathfinder/PathfinderUtil.lua
+++ b/scripts/pathfinder/PathfinderUtil.lua
@@ -845,7 +845,7 @@ function PathfinderUtil.findAnalyticPath(solver, vehicleDirectionNode, startOffs
     local start = State3D(x, -z, CourseGenerator.fromCpAngle(yRot))
     x, z, yRot = PathfinderUtil.getNodePositionAndDirection(goalReferenceNode, xOffset or 0, zOffset or 0)
     local goal = State3D(x, -z, CourseGenerator.fromCpAngle(yRot))
-    return PathfinderUtil.findAnalyticPathFromVehicleToGoal(solver, start, goal, turnRadius)
+    return PathfinderUtil.findAnalyticPathFromStartToGoal(solver, start, goal, turnRadius)
 end
 
 --- Generate an analytic path between a start and goal position (given as State3D)

--- a/scripts/pathfinder/PathfinderUtil.lua
+++ b/scripts/pathfinder/PathfinderUtil.lua
@@ -845,6 +845,15 @@ function PathfinderUtil.findAnalyticPath(solver, vehicleDirectionNode, startOffs
     local start = State3D(x, -z, CourseGenerator.fromCpAngle(yRot))
     x, z, yRot = PathfinderUtil.getNodePositionAndDirection(goalReferenceNode, xOffset or 0, zOffset or 0)
     local goal = State3D(x, -z, CourseGenerator.fromCpAngle(yRot))
+    return PathfinderUtil.findAnalyticPathFromVehicleToGoal(solver, start, goal, turnRadius)
+end
+
+--- Generate an analytic path between a start and goal position (given as State3D)
+---@param solver AnalyticSolver for instance PathfinderUtil.dubinsSolver or PathfinderUtil.reedsSheppSolver
+---@param start State3D start pose
+---@param goal State3D goal pose
+---@param turnRadius number vehicle turning radius
+function PathfinderUtil.findAnalyticPathFromStartToGoal(solver, start, goal, turnRadius)
     local solution = solver:solve(start, goal, turnRadius)
     local length, path = solution:getLength(turnRadius)
     -- a solution with math.huge length means no soulution found
@@ -862,9 +871,11 @@ function PathfinderUtil.getNodePositionAndDirection(node, xOffset, zOffset)
 end
 
 ---@param vehicle table
+---@param xOffset|nil
+---@param zOffset|nil
 ---@return State3D position/heading of vehicle
-function PathfinderUtil.getVehiclePositionAsState3D(vehicle)
-    local x, z, yRot = PathfinderUtil.getNodePositionAndDirection(vehicle:getAIDirectionNode())
+function PathfinderUtil.getVehiclePositionAsState3D(vehicle, xOffset, zOffset)
+    local x, z, yRot = PathfinderUtil.getNodePositionAndDirection(vehicle:getAIDirectionNode(), xOffset, zOffset)
     return State3D(x, -z, CourseGenerator.fromCpAngle(yRot))
 end
 


### PR DESCRIPTION
Since we already wait a bit after the unloading in pull back finishes to let the unloader leave and our unloader reverses anyway a bit, do not drive forward before returning to the row.

Not sure how this will work with the AD unloader.

#2519