### PR TITLE
fix: reduce fruit check area

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1011,7 +1011,7 @@ end
 
 function AIDriveStrategyCombineCourse:checkFruitAtNode(node, offsetX, offsetZ)
     local x, _, z = localToWorld(node, offsetX, 0, offsetZ or 0)
-    local hasFruit, fruitValue = PathfinderUtil.hasFruit(x, z, 5, 3)
+    local hasFruit, fruitValue = PathfinderUtil.hasFruit(x, z, 1, 1)
     return hasFruit, fruitValue
 end
 
@@ -1022,7 +1022,7 @@ function AIDriveStrategyCombineCourse:isPipeInFruitAtWaypointNow(course, ix)
     end
     self.storage.fruitCheckHelperWpNode:setToWaypoint(course, ix)
     local hasFruit, fruitValue = self:checkFruitAtNode(self.storage.fruitCheckHelperWpNode.node, self.pipeController:getPipeOffsetX())
-    self:debugSparse('at waypoint %d pipe in fruit %s (fruitValue %.1f)', ix, tostring(hasFruit), fruitValue or 0)
+    self:debug('at waypoint %d pipe in fruit %s (fruitValue %.1f)', ix, tostring(hasFruit), fruitValue or 0)
     return hasFruit, fruitValue
 end
 


### PR DESCRIPTION
When checking if there is currently fruit at a future waypoint, use a smaller area (1x1 m instead of 5x3 m) under the pipe to check for fruit.

Larger areas may include some of the fruit in the current row and thus return a false positive even if the
row to the left is already harvested. This may also be worsened by the resolution of the fruit map/angle of row.

#2655