### PR TITLE
fix: cover controller callstack

### DIFF
--- a/scripts/ai/controllers/CoverController.lua
+++ b/scripts/ai/controllers/CoverController.lua
@@ -30,6 +30,7 @@ function CoverController:getFillUnits()
 		end
 		return fillUnits
 	end
+	return {}
 end
 
 function CoverController:onStart()


### PR DESCRIPTION
Always return at least an empty table for fillUnits.

#2699