### PR TITLE
fix: safety check when registering

### DIFF
--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -356,7 +356,14 @@ function AIDriveStrategyUnloadCombine:getDriveData(dt, vX, vY, vZ)
     if self.combineToUnload and self.combineToUnload:getIsCpActive() then
         local strategy = self.combineToUnload:getCpDriveStrategy()
         if strategy then
-            self.combineToUnload:getCpDriveStrategy():registerUnloader(self)
+            if strategy.registerUnloader then
+                strategy:registerUnloader(self)
+            else
+                -- combine may have been stopped and restarted, so CP is active again but not yet the combine strategy,
+                -- for instance it is now driving to work start, so it can't accept a registration
+                self:debug('Lost my combine')
+                self:startWaitingForSomethingToDo()
+            end
         end
     end
 

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -682,7 +682,10 @@ end
 function AIDriveStrategyUnloadCombine:releaseCombine()
     self.combineJustUnloaded = nil
     if self.combineToUnload and self.combineToUnload:getIsCpActive() then
-        self.combineToUnload:getCpDriveStrategy():deregisterUnloader(self)
+        local strategy = self.combineToUnload:getCpDriveStrategy()
+        if strategy and strategy.deregisterUnloader then
+            strategy:deregisterUnloader(self)
+        end
         self.combineJustUnloaded = self.combineToUnload
     end
     self.combineToUnload = nil


### PR DESCRIPTION
Unloader checks if the combine really has the combine drive strategy installed.

#2691