### PR TITLE
Might be a fix for #2666

### DIFF
--- a/scripts/ai/WorkWidthUtil.lua
+++ b/scripts/ai/WorkWidthUtil.lua
@@ -155,6 +155,10 @@ function WorkWidthUtil.getAutomaticWorkWidthAndOffset(object, referenceNode, ign
                 configuredOffset, left, right)
     elseif width and left and right then
         offset = left - width / 2
+        if left < 0 then 
+            --- If the offset is on the right side of the vehicle, than the right marker needs to be used for the calculation.
+            offset = right - width / 2
+        end
         WorkWidthUtil.debug(object, 'calculated tool offset is %.1f.', offset)
     else
         offset = 0


### PR DESCRIPTION
Test:
- Implements or vehicle which depend on the tool offset calculation, so ignoring config tool offset.
- Implements were the needed offset is positiv(left) or negtive(right) for comparison
