### PR TITLE
feat: combine self unload during turns

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -153,7 +153,7 @@ You can define the following custom settings:
     <!--\vehicles\andersonGroup-->
     <Vehicle name="rbm2000.xml"
              toolOffsetX = "-2.7"
-             turnRadius = "15"
+             turnRadius = "10"
     />
     <!--\vehicles\amazone-->
     <Vehicle name="citan15001C.xml"

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -1051,7 +1051,6 @@ function Course:adjustForTowedImplements(extensionLength)
 	local waypoints = {self.waypoints[1]}
 	for i = 2, #self.waypoints do
 		if self:switchingDirectionAt(i) then
-			print(i)
 			local wp = self.waypoints[i - 1]
 			local newWp = Waypoint(wp)
 			newWp.x = wp.x + wp.dx * extensionLength

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -893,7 +893,7 @@ function Course:getNextFwdWaypointIxFromVehiclePosition(ix, vehicleNode, maxDx, 
 			end
 		end
 	end
-	CpUtil.debugVehicle(CpDebug.DBG_COURSES, self.vehicle, 'Course: could not find next forward waypoint after %d', ix)
+	CpUtil.debugVehicle(CpDebug.DBG_COURSES, self.vehicle, 'Course: could not find next forward waypoint from vehicle position after %d', ix)
 	return ix, false
 end
 
@@ -907,7 +907,7 @@ function Course:getNextRevWaypointIxFromVehiclePosition(ix, vehicleNode, lookAhe
 			end
 		end
 	end
-	CpUtil.debugVehicle(CpDebug.DBG_COURSES, self.vehicle, 'Course: could not find next forward waypoint after %d', ix)
+	CpUtil.debugVehicle(CpDebug.DBG_COURSES, self.vehicle, 'Course: could not find next reverse waypoint from vehicle position after %d', ix)
 	return ix
 end
 

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -977,6 +977,12 @@ function Course:extend(length, dx, dz)
 		local z = lastWp.z + dz * i
 		self:appendWaypoint({x = x, z = z})
 	end
+	if length % step > 0 then
+		-- add the remainder to make sure we extend all the way up to length
+		local x = lastWp.x + dx * length
+		local z = lastWp.z + dz * length
+		self:appendWaypoint({x = x, z = z})
+	end
 	-- enrich the waypoints we added
 	self:enrichWaypointData(nWaypoints)
 end
@@ -1045,6 +1051,7 @@ function Course:adjustForTowedImplements(extensionLength)
 	local waypoints = {self.waypoints[1]}
 	for i = 2, #self.waypoints do
 		if self:switchingDirectionAt(i) then
+			print(i)
 			local wp = self.waypoints[i - 1]
 			local newWp = Waypoint(wp)
 			newWp.x = wp.x + wp.dx * extensionLength

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1658,6 +1658,7 @@ function AIDriveStrategyCombineCourse:onPathfindingDoneAfterSelfUnload(path)
         self:debug('Pathfinding to return to fieldwork after self unload finished with %d waypoints (%d ms)',
                 #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
         local returnCourse = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
+        self.returnCourse:adjustForTowedImplements(2)
         local fm, bm = self:getFrontAndBackMarkers()
         self.turnContext = RowStartOrFinishContext(self.vehicle, course, ix, ix, self.turnNodes, self:getWorkWidth(),
                 fm, bm, 0, 0)

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -62,7 +62,7 @@ AIDriveStrategyCombineCourse.myStates = {
     DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED = {},
     SELF_UNLOADING_AFTER_FIELDWORK_ENDED = {},
     SELF_UNLOADING_AFTER_FIELDWORK_ENDED_WAITING_FOR_DISCHARGE = {},
-    RETURNING_FROM_SELF_UNLOAD = { useAITurnDriveData = true },
+    RETURNING_FROM_SELF_UNLOAD = {},
 }
 
 -- stop limit we use for self unload to approach the trailer
@@ -500,7 +500,6 @@ function AIDriveStrategyCombineCourse:onLastWaypointPassed()
         elseif self.unloadState == self.states.REVERSING_TO_MAKE_A_POCKET then
             self:debug('Reversed, now start making a pocket to waypoint %d', self.unloadInPocketIx)
             self:lowerImplements()
-            -- TODO: maybe lowerImplements should not set the WAITING_FOR_LOWER_DELAYED state...
             self.state = self.states.UNLOADING_ON_FIELD
             self.unloadState = self.states.MAKING_POCKET
             -- offset the main fieldwork course and start on it
@@ -1658,7 +1657,7 @@ function AIDriveStrategyCombineCourse:onPathfindingDoneAfterSelfUnload(path)
         self:debug('Pathfinding to return to fieldwork after self unload finished with %d waypoints (%d ms)',
                 #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
         local returnCourse = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
-        self.returnCourse:adjustForTowedImplements(2)
+        returnCourse:adjustForTowedImplements(2)
         local fm, bm = self:getFrontAndBackMarkers()
         self.turnContext = RowStartOrFinishContext(self.vehicle, course, ix, ix, self.turnNodes, self:getWorkWidth(),
                 fm, bm, 0, 0)

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -27,8 +27,14 @@ AIDriveStrategyCombineCourse.safeUnloadDistanceBeforeEndOfRow = 30
 -- in the fruit
 AIDriveStrategyCombineCourse.waitForUnloadAtEndOfRowFillLevelThreshold = 95
 
+-- When to initiate a self unload before turning to the next row?
+-- if the fill level is above this threshold when about to begin a turn and there is a trailer
+-- close by, and ...
+AIDriveStrategyCombineCourse.selfUnloadBeforeNextRowFillLevelThreshold = 60
+-- if the best trailer is less then this (meters) to the left or right
+AIDriveStrategyCombineCourse.selfUnloadBeforeNextRowMaxDistance = 50
 --- Percentage delta leftover until full, when the combine slows down.
-AIDriveStrategyCombineCourse.startingSlowdownFillLevelThreshold = 1.5 
+AIDriveStrategyCombineCourse.startingSlowdownFillLevelThreshold = 1.5
 --- Minimum working speed, for slowdown.
 AIDriveStrategyCombineCourse.normalMinimalWorkingSpeed = 5
 
@@ -50,12 +56,13 @@ AIDriveStrategyCombineCourse.myStates = {
     WAITING_FOR_UNLOADER_TO_LEAVE = {},
     RETURNING_FROM_POCKET = {},
     DRIVING_TO_SELF_UNLOAD = {},
+    DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW = {}, -- before turning into the next row, we unload into a nearby trailer
     SELF_UNLOADING = {},
     SELF_UNLOADING_WAITING_FOR_DISCHARGE = {},
     DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED = {},
     SELF_UNLOADING_AFTER_FIELDWORK_ENDED = {},
     SELF_UNLOADING_AFTER_FIELDWORK_ENDED_WAITING_FOR_DISCHARGE = {},
-    RETURNING_FROM_SELF_UNLOAD = {}
+    RETURNING_FROM_SELF_UNLOAD = { useAITurnDriveData = true },
 }
 
 -- stop limit we use for self unload to approach the trailer
@@ -155,6 +162,13 @@ function AIDriveStrategyCombineCourse:setAllStaticParameters()
     self.fillLevelFullPercentage = self.normalFillLevelFullPercentage
 end
 
+-- useAITurnDriveData: in this state we are driving an AITurn course and thus rely on the AITurn or derived
+-- class to get the drive data
+function AIDriveStrategyCombineCourse:useAITurnDriveData()
+    return self.state.properties.useAITurnDriveData or
+            (self.state == self.states.UNLOADING_ON_FIELD and self.unloadState.properties.useAITurnDriveData)
+end
+
 function AIDriveStrategyCombineCourse:initializeImplementControllers(vehicle)
     AIDriveStrategyCombineCourse:superClass().initializeImplementControllers(self, vehicle)
     local _
@@ -220,8 +234,8 @@ function AIDriveStrategyCombineCourse:getDriveData(dt, vX, vY, vZ)
             -- Slowdown the combine near the last few percent, so no crops are leftover, 
             -- as the combine needs to stop in time, before it's full.
             local leftoverPercentage = self.fillLevelFullPercentage - self.combineController:getFillLevelPercentage()
-            if( leftoverPercentage > 0 and leftoverPercentage < self.startingSlowdownFillLevelThreshold ) then 
-                local speed = leftoverPercentage * (self.vehicle:getSpeedLimit(true)/self.startingSlowdownFillLevelThreshold) + self.normalMinimalWorkingSpeed
+            if (leftoverPercentage > 0 and leftoverPercentage < self.startingSlowdownFillLevelThreshold) then
+                local speed = leftoverPercentage * (self.vehicle:getSpeedLimit(true) / self.startingSlowdownFillLevelThreshold) + self.normalMinimalWorkingSpeed
                 self:setMaxSpeed(speed)
             end
         end
@@ -237,7 +251,9 @@ function AIDriveStrategyCombineCourse:getDriveData(dt, vX, vY, vZ)
     elseif self.state == self.states.UNLOADING_ON_FIELD then
         -- Unloading
         self:driveUnloadOnField()
-        self:callUnloaderWhenNeeded()
+        if self:isWaitingForUnload() then
+            self:callUnloaderWhenNeeded()
+        end
     end
     if self:isTurning() and not self:isTurningOnHeadland() then
         if self:shouldHoldInTurnManeuver() then
@@ -371,7 +387,8 @@ function AIDriveStrategyCombineCourse:driveUnloadOnField()
             end
         end
     elseif self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED or
-            self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD then
+            self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD or
+            self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW then
         if self:isCloseToCourseEnd(25) then
             -- slow down towards the end of the course, near the trailer
             self:setMaxSpeed(0.5 * self.settings.fieldSpeed:getValue())
@@ -393,8 +410,6 @@ function AIDriveStrategyCombineCourse:driveUnloadOnField()
         if self:isUnloadFinished() then
             if not self:continueSelfUnloadToNextTrailer() then
                 self:debug('Self unloading finished, returning to fieldwork')
-                self.unloadState = self.states.RETURNING_FROM_SELF_UNLOAD
-                self.ppc:setNormalLookaheadDistance()
                 self:returnToFieldworkAfterSelfUnload()
             end
         end
@@ -430,6 +445,7 @@ end
 function AIDriveStrategyCombineCourse:onWaypointPassed(ix, course)
     if self.state == self.states.UNLOADING_ON_FIELD and
             (self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD or
+                    self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW or
                     self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED or
                     self.unloadState == self.states.RETURNING_FROM_SELF_UNLOAD) then
         -- nothing to do while driving to unload and back
@@ -494,7 +510,8 @@ function AIDriveStrategyCombineCourse:onLastWaypointPassed()
             -- pulled back, now wait for unload
             self.unloadState = self.states.WAITING_FOR_UNLOAD_AFTER_PULLED_BACK
             self:debug('Pulled back, now wait for unload')
-        elseif self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD then
+        elseif self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD or
+                self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW then
             self:debug('Self unloading point reached, fill level %.1f, waiting for unload to start.', fillLevel)
             self.unloadState = self.states.SELF_UNLOADING_WAITING_FOR_DISCHARGE
         elseif self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED then
@@ -504,12 +521,9 @@ function AIDriveStrategyCombineCourse:onLastWaypointPassed()
     elseif self.state == self.states.WORKING and fillLevel > 0 then
         -- reset offset we used for the course ending to not miss anything
         self.aiOffsetZ = 0
-        if self.settings.selfUnload:getValue() and self:startSelfUnload() then
+        if self.settings.selfUnload:getValue() and
+                self:startSelfUnload(self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED) then
             self:debug('Start self unload after fieldwork ended')
-            self:raiseImplements()
-            self.state = self.states.UNLOADING_ON_FIELD
-            self.unloadState = self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED
-            self.ppc:setShortLookaheadDistance()
             self:disableCollisionDetection()
         else
             -- let AutoDrive know we are done and can unload
@@ -544,12 +558,9 @@ end
 function AIDriveStrategyCombineCourse:changeToUnloadOnField()
     self:checkFruit()
     -- TODO: check around turn maneuvers we may not want to pull back before a turn
-    if self.settings.selfUnload:getValue() and self:startSelfUnload() then
+    self:rememberCourse(self.fieldWorkCourse, self:getBestWaypointToContinueFieldWork())
+    if self.settings.selfUnload:getValue() and self:startSelfUnload(self.states.DRIVING_TO_SELF_UNLOAD) then
         self:debug('Start self unload')
-        self:raiseImplements()
-        self.state = self.states.UNLOADING_ON_FIELD
-        self.unloadState = self.states.DRIVING_TO_SELF_UNLOAD
-        self.ppc:setShortLookaheadDistance()
     elseif self.settings.avoidFruit:getValue() and self:shouldMakePocket() then
         -- I'm on the edge of the field or fruit is on both sides, make a pocket on the right side and wait there for the unload
         local pocketCourse, nextIx = self:createPocketCourse()
@@ -735,6 +746,10 @@ function AIDriveStrategyCombineCourse:estimateDistanceUntilFull(ix)
 end
 
 function AIDriveStrategyCombineCourse:shouldWaitAtEndOfRow()
+    if self.settings.selfUnload:getValue() then
+        -- don't wait for anyone when self unloading
+        return false
+    end
     local nextRowStartIx = self.course:getNextRowStartIx(self.ppc:getRelevantWaypointIx())
     local lastPassedWaypointIx = self.ppc:getLastPassedWaypointIx() or self.ppc:getRelevantWaypointIx()
     local distanceToNextTurn = self.course:getDistanceToNextTurn(lastPassedWaypointIx) or math.huge
@@ -1223,7 +1238,7 @@ end
 
 --- Only allow fuel save, if no trailer is under the pipe and we are waiting for unloading.
 function AIDriveStrategyCombineCourse:isFuelSaveAllowed()
-    if self.pipeController:isFillableTrailerUnderPipe() then 
+    if self.pipeController:isFillableTrailerUnderPipe() then
         -- Disables Fuel save, when a trailer is under the pipe.
         return false
     end
@@ -1244,8 +1259,8 @@ function AIDriveStrategyCombineCourse:shouldHoldInTurnManeuver()
     local waitForStraw = self.combineController:isDroppingStrawSwath() and not isFinishingRow
 
     self:debugSparse('Turn maneuver=> Dischargeable: %s, wait for straw: %s, straw swath active: %s, finishing row: %s',
-        tostring(discharging), tostring(waitForStraw), 
-        tostring(self.combineController:isDroppingStrawSwath()), tostring(isFinishingRow))
+            tostring(discharging), tostring(waitForStraw),
+            tostring(self.combineController:isDroppingStrawSwath()), tostring(isFinishingRow))
     return discharging or waitForStraw
 end
 
@@ -1297,7 +1312,10 @@ end
 
 --- Can the cutter be turned off ?
 function AIDriveStrategyCombineCourse:getCanCutterBeTurnedOff()
-    return self:isWaitingForUnload() or self.state == self.states.UNLOADING_ON_FIELD and self:isUnloadStateOneOf(self.selfUnloadStates)
+    return self:isWaitingForUnload() or
+            (self.state == self.states.UNLOADING_ON_FIELD and self:isUnloadStateOneOf(self.selfUnloadStates) and
+            -- we want that cutter to be turned on when returning to fieldwork after self unload
+                    self.unloadState ~= self.states.RETURNING_FROM_SELF_UNLOAD)
 end
 
 -----------------------------------------------------------------------------------------------------------------------
@@ -1341,7 +1359,18 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
         end
     else
         self:debug('Non headland turn.')
-        AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)
+        if self.settings.selfUnload:getValue() and self:shouldSelfUnloadBeforeNextRow() then
+            self:debug('Fill level over %.0f, attempt to self unload before continue with next row',
+                    AIDriveStrategyCombineCourse.selfUnloadBeforeNextRowFillLevelThreshold)
+            -- will continue at the turn end waypoint after the unload is finished
+            self:rememberCourse(self.fieldWorkCourse, ix + 1)
+            self.aiTurn = FinishRowOnly(self.vehicle, self, self.ppc, self.proximityController, self.turnContext,
+                    self, AIDriveStrategyCombineCourse.startSelfUnloadBeforeNextRow)
+            self.state = self.states.TURNING
+            self.waypointIxToContinueOnFailedSelfUnload = ix
+        else
+            AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)
+        end
     end
 end
 
@@ -1508,20 +1537,32 @@ end
 
 -----------------------------------------------------------------------------------------------------------------------
 --- Self unload
+--- When self unload is enabled, instead of calling an unloader when full, the combine will find
+--- a suitable trailer on or around the field, drive to the trailer and empty the grain tank into the trailer.
+--- See SelfUnloadHelper.lua on how exactly a trailer is picked.
+---
+--- There are two events which can trigger a self unload:
+--- 1. grain tank full
+--- 2. grain tank at more than 60% when the combine just finished a row and there is a
+---    trailer nearby.
+
 -----------------------------------------------------------------------------------------------------------------------
 --- Find a path to the best trailer to unload
-function AIDriveStrategyCombineCourse:startSelfUnload()
+function AIDriveStrategyCombineCourse:startSelfUnload(unloadStateAfterPathfindingDoneForSelfUnload,
+                                                      bestTrailer, fillRootNode)
 
     if not self.pathfinder or not self.pathfinder:isActive() then
-        self:rememberCourse(self.fieldWorkCourse, self:getBestWaypointToContinueFieldWork())
         self.pathfindingStartedAt = g_currentMission.time
         self.courseAfterPathfinding = nil
         self.waypointIxAfterPathfinding = nil
 
-        local targetNode, alignLength, offsetX = SelfUnloadHelper:getTargetParameters(self.fieldWorkCourse:getFieldPolygon(),
+        local targetNode, alignLength, offsetX = SelfUnloadHelper:getTargetParameters(
+                self.fieldWorkCourse:getFieldPolygon(),
                 self.vehicle,
                 self:getFillType(),
-                self.pipeController)
+                self.pipeController,
+                bestTrailer,
+                fillRootNode)
 
         if not targetNode then
             return false
@@ -1530,6 +1571,8 @@ function AIDriveStrategyCombineCourse:startSelfUnload()
         -- little straight section parallel to the trailer to align better
         self.selfUnloadAlignCourse = Course.createFromNode(self.vehicle, targetNode,
                 offsetX, -alignLength + 1, -self.pipeController:getPipeOffsetZ() - 1, 1, false)
+
+        self.unloadStateAfterPathfindingDoneForSelfUnload = unloadStateAfterPathfindingDoneForSelfUnload
 
         local fieldNum = CpFieldUtil.getFieldNumUnderVehicle(self.vehicle)
         local done, path
@@ -1542,6 +1585,7 @@ function AIDriveStrategyCombineCourse:startSelfUnload()
         if done then
             return self:onPathfindingDoneBeforeSelfUnload(path)
         else
+            self.state = self.states.WAITING_FOR_PATHFINDER
             self:setPathfindingDoneCallback(self, self.onPathfindingDoneBeforeSelfUnload)
         end
     else
@@ -1559,14 +1603,22 @@ function AIDriveStrategyCombineCourse:onPathfindingDoneBeforeSelfUnload(path)
             selfUnloadCourse:append(self.selfUnloadAlignCourse)
             self.selfUnloadAlignCourse = nil
         end
+        self:raiseImplements()
+        self.state = self.states.UNLOADING_ON_FIELD
+        self.unloadState = self.unloadStateAfterPathfindingDoneForSelfUnload
+        self.ppc:setShortLookaheadDistance()
         self:startCourse(selfUnloadCourse, 1)
         return true
     else
         self:debug('No path found to self unload in %d ms',
                 g_currentMission.time - (self.pathfindingStartedAt or 0))
-        if self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD then
+        if self.unloadStateAfterPathfindingDoneForSelfUnload == self.states.DRIVING_TO_SELF_UNLOAD then
             self.unloadState = self.states.WAITING_FOR_UNLOAD_ON_FIELD
-        elseif self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED then
+        elseif self.unloadStateAfterPathfindingDoneForSelfUnload == self.states.DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW then
+            -- continue turn as if nothing happened
+            self:startCourse(self.fieldWorkCourse, self.waypointIxToContinueOnFailedSelfUnload)
+            AIDriveStrategyCombineCourse.superClass().startTurn(self, self.waypointIxToContinueOnFailedSelfUnload)
+        elseif self.unloadStateAfterPathfindingDoneForSelfUnload == self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED then
             self.unloadState = self.states.WAITING_FOR_UNLOAD_AFTER_FIELDWORK_ENDED
         end
         return false
@@ -1586,6 +1638,7 @@ function AIDriveStrategyCombineCourse:returnToFieldworkAfterSelfUnload()
         if done then
             return self:onPathfindingDoneAfterSelfUnload(path)
         else
+            self.state = self.states.WAITING_FOR_PATHFINDER
             self:setPathfindingDoneCallback(self, self.onPathfindingDoneAfterSelfUnload)
         end
     else
@@ -1597,22 +1650,34 @@ end
 function AIDriveStrategyCombineCourse:onPathfindingDoneAfterSelfUnload(path)
     -- TODO: for some reason, the combine lowers the header while unloading, that should be fixed, for now, raise it here
     self:raiseImplements()
+    local course, ix = self:getRememberedCourseAndIx()
     if path and #path > 2 then
+        self.state = self.states.UNLOADING_ON_FIELD
+        self.unloadState = self.states.RETURNING_FROM_SELF_UNLOAD
+        self.ppc:setShortLookaheadDistance()
         self:debug('Pathfinding to return to fieldwork after self unload finished with %d waypoints (%d ms)',
                 #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
         local returnCourse = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
-        self:startCourse(returnCourse, 1)
+        local fm, bm = self:getFrontAndBackMarkers()
+        self.turnContext = RowStartOrFinishContext(self.vehicle, course, ix, ix, self.turnNodes, self:getWorkWidth(),
+                fm, bm, 0, 0)
+        self.aiTurn = StartRowOnly(self.vehicle, self, self.ppc, self.proximityController,
+                self.turnContext, returnCourse, course, self.workWidth)
+        self.course = course
         return true
     else
         self:debug('No path found to return to fieldwork after self unload (%d ms)',
                 g_currentMission.time - (self.pathfindingStartedAt or 0))
-        local course, ix = self:getRememberedCourseAndIx()
         local returnCourse = AlignmentCourse(self.vehicle, self.vehicle:getAIDirectionNode(),
                 self.turningRadius, course, ix, 0):getCourse()
         if returnCourse then
+            self.state = self.states.UNLOADING_ON_FIELD
+            self.unloadState = self.states.RETURNING_FROM_SELF_UNLOAD
+            self.ppc:setShortLookaheadDistance()
             self:debug('Start an alignment course to fieldwork waypoint %d', ix)
             self:startCourse(returnCourse, 1)
         else
+            self.state = self.states.WORKING
             self:debug('Could not generate alignment course to fieldwork waypoint %d, starting course directly', ix)
             self:startRememberedCourse()
         end
@@ -1624,15 +1689,48 @@ function AIDriveStrategyCombineCourse:continueSelfUnloadToNextTrailer()
     local fillLevel = self.combineController:getFillLevel()
     if fillLevel > 20 then
         self:debug('Self unloading finished, but fill level is %.1f, is there another trailer around we can unload to?', fillLevel)
-        if self:startSelfUnload() then
-            self:raiseImplements()
-            self.state = self.states.UNLOADING_ON_FIELD
-            self.unloadState = self.states.DRIVING_TO_SELF_UNLOAD
-            self.ppc:setShortLookaheadDistance()
+        if self:startSelfUnload(self.states.DRIVING_TO_SELF_UNLOAD) then
             return true
         end
     end
     return false
+end
+
+function AIDriveStrategyCombineCourse:shouldSelfUnloadBeforeNextRow()
+    if self:isFull(AIDriveStrategyCombineCourse.selfUnloadBeforeNextRowFillLevelThreshold) then
+        local distance
+        self.selfUnloadBestTrailer, self.selfUnloadFillRootNode, distance = SelfUnloadHelper:findBestTrailer(
+                self.fieldWorkCourse:getFieldPolygon(),
+                self.vehicle,
+                self:getFillType(),
+                self.pipeController.pipeOffsetX)
+        local dx, _, dz = localToLocal(AIUtil.getDirectionNode(self.vehicle),
+                AIUtil.getDirectionNode(self.selfUnloadBestTrailer), 0, 0, 0)
+        self:debug('Best trailer dx: %.1f, dz: %.1f', dx, dz)
+        -- the best trailer is sort of in front of us and not too far to the left or right
+        if dz > -10 and math.abs(dx) < AIDriveStrategyCombineCourse.selfUnloadBeforeNextRowMaxDistance then
+            self:debug('Best trailer for self unload is less than %.0f m, start self unload before continuing with next row',
+                    AIDriveStrategyCombineCourse.selfUnloadBeforeNextRowMaxDistance)
+            return true
+        end
+    end
+    return false
+end
+
+-- This is a callback from the "finish row only" turn initiated at the end of the row when there is a
+-- trailer nearby for self unloading. At this point, the row is done and we are ready to drive to the
+-- trailer before starting the next row
+function AIDriveStrategyCombineCourse:startSelfUnloadBeforeNextRow()
+    -- giving back control to the strategy, re-register these listeners
+    self.ppc:registerListeners(self, 'onWaypointPassed', 'onWaypointChange')
+    if self:startSelfUnload(self.states.DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW,
+            self.selfUnloadBestTrailer, self.selfUnloadFillRootNode) then
+        self:debug('Start self unload before continuing with next row')
+    else
+        -- giving up self unload, attempt to re-initialize the turn
+        self:startCourse(self.fieldWorkCourse, self.waypointIxToContinueOnFailedSelfUnload)
+        AIDriveStrategyCombineCourse.superClass().startTurn(self, self.waypointIxToContinueOnFailedSelfUnload)
+    end
 end
 
 --- Let unloaders register for events. This is different from the CombineUnloadManager registration, these
@@ -1651,7 +1749,7 @@ function AIDriveStrategyCombineCourse:registerUnloader(driver)
 end
 
 --- Deregister a combine unload AI driver from notifications
----@param driver CombineUnloadAIDriver
+---@param driver AIDriveStrategyUnloadCombine
 function AIDriveStrategyCombineCourse:deregisterUnloader(driver, noEventSend)
     self:cancelRendezvous()
     self.unloader:reset()

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -28,7 +28,6 @@ local AIDriveStrategyCourse_mt = Class(AIDriveStrategyCourse, AIDriveStrategy)
 AIDriveStrategyCourse.myStates = {
     INITIAL = {},
     WAITING_FOR_PATHFINDER = {},
-    DRIVING_TO_WORK_START_WAYPOINT = {},
 }
 
 --- Implement controller events.

--- a/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -31,6 +31,7 @@ local AIDriveStrategyDriveToFieldWorkStart_mt = Class(AIDriveStrategyDriveToFiel
 
 AIDriveStrategyDriveToFieldWorkStart.myStates = {
     PREPARE_TO_DRIVE = {},
+    DRIVING_TO_WORK_START = {},
     WORK_START_REACHED = {},
 }
 
@@ -130,7 +131,7 @@ function AIDriveStrategyDriveToFieldWorkStart:getDriveData(dt, vX, vY, vZ)
         self:setMaxSpeed(0)
         local isReadyToDrive, blockingVehicle = self.vehicle:getIsAIReadyToDrive()
         if isReadyToDrive then
-            self.state = self.states.DRIVING_TO_WORK_START_WAYPOINT
+            self.state = self.states.DRIVING_TO_WORK_START
             self:debug('Ready to drive to work start')
         else
             self:debugSparse('Not ready to drive because of %s, preparing ...', CpUtil.getName(blockingVehicle))
@@ -138,11 +139,11 @@ function AIDriveStrategyDriveToFieldWorkStart:getDriveData(dt, vX, vY, vZ)
                 self.prepareTimeout = self.prepareTimeout + dt
                 if 2000 < self.prepareTimeout then
                     self:debug('Timeout preparing, continue anyway')
-                    self.state = self.states.DRIVING_TO_WORK_START_WAYPOINT
+                    self.state = self.states.DRIVING_TO_WORK_START
                 end
             end
         end
-    elseif self.state == self.states.DRIVING_TO_WORK_START_WAYPOINT then
+    elseif self.state == self.states.DRIVING_TO_WORK_START then
         self:setMaxSpeed(self.settings.fieldSpeed:getValue())
     elseif self.state == self.states.WORK_START_REACHED then
         if self.emergencyBrake:get() then

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -451,8 +451,6 @@ function AIDriveStrategyFieldWorkCourse:onWaypointPassed(ix, course)
         self:checkTransitionFromConnectingTrack(ix, course)
     elseif self.state == self.states.ON_CONNECTING_TRACK then
         self:checkTransitionFromConnectingTrack(ix, course)
-    elseif self.state == self.states.DRIVING_TO_WORK_START_WAYPOINT then
-        self.workStarter:onWaypointPassed(ix, course)
     end
     if course:isLastWaypointIx(ix) then
         self:onLastWaypointPassed()
@@ -506,7 +504,7 @@ function AIDriveStrategyFieldWorkCourse:resumeFieldworkAfterTurn(ix, forceIx)
     self:lowerImplements()
     -- restore our own listeners for waypoint changes
     self.ppc:registerListeners(self, 'onWaypointPassed', 'onWaypointChange')
-    local startIx = forceIx and ix or self.course:getNextFwdWaypointIxFromVehiclePosition(ix,
+    local startIx = forceIx and ix or self.fieldWorkCourse:getNextFwdWaypointIxFromVehiclePosition(ix,
             self.vehicle:getAIDirectionNode(), self.workWidth / 2)
     self:startCourse(self.fieldWorkCourse, startIx)
 end

--- a/scripts/ai/AIDriveStrategyPlowCourse.lua
+++ b/scripts/ai/AIDriveStrategyPlowCourse.lua
@@ -79,8 +79,8 @@ function AIDriveStrategyPlowCourse:getDriveData(dt, vX, vY, vZ)
         self:setMaxSpeed(0)
         if not self.plow.spec_plow:getIsAnimationPlaying(self.plow.spec_plow.rotationPart.turnAnimation) then
             self:setOffsetX()
+            self:startWaitingForLower()
             self:lowerImplements(self.vehicle)
-            self.state = self.states.WAITING_FOR_LOWER_DELAYED
             self:debug('Plow rotation finished, ')
         end
     elseif self.state == self.states.UNFOLDING_PLOW then

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -102,7 +102,7 @@ end
 
 function AIUtil.getTowBarLength(vehicle)
 	-- is there a wheeled implement behind the tractor and is it on a pivot?
-	local implement = AIUtil.getFirstReversingImplementWithWheels(vehicle)
+	local implement = AIUtil.getFirstReversingImplementWithWheels(vehicle, true)
 	if not implement or not implement.steeringAxleNode then
 		CpUtil.debugVehicle(CpDebug.DBG_AI_DRIVER, vehicle, 'could not get tow bar length, using default 3 m.')
 		-- default is not 0 as this is used to calculate trailer heading and 0 here may result in NaNs

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -1,6 +1,6 @@
 --[[
 This file is part of Courseplay (https://github.com/Courseplay/courseplay)
-Copyright (C) 2019 Peter Vaiko
+Copyright (C) 2019 - 2023 Courseplay Dev Team
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -947,15 +947,24 @@ end
 ---@class FinishRowOnly : AITurn
 FinishRowOnly = CpObject(AITurn)
 
+---@param callbackObject table|nil
+---@param callbackFunction function|nil member function of callbackObject to call after the row is finished. If
+--- object and function is nil, just resume fieldwork.
 function FinishRowOnly:init(vehicle, driveStrategy, ppc, proximityController, turnContext, callbackObject, callbackFunction)
     AITurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, 0, 'FinishRow')
     self.callbackObject = callbackObject
     self.callbackFunction = callbackFunction
 end
 
+-- don't perform the actual turn, just give back control to the strategy
 function FinishRowOnly:startTurn()
-    self:debug('Triggering callback function')
-    self.callbackFunction(self.callbackObject)
+    if self.callbackFunction and self.callbackObject then
+        self:debug('Row finished, triggering callback function')
+        self.callbackFunction(self.callbackObject)
+    else
+        self:debug('Row finished, no callback supplied, so resuming fieldwork')
+        self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+    end
 end
 
 function FinishRowOnly:updateTurnProgress()
@@ -963,27 +972,96 @@ function FinishRowOnly:updateTurnProgress()
 end
 
 --- A turn which really isn't a turn just a course to start a field work row using the supplied course and
---- making sure we start working at that waypoint with all implements lowered in time.
+--- making sure we start working at the start point defined by the turn context with all implements lowered in time.
+--- This does not actually drive the course like the other AITurn derivates to keep full control in the strategy
+--- (like not registering its own onWaypoint* callbacks). It only provides a getDriveData() for limiting
+--- the speed, and probably should not even be a turn.
 ---@class StartRowOnly: CourseTurn
 StartRowOnly = CpObject(CourseTurn)
+---@param turnContext RowStartOrFinishContext a turn context holding all data about the work start location and
+--- the implement configuration
 ---@param startRowCourse Course course leading to the first waypoint of the row to start
----@param fieldWorkCourse Course field work course
----@param workWidth number
-function StartRowOnly:init(vehicle, driveStrategy, ppc, proximityController, turnContext, startRowCourse, fieldWorkCourse, workWidth)
-    CourseTurn.init(self, vehicle, driveStrategy, ppc, proximityController, turnContext, fieldWorkCourse, workWidth, 'StartRow')
+function StartRowOnly:init(vehicle, driveStrategy, ppc, turnContext, startRowCourse)
+    -- not yet reached a TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END marker
+    self:addState('DRIVING_TO_ROW')
+    -- close to the work start point, ready to lower at the right moment
+    self:addState('APPROACHING_ROW')
+    -- implements are now lowering, maneuver ends when they are completely lowered
+    self:addState('IMPLEMENTS_LOWERING')
+    self.vehicle = vehicle
+    self.settings = vehicle:getCpSettings()
+    self.turningRadius = AIUtil.getTurningRadius(self.vehicle)
+    ---@type AIDriveStrategyFieldWorkCourse
+    self.driveStrategy = driveStrategy
+    ---@type PurePursuitController
+    self.ppc = ppc
+    ---@type TurnContext
+    self.turnContext = turnContext
+    self.name = 'StartRowOnly'
+
     self.turnCourse = startRowCourse
-    self.enableTightTurnOffset = true
+
+    self.forceTightTurnOffset = false
+    local _, steeringLength = AIUtil.getSteeringParameters(self.vehicle)
+    self.enableTightTurnOffset = steeringLength > 0 and not AIUtil.hasArticulatedAxis(self.vehicle)
+
+        -- TODO: do we need tight turn offset here?
     self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
     -- add a turn ending section into the row to make sure the implements are lowered correctly
     local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, 3, true)
     TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
-    self.ppc:setCourse(self.turnCourse)
-    self.ppc:initialize(1)
-    self.state = self.states.TURNING
+    self.state = self.states.DRIVING_TO_ROW
 end
 
-function StartRowOnly:updateTurnProgress()
-    -- do nothing since this isn't really a turn
+function StartRowOnly:getCourse()
+    return self.turnCourse
+end
+
+--- Implements the usual getDriveData() interface, only ever sets the maximum speed though
+function StartRowOnly:getDriveData()
+    if self.state == self.states.DRIVING_TO_ROW then
+        if TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(),
+                TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END) then
+            self.state = self.states.APPROACHING_ROW
+            self:debug('Approaching row')
+        end
+    elseif self.state == self.states.APPROACHING_ROW then
+        local shouldLower, _ = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode,
+                self.ppc:isReversing())
+        if shouldLower then
+            -- have not started lowering implements yet
+            self:debug('Lowering implements')
+            self.driveStrategy:lowerImplements()
+            self.state = self.states.IMPLEMENTS_LOWERING
+            if self.ppc:isReversing() then
+                -- when ending a turn in reverse, don't drive the rest of the course, switch right back to fieldwork
+                self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+            end
+        end
+        return nil, nil, nil, self:getForwardSpeed()
+    elseif self.state == self.states.IMPLEMENTS_LOWERING then
+        local _, dz = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode, self.ppc:isReversing())
+        -- implements already lowering, making sure we check if they are lowered, the faster we go, the earlier,
+        -- for those people who set insanely high turn speeds...
+        local implementCheckDistance = math.max(1, 0.1 * self.vehicle:getLastSpeed())
+        if dz and dz > -implementCheckDistance then
+            if self.vehicle:getCanAIFieldWorkerContinueWork() then
+                self:debug("implements lowered, resume fieldwork")
+                self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
+            else
+                self:debug('waiting for lower at dz=%.1f', dz)
+                -- we are almost at the start of the row but still not lowered everything, hold.
+                return nil, nil, nil, 0
+            end
+        end
+        return nil, nil, nil, self:getForwardSpeed()
+    end
+    return nil, nil, nil, nil
+end
+
+function StartRowOnly:onLastWaypoint()
+    self:debug('Last waypoint reached before all implements are lowered, resuming fieldwork')
+    self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
 end
 
 --- A turn for working between vine rows.

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -384,8 +384,10 @@ function TurnContext:appendEndingTurnCourse(course, extraLength, useTightTurnOff
     local waypoints = {}
     -- A line between the front marker and the work start node, regardless of which one is first
     local startNode = dzFrontMarker < dzWorkStart and self.vehicleAtTurnEndNode or self.workStartNode
+    -- make sure course is long enough that the back marker reaches the work start
+    local lenToBackMarker = self.frontMarkerDistance - self.backMarkerDistance
 	-- extra length at the end to allow for alignment
-	extraLength = extraLength and (extraLength + 3) or 3
+	extraLength = extraLength and (extraLength + lenToBackMarker) or lenToBackMarker
     -- +1 so the first waypoint of the appended line won't overlap with the last wp of course
     self:debug('appendEndingTurnCourse: dzVehicleAtTurnEnd: %.1f, dzWorkStart: %.1f, extra %.1f)',
             dzFrontMarker, dzWorkStart, extraLength)


### PR DESCRIPTION
At the end of the row, the combine checks if there is a trailer nearby, and above a certain fill level, it empties its grain tank into the trailer before
continuing with the next row.