### PR TITLE
fix: reversing with offset tools

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -185,7 +185,6 @@ You can define the following custom settings:
     <!--\vehicles\ropa-->
     <Vehicle name="keiler2.xml"
              toolOffsetX = "-2.0"
-             noReverse = "true"
     />
 	<!--\vehicles\ropa-->
     <Vehicle name="nawaRoMaus.xml"
@@ -228,12 +227,10 @@ You can define the following custom settings:
     />
     <!--\vehicles\lemken-->
     <Vehicle name="titan11.xml"
-             noReverse = "true"
              turnRadius = "7.5"
              implementWheelAlwaysOnGround = "true"
 	/>
     <Vehicle name="titan18.xml"
-             noReverse="true"
              turnRadius = "7.5"
              implementWheelAlwaysOnGround = "true"
              raiseLate = "true"
@@ -252,7 +249,6 @@ You can define the following custom settings:
              noReverse = "false"
              turnRadius = "9"
     />
-    <!--vehicles\seedHawk-->
     <Vehicle name="980AirCart.xml"
              noReverse = "true"
     />
@@ -406,7 +402,6 @@ You can define the following custom settings:
              turnRadius = "7.5"
              implementWheelAlwaysOnGround = "true"
 			 workingWidth = "10.5"
-             noReverse = "true"
     />
     <!--Mod: KOECKERLING Vector 460-->
 	<Vehicle name="vector460.xml"

--- a/scripts/ai/AIDriveStrategyPlowCourse.lua
+++ b/scripts/ai/AIDriveStrategyPlowCourse.lua
@@ -40,6 +40,9 @@ function AIDriveStrategyPlowCourse.new(customMt)
     local self = AIDriveStrategyFieldWorkCourse.new(customMt)
     AIDriveStrategyFieldWorkCourse.initStates(self, AIDriveStrategyPlowCourse.myStates)
     self.debugChannel = CpDebug.DBG_FIELDWORK
+    -- the plow offset is automatically calculated on each waypoint and if it wasn't calculated for a while
+    -- or when some event (like a turn) invalidated it
+    self.plowOffsetUnknown = CpTemporaryObject(true)
     return self
 end
 
@@ -86,6 +89,9 @@ function AIDriveStrategyPlowCourse:getDriveData(dt, vX, vY, vZ)
             self:debug('Plow is unfolded and ready to start')
         end
     end
+    if self.plowOffsetUnknown:get() then
+        self:updatePlowOffset()
+    end
     return AIDriveStrategyFieldWorkCourse.getDriveData(self, dt, vX, vY, vZ)
 end
 
@@ -107,7 +113,7 @@ function AIDriveStrategyPlowCourse:updatePlowOffset()
         if controller.getAutomaticXOffset then
             local autoOffset = controller:getAutomaticXOffset()
             if autoOffset == nil then
-                self:debug('Plow offset can\'t be calculated now, leaving offset at %.2f', self.aiOffsetX)
+                self:debugSparse('Plow offset can\'t be calculated now, leaving offset at %.2f', self.aiOffsetX)
                 return
             end
             xOffset = xOffset + autoOffset
@@ -115,9 +121,12 @@ function AIDriveStrategyPlowCourse:updatePlowOffset()
     end
     local oldOffset = self.aiOffsetX
     -- set to the average of old and new to smooth a little bit to avoid oscillations
-    self.aiOffsetX = (0.5 * self.aiOffsetX + 1.5 * xOffset) / 2
-    self:debug("Plow offset calculated was %.2f and it changed from %.2f to %.2f",
-        xOffset, oldOffset, self.aiOffsetX)
+    -- when we have a valid previous value
+    self.aiOffsetX = self.plowOffsetUnknown:get() and xOffset or ((0.5 * self.aiOffsetX + 1.5 * xOffset) / 2)
+    if math.abs(oldOffset - xOffset) > 0.05 then
+        self:debug("Plow offset calculated was %.2f and it changed from %.2f to %.2f", xOffset, oldOffset, self.aiOffsetX)
+    end
+    self.plowOffsetUnknown:set(false, 3000)
 end
 
 --- Is a plow currently rotating?
@@ -178,8 +187,6 @@ end
 --- When we return from a turn, the offset is reverted and should immediately set, not waiting
 --- for the first waypoint to pass as it is on the wrong side right after the turn
 function AIDriveStrategyPlowCourse:resumeFieldworkAfterTurn(ix)
-    -- call twice to trick the smoothing and reach the desired value sooner.
-    self:updatePlowOffset()
-    self:updatePlowOffset()
+    self.plowOffsetUnknown:reset()
     AIDriveStrategyPlowCourse.superClass().resumeFieldworkAfterTurn(self, ix)
 end

--- a/scripts/ai/AIDriveStrategyPlowCourse.lua
+++ b/scripts/ai/AIDriveStrategyPlowCourse.lua
@@ -104,8 +104,13 @@ end
 function AIDriveStrategyPlowCourse:updatePlowOffset()
     local xOffset = 0
     for _, controller in pairs(self.controllers) do 
-        if controller.getAutomaticXOffset then 
-            xOffset = xOffset + controller:getAutomaticXOffset()
+        if controller.getAutomaticXOffset then
+            local autoOffset = controller:getAutomaticXOffset()
+            if autoOffset == nil then
+                self:debug('Plow offset can\'t be calculated now, leaving offset at %.2f', self.aiOffsetX)
+                return
+            end
+            xOffset = xOffset + autoOffset
         end
     end
     local oldOffset = self.aiOffsetX

--- a/scripts/ai/AIReverseDriver.lua
+++ b/scripts/ai/AIReverseDriver.lua
@@ -25,32 +25,32 @@ AIReverseDriver = CpObject()
 
 ---@param course Course
 function AIReverseDriver:init(vehicle, ppc)
-	self.vehicle = vehicle
-	self.settings = vehicle:getCpSettings()
-	---@type PurePursuitController
-	self.ppc = ppc
-	-- the main implement (towed) or trailer we are controlling
-	self.reversingImplement = AIUtil.getFirstReversingImplementWithWheels(self.vehicle)
-	if self.reversingImplement then
-		self.steeringLength = AIUtil.getTowBarLength(self.vehicle)
-		self:setReversingProperties(self.reversingImplement)
-	else
-		self:debug('No towed implement found.')
-	end
-	self:debug('AIReverseDriver created.')
-	-- TODO_22
-	-- handle HookLift
+    self.vehicle = vehicle
+    self.settings = vehicle:getCpSettings()
+    ---@type PurePursuitController
+    self.ppc = ppc
+    -- the main implement (towed) or trailer we are controlling
+    self.reversingImplement = AIUtil.getFirstReversingImplementWithWheels(self.vehicle)
+    if self.reversingImplement then
+        self.steeringLength = AIUtil.getTowBarLength(self.vehicle)
+        self:setReversingProperties(self.reversingImplement)
+    else
+        self:debug('No towed implement found.')
+    end
+    self:debug('AIReverseDriver created.')
+    -- TODO_22
+    -- handle HookLift
 end
 
 function AIReverseDriver:debug(...)
-	CpUtil.debugVehicle(CpDebug.DBG_REVERSE, self.vehicle, ...)
+    CpUtil.debugVehicle(CpDebug.DBG_REVERSE, self.vehicle, ...)
 end
 
 function AIReverseDriver:getDriveData()
-	if self.reversingImplement == nil then
-		-- no wheeled implement, simple reversing the PPC can handle by itself
-		return nil
-	end
+    if self.reversingImplement == nil then
+        -- no wheeled implement, simple reversing the PPC can handle by itself
+        return nil
+    end
 
     -- if there's a reverser node on the tool, use that, otherwise the steering node
     -- the reverser direction node, if exists, works better for tools with offset or for
@@ -86,167 +86,171 @@ function AIReverseDriver:getDriveData()
         local lxTractor, lzTractor = AIVehicleUtil.getDriveDirection(tractorNode, xFrontNode, yFrontNode, zFrontNode)
         self:showDirection(tractorNode, lxTractor, lzTractor, 0, 0.7, 0)
 
-		local rotDelta = (self.reversingImplement.reversingProperties.nodeDistance *
-				(0.5 - (0.023 * self.reversingImplement.reversingProperties.nodeDistance - 0.073)))
-		local trailerToWaypointAngle = self:getLocalYRotationToPoint(trailerNode, tx, ty, tz, -1) * rotDelta
-		trailerToWaypointAngle = MathUtil.clamp(trailerToWaypointAngle, -math.rad(90), math.rad(90))
+        local rotDelta = (self.reversingImplement.reversingProperties.nodeDistance *
+                (0.5 - (0.023 * self.reversingImplement.reversingProperties.nodeDistance - 0.073)))
+        local trailerToWaypointAngle = self:getLocalYRotationToPoint(trailerNode, tx, ty, tz, -1) * rotDelta
+        trailerToWaypointAngle = MathUtil.clamp(trailerToWaypointAngle, -math.rad(90), math.rad(90))
 
-		local dollyToTrailerAngle = self:getLocalYRotationToPoint(trailerFrontNode, xTrailer, yTrailer, zTrailer, -1)
+        local dollyToTrailerAngle = self:getLocalYRotationToPoint(trailerFrontNode, xTrailer, yTrailer, zTrailer, -1)
 
-		local tractorToDollyAngle = self:getLocalYRotationToPoint(tractorNode, xFrontNode, yFrontNode, zFrontNode, -1)
+        local tractorToDollyAngle = self:getLocalYRotationToPoint(tractorNode, xFrontNode, yFrontNode, zFrontNode, -1)
 
-		local rearAngleDiff	= (dollyToTrailerAngle - trailerToWaypointAngle)
-		rearAngleDiff = MathUtil.clamp(rearAngleDiff, -math.rad(45), math.rad(45))
+        local rearAngleDiff = (dollyToTrailerAngle - trailerToWaypointAngle)
+        rearAngleDiff = MathUtil.clamp(rearAngleDiff, -math.rad(45), math.rad(45))
 
-		local frontAngleDiff = (tractorToDollyAngle - dollyToTrailerAngle)
-		frontAngleDiff = MathUtil.clamp(frontAngleDiff, -math.rad(45), math.rad(45))
+        local frontAngleDiff = (tractorToDollyAngle - dollyToTrailerAngle)
+        frontAngleDiff = MathUtil.clamp(frontAngleDiff, -math.rad(45), math.rad(45))
 
-		angleDiff = (frontAngleDiff - rearAngleDiff) * 
-				(1.5 - (self.reversingImplement.reversingProperties.nodeDistance * 0.4 - 0.9) + rotDelta)
-		angleDiff = MathUtil.clamp(angleDiff, -math.rad(45), math.rad(45))
+        angleDiff = (frontAngleDiff - rearAngleDiff) *
+                (1.5 - (self.reversingImplement.reversingProperties.nodeDistance * 0.4 - 0.9) + rotDelta)
+        angleDiff = MathUtil.clamp(angleDiff, -math.rad(45), math.rad(45))
 
-		lx, lz = MathUtil.getDirectionFromYRotation(angleDiff)
-	else
-		local crossTrackError, orientationError, curvatureError, currentHitchAngle = self:calculateErrors(tractorNode, trailerNode)
-		angleDiff = self:calculateHitchCorrectionAngle(crossTrackError, orientationError, curvatureError, currentHitchAngle)
-		angleDiff = MathUtil.clamp(angleDiff, -maxTractorAngle, maxTractorAngle)
+        lx, lz = MathUtil.getDirectionFromYRotation(angleDiff)
+    else
+        local crossTrackError, orientationError, curvatureError, currentHitchAngle = self:calculateErrors(tractorNode, trailerNode)
+        angleDiff = self:calculateHitchCorrectionAngle(crossTrackError, orientationError, curvatureError, currentHitchAngle)
+        angleDiff = MathUtil.clamp(angleDiff, -maxTractorAngle, maxTractorAngle)
 
-		lx, lz = MathUtil.getDirectionFromYRotation(angleDiff)
-	end
+        lx, lz = MathUtil.getDirectionFromYRotation(angleDiff)
+    end
 
-	self:showDirection(tractorNode, lx, lz, 0.7, 0, 1)
-	-- do a little bit of damping if using the articulated axis as lx tends to oscillate around 0 which results in the
-	-- speed adjustment kicking in and slowing down the vehicle.
-	if useArticulatedAxisRotationNode and math.abs(lx) < 0.04 then lx = 0 end
-	-- construct an artificial goal point to drive to
-	lx, lz = -lx * self.ppc:getLookaheadDistance(), -lz * self.ppc:getLookaheadDistance()
-	-- AIDriveStrategy wants a global position to drive to (which it later converts to local, but whatever...)
-	local gx, _, gz = localToWorld(self.vehicle:getAIDirectionNode(), lx, 0, lz)
-	return gx, gz, false, self.settings.reverseSpeed:getValue()
+    self:showDirection(tractorNode, lx, lz, 0.7, 0, 1)
+    -- do a little bit of damping if using the articulated axis as lx tends to oscillate around 0 which results in the
+    -- speed adjustment kicking in and slowing down the vehicle.
+    if useArticulatedAxisRotationNode and math.abs(lx) < 0.04 then
+        lx = 0
+    end
+    -- construct an artificial goal point to drive to
+    lx, lz = -lx * self.ppc:getLookaheadDistance(), -lz * self.ppc:getLookaheadDistance()
+    -- AIDriveStrategy wants a global position to drive to (which it later converts to local, but whatever...)
+    local gx, _, gz = localToWorld(self.vehicle:getAIDirectionNode(), lx, 0, lz)
+    return gx, gz, false, self.settings.reverseSpeed:getValue()
 end
 
 function AIReverseDriver:getLocalYRotationToPoint(node, x, y, z, direction)
-	direction = direction or 1
-	local dx, _, dz = worldToLocal(node, x, y, z)
-	dx = dx * direction
-	dz = dz * direction
-	return MathUtil.getYRotationFromDirection(dx, dz)
+    direction = direction or 1
+    local dx, _, dz = worldToLocal(node, x, y, z)
+    dx = dx * direction
+    dz = dz * direction
+    return MathUtil.getYRotationFromDirection(dx, dz)
 end
 
 function AIReverseDriver:showDirection(node, lx, lz, r, g, b)
-	if CpDebug:isChannelActive(CpDebug.DBG_REVERSE, self.vehicle) then
-		local x,y,z = getWorldTranslation(node)
-		local tx,_, tz = localToWorld(node,lx*5,y,lz*5)
-		DebugUtil.drawDebugLine(x, y+5, z, tx, y+5, tz, r or 1, g or 0, b or 0)
-	end
+    if CpDebug:isChannelActive(CpDebug.DBG_REVERSE, self.vehicle) then
+        local x, y, z = getWorldTranslation(node)
+        local tx, _, tz = localToWorld(node, lx * 5, y, lz * 5)
+        DebugUtil.drawDebugLine(x, y + 5, z, tx, y + 5, tz, r or 1, g or 0, b or 0)
+    end
 end
 
 ---@param implement table implement.object
 function AIReverseDriver:setReversingProperties(implement)
-	if implement.reversingProperties and implement.reversingProperties.frontNode then return end
-	self:debug('setReversingProperties for %s', CpUtil.getName(implement))
+    if implement.reversingProperties and implement.reversingProperties.frontNode then
+        return
+    end
+    self:debug('setReversingProperties for %s', CpUtil.getName(implement))
 
-	implement.reversingProperties = {}
+    implement.reversingProperties = {}
 
-	local attacherVehicle = self.reversingImplement:getAttacherVehicle()
+    local attacherVehicle = self.reversingImplement:getAttacherVehicle()
 
-	if attacherVehicle == self.vehicle or ImplementUtil.isAttacherModule(attacherVehicle) then
-		implement.reversingProperties.frontNode = ImplementUtil.getRealTrailerFrontNode(implement)
-	else
-		implement.reversingProperties.frontNode = ImplementUtil.getRealDollyFrontNode(attacherVehicle)
-		if implement.reversingProperties.frontNode then
-			self:debug('--> self.reversingImplement %s has dolly', CpUtil.getName(implement))
-		else
-			self:debug('--> self.reversingImplement %s has invalid dolly -> use implement own front node',
-					CpUtil.getName(implement))
-			implement.reversingProperties.frontNode = ImplementUtil.getRealTrailerFrontNode(implement)
-		end
-	end
+    if attacherVehicle == self.vehicle or ImplementUtil.isAttacherModule(attacherVehicle) then
+        implement.reversingProperties.frontNode = ImplementUtil.getRealTrailerFrontNode(implement)
+    else
+        implement.reversingProperties.frontNode = ImplementUtil.getRealDollyFrontNode(attacherVehicle)
+        if implement.reversingProperties.frontNode then
+            self:debug('--> self.reversingImplement %s has dolly', CpUtil.getName(implement))
+        else
+            self:debug('--> self.reversingImplement %s has invalid dolly -> use implement own front node',
+                    CpUtil.getName(implement))
+            implement.reversingProperties.frontNode = ImplementUtil.getRealTrailerFrontNode(implement)
+        end
+    end
 
-	implement.reversingProperties.nodeDistance = ImplementUtil.getRealTrailerDistanceToPivot(implement)
-	self:debug("--> tz: %.1f real trailer distance to pivot: %s",
-			implement.reversingProperties.nodeDistance, tostring(implement.steeringAxleNode))
+    implement.reversingProperties.nodeDistance = ImplementUtil.getRealTrailerDistanceToPivot(implement)
+    self:debug("--> tz: %.1f real trailer distance to pivot: %s",
+            implement.reversingProperties.nodeDistance, tostring(implement.steeringAxleNode))
 
-	if implement.steeringAxleNode == implement.reversingProperties.frontNode then
-		self:debug('--> implement.steeringAxleNode == implement.reversingProperties.frontNode')
-		implement.reversingProperties.isPivot = false
-	else
-		implement.reversingProperties.isPivot = true
-	end
+    if implement.steeringAxleNode == implement.reversingProperties.frontNode then
+        self:debug('--> implement.steeringAxleNode == implement.reversingProperties.frontNode')
+        implement.reversingProperties.isPivot = false
+    else
+        implement.reversingProperties.isPivot = true
+    end
 
-	self:debug('--> isPivot=%s, frontNode=%s', 
-			tostring(implement.reversingProperties.isPivot), tostring(implement.reversingProperties.frontNode))
+    self:debug('--> isPivot=%s, frontNode=%s',
+            tostring(implement.reversingProperties.isPivot), tostring(implement.reversingProperties.frontNode))
 end
 
 --- The reversing algorithm here is based on the papers:
---- 	Peter Ridley and Peter Corke. Load haul dump vehicle kinematics and control.
---- 		Journal of dynamic systems, measurement, and control, 125(1):54–59, 2003.
+---    Peter Ridley and Peter Corke. Load haul dump vehicle kinematics and control.
+---        Journal of dynamic systems, measurement, and control, 125(1):54–59, 2003.
 --- and
----		Amro Elhassan. Autonomous driving system for reversing an articulated vehicle, 2015
+---        Amro Elhassan. Autonomous driving system for reversing an articulated vehicle, 2015
 
 --- Calculate the path following errors (also called path disturbance inputs in the context of a controller)
 function AIReverseDriver:calculateErrors(tractorNode, trailerNode)
 
-	-- PPC already has the cross track error (lateral error)
-	local crossTrackError = self.ppc:getCrossTrackError() --+ self.settings.toolOffsetX:getValue()
+    -- PPC already has the cross track error (lateral error)
+    local crossTrackError = self.ppc:getCrossTrackError() --+ self.settings.toolOffsetX:getValue()
 
-	-- Calculate the orientation error, the angle between the trailers current direction and
-	-- the path direction
-	local referencePathAngle = self.ppc:getCurrentWaypointYRotation()
+    -- Calculate the orientation error, the angle between the trailers current direction and
+    -- the path direction
+    local referencePathAngle = self.ppc:getCurrentWaypointYRotation()
 
-	local dx, _, dz = localDirectionToWorld(trailerNode, 0, 0, -1)
-	local trailerAngle = MathUtil.getYRotationFromDirection(dx, dz)
+    local dx, _, dz = localDirectionToWorld(trailerNode, 0, 0, -1)
+    local trailerAngle = MathUtil.getYRotationFromDirection(dx, dz)
 
-	local orientationError = getDeltaAngle(trailerAngle, referencePathAngle)
+    local orientationError = getDeltaAngle(trailerAngle, referencePathAngle)
 
-	-- The curvature (1/r) error is between the curvature of the path and the curvature of the tractor-trailer.
-	-- This is really needed only when we are trying to follow a curved path in reverse
-	local _, tractorAngle, _ = getWorldRotation(tractorNode)
-	dx, _, dz = localDirectionToWorld(tractorNode, 0, 0, -1)
-	tractorAngle = MathUtil.getYRotationFromDirection(dx, dz)
+    -- The curvature (1/r) error is between the curvature of the path and the curvature of the tractor-trailer.
+    -- This is really needed only when we are trying to follow a curved path in reverse
+    local _, tractorAngle, _ = getWorldRotation(tractorNode)
+    dx, _, dz = localDirectionToWorld(tractorNode, 0, 0, -1)
+    tractorAngle = MathUtil.getYRotationFromDirection(dx, dz)
 
-	local currentHitchAngle = getDeltaAngle(tractorAngle, trailerAngle)
+    local currentHitchAngle = getDeltaAngle(tractorAngle, trailerAngle)
 
-	local curvature = ( 2 * math.sin(currentHitchAngle / 2 )) / calcDistanceFrom(tractorNode, trailerNode)
-	local currentWp = self.ppc:getCurrentWaypoint()
-	local curvatureError = currentWp.curvature - curvature
+    local curvature = (2 * math.sin(currentHitchAngle / 2)) / calcDistanceFrom(tractorNode, trailerNode)
+    local currentWp = self.ppc:getCurrentWaypoint()
+    local curvatureError = currentWp.curvature - curvature
 
-	return crossTrackError, orientationError, curvatureError, currentHitchAngle
+    return crossTrackError, orientationError, curvatureError, currentHitchAngle
 end
 
 --- Based on the current errors, calculate the required correction (in controller terms, use different gains for
 --- different disturbances to calculate the controller's output, which in our case is just an angle the tractor
 --- needs to drive to, in the tractor's local coordinate system.)
 function AIReverseDriver:calculateHitchCorrectionAngle(crossTrackError, orientationError, curvatureError, currentHitchAngle)
-	-- the following constants must be tuned based on experiments.
+    -- the following constants must be tuned based on experiments.
 
-	-- base cross track error gain. 0.6-0.7 for longer implements, 0.5 for shorter ones, should be adjusted based on
-	-- the steering length
-	local kXeBase = -0.5 - self.steeringLength / 50
-	-- base orientation error gain
-	local kOeBase = 6
-	-- base curvature error gain. 0 for now, as currently we only drive straight reverse
-	local kCeBase = 0
+    -- base cross track error gain. 0.6-0.7 for longer implements, 0.5 for shorter ones, should be adjusted based on
+    -- the steering length
+    local kXeBase = -0.5 - self.steeringLength / 50
+    -- base orientation error gain
+    local kOeBase = 6
+    -- base curvature error gain. 0 for now, as currently we only drive straight reverse
+    local kCeBase = 0
 
-	-- gain correction
-	local gainCorrection = 1.5
+    -- gain correction
+    local gainCorrection = 1.5
 
     local hitchAngle = gainCorrection * (
             kXeBase * crossTrackError +
-            kOeBase * orientationError +
-            kCeBase * curvatureError
+                    kOeBase * orientationError +
+                    kCeBase * curvatureError
     )
     local maxHitchAngle = math.rad(35)
     hitchAngle = MathUtil.clamp(hitchAngle, -maxHitchAngle, maxHitchAngle)
 
-	local correctionAngle = -(hitchAngle - currentHitchAngle)
+    local correctionAngle = -(hitchAngle - currentHitchAngle)
 
-	if CpDebug:isChannelActive(CpDebug.DBG_REVERSE, self.vehicle) then
-		local text = string.format('xte=%.1f oe=%.1f ce=%.1f current=%.1f reference=%.1f correction=%.1f',
-				crossTrackError, math.deg(orientationError), curvatureError, math.deg(currentHitchAngle), math.deg(hitchAngle), math.deg(correctionAngle))
-		setTextColor(1, 1, 0, 1)
-		renderText(0.3, 0.3, 0.015, text)
-	end
+    if CpDebug:isChannelActive(CpDebug.DBG_REVERSE, self.vehicle) then
+        local text = string.format('xte=%.1f oe=%.1f ce=%.1f current=%.1f reference=%.1f correction=%.1f',
+                crossTrackError, math.deg(orientationError), curvatureError, math.deg(currentHitchAngle), math.deg(hitchAngle), math.deg(correctionAngle))
+        setTextColor(1, 1, 0, 1)
+        renderText(0.3, 0.3, 0.015, text)
+    end
 
-	return correctionAngle
+    return correctionAngle
 end

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -54,7 +54,7 @@ function AIUtil.calculateTightTurnOffset(vehicle, vehicleTurningRadius, course, 
 	local tightTurnOffset
 
 	local function smoothOffset(offset)
-		return (offset + 3 * (previousOffset or 0 )) / 4
+		return (offset + 4 * (previousOffset or 0 )) / 5
 	end
 
 	-- first of all, does the current waypoint have radius data?

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -157,12 +157,12 @@ end
 function AIUtil.getReverserNode(vehicle, reversingImplement, suppressLog)
 	local reverserNode, debugText
 	-- if there's a reverser node on the tool, use that
-	reversingImplement = reversingImplement and reversingImplement or AIUtil.getFirstReversingImplementWithWheels(vehicle, suppressLog)
-	if reversingImplement and reversingImplement.steeringAxleNode then
-		reverserNode, debugText = reversingImplement.steeringAxleNode, 'implement steering axle node'
-	end
+	reverserNode, debugText = AIVehicleUtil.getAIToolReverserDirectionNode(vehicle), 'AIToolReverserDirectionNode'
 	if not reverserNode then
-		reverserNode, debugText = AIVehicleUtil.getAIToolReverserDirectionNode(vehicle), 'AIToolReverserDirectionNode'
+		reversingImplement = reversingImplement and reversingImplement or AIUtil.getFirstReversingImplementWithWheels(vehicle, suppressLog)
+		if reversingImplement and reversingImplement.steeringAxleNode then
+			reverserNode, debugText = reversingImplement.steeringAxleNode, 'implement steering axle node'
+		end
 	end
 	if not reverserNode and vehicle.getAIReverserNode then
 		reverserNode, debugText = vehicle:getAIReverserNode(), 'AIReverserNode'

--- a/scripts/ai/PurePursuitController.lua
+++ b/scripts/ai/PurePursuitController.lua
@@ -241,15 +241,6 @@ function PurePursuitController:switchControlledNode()
 	end
 end
 
---- Compatibility function to return the original waypoint index as in vehicle.Waypoints. This
--- is the same as self.currentWpNode.ix unless we have combined courses where the legacy CP code
--- concatenates all courses into one Waypoints array (as opposed to the AIDriver which splits these
--- combined courses into its parts). The rest of the CP code however (HUD, reverse, etc.) works with
--- vehicle.Waypoints and vehicle.cp.waypointIndex and therefore expects the combined index
-function PurePursuitController:getCurrentOriginalWaypointIx()
-	return self.course.waypoints[self:getCurrentWaypointIx()].cpIndex
-end
-
 function PurePursuitController:update()
 	if not self.course then
 		self:debugSparse('no course set.')

--- a/scripts/ai/controllers/ImplementController.lua
+++ b/scripts/ai/controllers/ImplementController.lua
@@ -90,7 +90,7 @@ end
 function ImplementController:onFinishRow(isHeadlandTurn)
 end
 
-function ImplementController:onTurnEndProgress(workStartNode, isLeftTurn)
+function ImplementController:onTurnEndProgress(workStartNode, shouldLower, isLeftTurn)
 end
 
 --- Any object this controller wants us to ignore, can register here a callback at the proximity controller

--- a/scripts/ai/controllers/ImplementController.lua
+++ b/scripts/ai/controllers/ImplementController.lua
@@ -90,7 +90,7 @@ end
 function ImplementController:onFinishRow(isHeadlandTurn)
 end
 
-function ImplementController:onTurnEndProgress(workStartNode, shouldLower, isLeftTurn)
+function ImplementController:onTurnEndProgress(workStartNode, reversing, shouldLower, isLeftTurn)
 end
 
 --- Any object this controller wants us to ignore, can register here a callback at the proximity controller

--- a/scripts/ai/controllers/PlowController.lua
+++ b/scripts/ai/controllers/PlowController.lua
@@ -103,11 +103,16 @@ end
 --- here we only make sure that the plow is rotated to the work position (from the center position)
 --- in time.
 ---@param workStartNode number node where the work starts as calculated by TurnContext
+---@param shouldLower boolean the implement should be lowered as we are close to the work start (this
+--- should most likely be calculated here in the controller, but for now, we get it from an argument
 ---@param isLeftTurn boolean is this a left turn?
-function PlowController:onTurnEndProgress(workStartNode, isLeftTurn)
+function PlowController:onTurnEndProgress(workStartNode, shouldLower, isLeftTurn)
     if self:isRotatablePlow() and not self:isFullyRotated() and not self:isRotationActive() then
         -- more or less aligned with the first waypoint of the row, start rotating to working position
-        if CpMathUtil.isSameDirection(self.implement.rootNode, workStartNode, 30) then
+        -- or, when it should have been lowered, that is, we are too late, not aligned yet, but
+        -- rotate anyway
+        if CpMathUtil.isSameDirection(self.implement.rootNode, workStartNode, 30) or shouldLower then
+            self:debug('Rotating plow to working position now.')
             self.implement:setRotationMax(isLeftTurn)
         end
     end

--- a/scripts/ai/controllers/PlowController.lua
+++ b/scripts/ai/controllers/PlowController.lua
@@ -6,6 +6,13 @@ PlowController = CpObject(ImplementController)
 function PlowController:init(vehicle, implement)
     ImplementController.init(self, vehicle, implement)
     self.plowSpec = self.implement.spec_plow
+    -- towed (not hitch mounted) and can reverse
+    self.towed = AIUtil.getFirstReversingImplementWithWheels(vehicle, true)
+    -- temporarily store the direction of the last turn. This hack is for the case when for some reason
+    -- the plow was not rotated into the working position before lowering. If that's the case, onLowering will
+    -- rotate it but it needs to know which direction to lower, which, however is not known at that point
+    -- anymore
+    self.lastTurnIsLeftTurn = CpTemporaryObject()
 end
 
 
@@ -98,22 +105,44 @@ function PlowController:onFinishRow(isHeadlandTurn)
     end
 end
 
+
+--- making sure the plow is in the working position when lowering
+-- TODO: this whole magic hack would not be necessary if we moved the actual lowering into onTurnEndProgress()
+function PlowController:onLowering()
+    -- if we just turned (that is, not starting to work)
+    local lastTurnIsLeftTurn = self.lastTurnIsLeftTurn:get()
+    if lastTurnIsLeftTurn ~= nil and
+            self:isRotatablePlow() and not self:isFullyRotated() and not self:isRotationActive() then
+        self:debug('Lowering, rotating plow to working position (last turn is left %s).', lastTurnIsLeftTurn)
+        -- rotation direction depends on the direction of the last turn
+        self.implement:setRotationMax(lastTurnIsLeftTurn)
+    end
+end
+
 --- This is called in every loop when we approach the start of the row, the location where
 --- the plow must be lowered. Currently AIDriveStrategyFieldworkCourse takes care of the lowering,
 --- here we only make sure that the plow is rotated to the work position (from the center position)
 --- in time.
 ---@param workStartNode number node where the work starts as calculated by TurnContext
+---@param reversing boolean driving in reverse now
 ---@param shouldLower boolean the implement should be lowered as we are close to the work start (this
 --- should most likely be calculated here in the controller, but for now, we get it from an argument
 ---@param isLeftTurn boolean is this a left turn?
-function PlowController:onTurnEndProgress(workStartNode, shouldLower, isLeftTurn)
+function PlowController:onTurnEndProgress(workStartNode, reversing, shouldLower, isLeftTurn)
+    self.lastTurnIsLeftTurn:set(isLeftTurn or false, 2000)
     if self:isRotatablePlow() and not self:isFullyRotated() and not self:isRotationActive() then
         -- more or less aligned with the first waypoint of the row, start rotating to working position
-        -- or, when it should have been lowered, that is, we are too late, not aligned yet, but
-        -- rotate anyway
         if CpMathUtil.isSameDirection(self.implement.rootNode, workStartNode, 30) or shouldLower then
-            self:debug('Rotating plow to working position now.')
-            self.implement:setRotationMax(isLeftTurn)
+            if self.towed then
+                -- let towed plows remain in the center position while reversing to the start of the row
+                if not reversing then
+                    self:debug('Rotating towed plow to working position.')
+                    self.implement:setRotationMax(isLeftTurn)
+                end
+            else
+                self:debug('Rotating hitch-mounted plow to working position.')
+                self.implement:setRotationMax(isLeftTurn)
+            end
         end
     end
 end

--- a/scripts/ai/controllers/PlowController.lua
+++ b/scripts/ai/controllers/PlowController.lua
@@ -19,7 +19,7 @@ end
 ---@return number|nil if an X offset could be calculated, return that, otherwise nil
 function PlowController:getAutomaticXOffset()
     if self:isRotatablePlow() and not self:isFullyRotated() then
-        self:debug('Plow is not fully rotated, not calculating offset')
+        self:debugSparse('Plow is not fully rotated, not calculating offset')
         return nil
     end
 	local aiLeftMarker, aiRightMarker, aiBackMarker = self.implement:getAIMarkers()
@@ -27,7 +27,7 @@ function PlowController:getAutomaticXOffset()
         local attacherJoint = self.implement:getActiveInputAttacherJoint()
         local referenceNode = attacherJoint and attacherJoint.node or self.vehicle:getAIDirectionNode()
         -- find out the left/right AI markers distance from the attacher joint (or, if does not exist, the
-        -- vehicle's root node) to calculate the offset.
+        -- vehicle's direction node) to calculate the offset.
         self.plowReferenceNode = referenceNode
         local leftMarkerDistance, rightMarkerDistance = self:getOffsets(referenceNode, 
 			aiLeftMarker, aiRightMarker)
@@ -40,7 +40,7 @@ function PlowController:getAutomaticXOffset()
             leftMarkerDistance, rightMarkerDistance = -rightMarkerDistance, -leftMarkerDistance
         end
         local newToolOffsetX = -(leftMarkerDistance + rightMarkerDistance) / 2
-        self:debug('Current Offset left = %.1f, right = %.1f, leftDx = %.1f, rightDx = %.1f, new = %.1f',
+        self:debugSparse('Current Offset left = %.1f, right = %.1f, leftDx = %.1f, rightDx = %.1f, new = %.1f',
             leftMarkerDistance, rightMarkerDistance, leftDx, rightDx, newToolOffsetX)
 		return newToolOffsetX
     end

--- a/scripts/ai/controllers/PlowController.lua
+++ b/scripts/ai/controllers/PlowController.lua
@@ -16,7 +16,12 @@ function PlowController:init(vehicle, implement)
 end
 
 
+---@return number|nil if an X offset could be calculated, return that, otherwise nil
 function PlowController:getAutomaticXOffset()
+    if self:isRotatablePlow() and not self:isFullyRotated() then
+        self:debug('Plow is not fully rotated, not calculating offset')
+        return nil
+    end
 	local aiLeftMarker, aiRightMarker, aiBackMarker = self.implement:getAIMarkers()
     if aiLeftMarker and aiBackMarker and aiRightMarker then
         local attacherJoint = self.implement:getActiveInputAttacherJoint()

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -584,9 +584,9 @@ end
 ---@return boolean true if it is ok the continue driving, false when the vehicle should stop
 function CourseTurn:endTurn(dt)
     -- keep driving on the turn course until we need to lower our implements
-    self.driveStrategy:raiseControllerEvent(AIDriveStrategyCourse.onTurnEndProgressEvent,
-            self.turnContext.workStartNode, self.turnContext:isLeftTurn())
     local shouldLower, dz = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode, self.ppc:isReversing())
+    self.driveStrategy:raiseControllerEvent(AIDriveStrategyCourse.onTurnEndProgressEvent,
+            self.turnContext.workStartNode, shouldLower, self.turnContext:isLeftTurn())
     if shouldLower then
         if not self.implementsLowered then
             -- have not started lowering implements yet

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -586,7 +586,7 @@ function CourseTurn:endTurn(dt)
     -- keep driving on the turn course until we need to lower our implements
     local shouldLower, dz = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode, self.ppc:isReversing())
     self.driveStrategy:raiseControllerEvent(AIDriveStrategyCourse.onTurnEndProgressEvent,
-            self.turnContext.workStartNode, shouldLower, self.turnContext:isLeftTurn())
+            self.turnContext.workStartNode, self.ppc:isReversing(), shouldLower, self.turnContext:isLeftTurn())
     if shouldLower then
         if not self.implementsLowered then
             -- have not started lowering implements yet

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -283,9 +283,10 @@ function TurnManeuver:moveCourseBack(course, dBack, ixBeforeEndingTurnSection, e
 		-- allow early direction change when aligned
 		TurnManeuver.setTurnControlForLastWaypoints(movedCourse, endingTurnLength,
 			TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED, true, true)
+		-- go all the way to the back marker distance so there's plenty of room for lower early too
 		local reverseAfterTurn = Course.createFromNode(self.vehicle, self.turnContext.vehicleAtTurnEndNode,
 			0, dFromTurnEnd + self.steeringLength,
-			math.min(dFromTurnEnd, self.turnContext.frontMarkerDistance), -0.8, true)
+			math.min(dFromTurnEnd, self.turnContext.backMarkerDistance), -0.8, true)
 		movedCourse:append(reverseAfterTurn)
 	elseif self.turnContext.turnEndForwardOffset <= 0 and dFromTurnEnd >= 0 then
 		self:debug('Reverse to work start (implement in front)')

--- a/scripts/ai/turns/TurnManeuver.lua
+++ b/scripts/ai/turns/TurnManeuver.lua
@@ -235,14 +235,11 @@ end
 --- is to make sure that when the course changes to reverse and there is a reverse node, the first reverse
 --- waypoint is behind the reverser node. Otherwise we'll just keep backing up until the emergency brake is triggered.
 function TurnManeuver:getReversingOffset()
-	if self.steeringLength == 0 then
-		local reverserNode, debugText = AIUtil.getReverserNode(self.vehicle)
-		if reverserNode then
-			local _, _, dz = localToLocal(reverserNode, self.vehicleDirectionNode, 0, 0, 0)
-			self:debug('Using the vehicle\'s steering length 0, use reverser node (%s) distance %.1f instead',
-					debugText, dz)
-			return math.abs(dz)
-		end
+	local reverserNode, debugText = AIUtil.getReverserNode(self.vehicle)
+	if reverserNode then
+		local _, _, dz = localToLocal(reverserNode, self.vehicleDirectionNode, 0, 0, 0)
+		self:debug('Using reverser node (%s) distance %.1f', debugText, dz)
+		return math.abs(dz)
 	end
 	return self.steeringLength
 end
@@ -283,10 +280,13 @@ function TurnManeuver:moveCourseBack(course, dBack, ixBeforeEndingTurnSection, e
 		-- allow early direction change when aligned
 		TurnManeuver.setTurnControlForLastWaypoints(movedCourse, endingTurnLength,
 			TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED, true, true)
-		-- go all the way to the back marker distance so there's plenty of room for lower early too
+		-- go all the way to the back marker distance so there's plenty of room for lower early too, also, the
+		-- reversingOffset may be even behind the back marker, especially for vehicles which have a AIToolReverserDirectionNode
+		-- which is then used as the PPC controlled node, and thus it must be far enough that we reach the lowering
+		-- point before the controlled node reaches the end of the course
 		local reverseAfterTurn = Course.createFromNode(self.vehicle, self.turnContext.vehicleAtTurnEndNode,
 			0, dFromTurnEnd + self.steeringLength,
-			math.min(dFromTurnEnd, self.turnContext.backMarkerDistance), -0.8, true)
+			math.min(dFromTurnEnd, self.turnContext.backMarkerDistance, -reversingOffset), -0.8, true)
 		movedCourse:append(reverseAfterTurn)
 	elseif self.turnContext.turnEndForwardOffset <= 0 and dFromTurnEnd >= 0 then
 		self:debug('Reverse to work start (implement in front)')

--- a/scripts/dev/DevHelper.lua
+++ b/scripts/dev/DevHelper.lua
@@ -47,10 +47,6 @@ function DevHelper:update()
     -- make sure not calling this for something which does not have courseplay installed (only ones with spec_aiVehicle)
     if g_currentMission.controlledVehicle and g_currentMission.controlledVehicle.spec_aiVehicle then
 
-        if self.vehicle ~= g_currentMission.controlledVehicle then
-            --self.vehicleData = PathfinderUtil.VehicleData(g_currentMission.controlledVehicle, true)
-        end
-
         self.vehicle = g_currentMission.controlledVehicle
         self.node = g_currentMission.controlledVehicle:getAIDirectionNode()
         lx, _, lz = localDirectionToWorld(self.node, 0, 0, 1)
@@ -169,6 +165,8 @@ function DevHelper:keyEvent(unicode, sym, modifier, isDown)
         if ok then
             self.course = course
         end
+    elseif bitAND(modifier, Input.MOD_LALT) ~= 0 and isDown and sym == Input.KEY_n then
+        self:togglePpcControlledNode()
     end
 end
 
@@ -182,10 +180,12 @@ function DevHelper:draw()
     for key, value in pairs(self.data) do
         table.insert(data, {name = key, value = value})
     end
-    DebugUtil.renderTable(0.65, 0.3, 0.013, data, 0.05)
+    DebugUtil.renderTable(0.65, 0.27, 0.013, data, 0.05)
 
     self:showFillNodes()
     self:showAIMarkers()
+
+    self:showDriveData()
 
 	if not self.tNode then
 		self.tNode = createTransformGroup("devhelper")
@@ -266,6 +266,25 @@ function DevHelper:showAIMarkers()
         CpUtil.drawDebugNode(self.vehicle:getAIDirectionNode(), false , 3, "AiDirectionNode")
     end
 
+end
+
+function DevHelper:togglePpcControlledNode()
+    if not self.vehicle then return end
+    local strategy = self.vehicle:getCpDriveStrategy()
+    if not strategy then return end
+    if strategy.ppc:getControlledNode() == AIUtil.getReverserNode(self.vehicle) then
+        strategy.pcc:resetControlledNode()
+    else
+        strategy.ppc:setControlledNode(AIUtil.getReverserNode(self.vehicle))
+    end
+end
+
+function DevHelper:showDriveData()
+    if not self.vehicle then return end
+    local strategy = self.vehicle:getCpDriveStrategy()
+    if not strategy then return end
+    strategy.ppc:update()
+    strategy.reverser:getForwardDriveData()
 end
 
 -- make sure to recreate the global dev helper whenever this script is (re)loaded

--- a/scripts/dev/DevHelper.lua
+++ b/scripts/dev/DevHelper.lua
@@ -284,7 +284,7 @@ function DevHelper:showDriveData()
     local strategy = self.vehicle:getCpDriveStrategy()
     if not strategy then return end
     strategy.ppc:update()
-    strategy.reverser:getForwardDriveData()
+    strategy.reverser:getDriveData()
 end
 
 -- make sure to recreate the global dev helper whenever this script is (re)loaded

--- a/scripts/util/CpRemainingTime.lua
+++ b/scripts/util/CpRemainingTime.lua
@@ -52,7 +52,7 @@ end
 
 function CpRemainingTime:update(dt)
 	if g_currentMission.controlledVehicle == self.vehicle and self.DEBUG_ACTIVE and CpDebug:isChannelActive(self.debugChannel, self.vehicle) then
-		DebugUtil.renderTable(0.4, 0.4, 0.018, {
+		DebugUtil.renderTable(0.2, 0.2, 0.018, {
 			{name = "time", value = CpGuiUtil.getFormatTimeText(self.time)},
 			{name = "optimal speed", value = MathUtil.mpsToKmh(self:getOptimalSpeed())},
 			{name = "optimal time", value = CpGuiUtil.getFormatTimeText(self:getOptimalCourseTime(self.course, self.lastIx))},


### PR DESCRIPTION
For reversing, use the steering node only if
AIVehicleUtil.getAIToolReverserDirectionNode()
does not exist.