### PR TITLE
Temporary fix for baleloaders in fieldwork mode

### DIFF
--- a/scripts/ai/controllers/BaleLoaderController.lua
+++ b/scripts/ai/controllers/BaleLoaderController.lua
@@ -63,7 +63,7 @@ function BaleLoaderController:update()
         if not self:isBaleFinderMode() then 
             --- In the fieldwork mode the driver has to stop once full
             --- The bale finder mode controls this in the strategy.
-            --- TODO: Breaks multiple trailers in fieldwork!
+            --- TODO: Breaks multiple trailers in fieldwork (on one tractor)!
             self.vehicle:stopCurrentAIJob(AIMessageErrorIsFull.new())
         end
     end


### PR DESCRIPTION
#2768 
Test:
- Bale finder with normal bale loader
- Fieldwork with normal bale loader

TODO but not this PR:
- Fill level handler for field work to check if all implements are full and not each separately in the controllers.