### PR TITLE
fix: pathfinder turns

### DIFF
--- a/scripts/Waypoint.lua
+++ b/scripts/Waypoint.lua
@@ -90,7 +90,6 @@ function Waypoint:set(wp, cpIndex)
 	self.cpIndex = cpIndex or 0
 	self.turnStart = wp.turnStart
 	self.turnEnd = wp.turnEnd
-	self.interact = wp.wait or wp.interact or false
 	self.isConnectingTrack = wp.isConnectingTrack or nil
 	self.lane = wp.lane
 	self.rowNumber = wp.rowNumber

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -148,7 +148,6 @@ function AIDriveStrategyCombineCourse:setAllStaticParameters()
     self.pocketReverseDistance = 20
     -- register ourselves at our boss
     -- TODO_22 g_combineUnloadManager:addCombineToList(self.vehicle, self)
-    self:measureBackDistance()
     self.waitingForUnloaderAtEndOfRow = CpTemporaryObject()
     --- My unloader. This expires in a few seconds, so unloaders have to renew their registration periodically
     ---@type CpTemporaryObject
@@ -1922,8 +1921,8 @@ end
 function AIDriveStrategyCombineCourse:measureBackDistance()
     self.measuredBackDistance = 0
     -- raycast from a point behind the vehicle forward towards the direction node
-    local nx, ny, nz = localDirectionToWorld(self.vehicle.rootNode, 0, 0, 1)
-    local x, y, z = localToWorld(self.vehicle.rootNode, 0, 1.5, -self.maxBackDistance)
+    local nx, ny, nz = localDirectionToWorld(AIUtil.getDirectionNode(self.vehicle), 0, 0, 1)
+    local x, y, z = localToWorld(AIUtil.getDirectionNode(self.vehicle), 0, 1.5, -self.maxBackDistance)
     raycastAll(x, y, z, nx, ny, nz, 'raycastBackCallback', self.maxBackDistance, self)
 end
 

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -379,9 +379,10 @@ function AIDriveStrategyCourse:setFrontAndBackMarkers()
     self:debug('front marker: %.1f, back marker: %.1f', frontMarkerDistance, backMarkerDistance)
 end
 
---- Gets the front and back marker offset
----@return number front marker distance
----@return number back marker distance
+--- Gets the front and back marker offset relative to the direction node. These markers define the front
+--- and the back of the work area. When negative, they are behind the direction node, when positive, in front of it.
+---@return number distance of the foremost work area from the direction node, negative when behind the direction node
+---@return number distance of the rearmost work area from the direction node, negative when behind the direction node
 function AIDriveStrategyCourse:getFrontAndBackMarkers()
     if not self.frontMarkerDistance then
         self:setFrontAndBackMarkers()

--- a/scripts/ai/Markers.lua
+++ b/scripts/ai/Markers.lua
@@ -7,9 +7,9 @@
             - moved all the way to the back of the vehicle or the rear most attached implement.
 
         - front marker offset:
-            - distance between the vehicle root node and the front maker node (positive)
+            - distance between the vehicle direction node and the front maker node (positive)
         - back marker offset:
-            - distance between the vehicle root node and the back maker node (negative)
+            - distance between the vehicle direction node and the back maker node (negative)
 
 ]]
 
@@ -68,7 +68,7 @@ end
 -- Put a node on the front of the vehicle for easy distance checks use this instead of the root/direction node
 local function setFrontMarkerNode(vehicle)
     local firstImplement, frontMarkerOffset = AIUtil.getFirstAttachedImplement(vehicle)
-    CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, 'Using the %s\'s root node for the front marker node, %d m from root node',
+    CpUtil.debugVehicle(CpDebug.DBG_IMPLEMENTS, vehicle, 'Using the %s\'s direction node for the front marker node, %d m from direction node',
             CpUtil.getName(firstImplement), frontMarkerOffset)
 
     createMarkerIfDoesNotExist(vehicle, 'frontMarkerNode',  AIUtil.getDirectionNode(vehicle))

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -606,7 +606,7 @@ function CourseTurn:endTurn(dt)
                     self:debug("implements lowered, resume fieldwork")
                     self:resumeFieldworkAfterTurn(self.turnContext.turnEndWpIx)
                 else
-                    self:debug('waiting for lower at dz=%.1f %s', dz, self.vehicle:getAttachedImplements()[1].object:getCanAIImplementContinueWork())
+                    self:debug('waiting for lower at dz=%.1f', dz)
                     -- we are almost at the start of the row but still not lowered everything,
                     -- hold.
                     return false
@@ -726,10 +726,12 @@ function CourseTurn:onPathfindingDone(path)
     if path and #path > 2 then
         self:debug('Pathfinding finished with %d waypoints (%d ms)', #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
         self.turnCourse = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
-        self.turnCourse:adjustForTowedImplements(2)
         -- make sure we use tight turn offset towards the end of the course so a towed implement is aligned with the new row
         self.turnCourse:setUseTightTurnOffsetForLastWaypoints(15)
         local endingTurnLength = self.turnContext:appendEndingTurnCourse(self.turnCourse, nil, true)
+        local x = AIUtil.getDirectionNodeToReverserNodeOffset(self.vehicle)
+        self:debug('Extending course at direction switch for reversing: %.1f m', -x )
+        self.turnCourse:adjustForReversing(math.max(0, -x))
         TurnManeuver.setLowerImplements(self.turnCourse, endingTurnLength, true)
     else
         self:debug('No path found in %d ms, falling back to normal turn course generator', g_currentMission.time - (self.pathfindingStartedAt or 0))


### PR DESCRIPTION
- Fix pathfinder turns for vehicles with reverser nodes: extend the path at direction switch to make sure the direction node of the vehicle reaches the direction switch waypoint.
- Fix the front and back markers: they are related to the direction node, not the root node.
- Fix a call stack at turn end (forgotten debug)
- Removed some obsolete legacy code from Course.lua

#2751