### PR TITLE
Feature/improve harvester turning

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -537,7 +537,6 @@ end
 
 --- Some of our turns need a short look ahead distance, make sure we restore the normal after the turn
 function AIDriveStrategyCombineCourse:resumeFieldworkAfterTurn(ix)
-    self.state = self.states.WORKING
     self.ppc:setNormalLookaheadDistance()
     AIDriveStrategyCombineCourse.superClass().resumeFieldworkAfterTurn(self, ix)
 end

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -537,6 +537,7 @@ end
 
 --- Some of our turns need a short look ahead distance, make sure we restore the normal after the turn
 function AIDriveStrategyCombineCourse:resumeFieldworkAfterTurn(ix)
+    self.state = self.states.WORKING
     self.ppc:setNormalLookaheadDistance()
     AIDriveStrategyCombineCourse.superClass().resumeFieldworkAfterTurn(self, ix)
 end
@@ -1307,7 +1308,7 @@ end
 
 --- Can the cutter be turned off ?
 function AIDriveStrategyCombineCourse:getCanCutterBeTurnedOff()
-    return self:isWaitingForUnload() or
+    return self:isWaitingForUnload() or self.state == self.states.TURNING or
             (self.state == self.states.UNLOADING_ON_FIELD and self:isUnloadStateOneOf(self.selfUnloadStates) and
             -- we want that cutter to be turned on when returning to fieldwork after self unload
                     self.unloadState ~= self.states.RETURNING_FROM_SELF_UNLOAD)

--- a/scripts/ai/controllers/CutterController.lua
+++ b/scripts/ai/controllers/CutterController.lua
@@ -11,13 +11,13 @@ end
 function CutterController:getDriveData()
 	self:disableCutterTimer()
 	--- Turns off the cutter, while the driver is waiting for unloading.
-	if self.driveStrategy.getCanCutterBeTurnedOff and self.driveStrategy:getCanCutterBeTurnedOff() then 
-		if self.implement:getIsTurnedOn() then 
+	if self.driveStrategy.getCanCutterBeTurnedOff and self.driveStrategy:getCanCutterBeTurnedOff() then
+		if self.implement:getIsTurnedOn() then
 			self.implement:setIsTurnedOn(false)
 		end
-	else 
+	else
 		--- Turns it back on, when the unloading finished and the cutter is lowered.
-		if not self.implement:getIsTurnedOn() and self.implement:getIsLowered() then 
+		if not self.implement:getIsTurnedOn() and self.implement:getIsLowered() then
 			self.implement:setIsTurnedOn(true)
 		end
 	end

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -591,6 +591,8 @@ function CourseTurn:endTurn(dt)
         if not self.implementsLowered then
             -- have not started lowering implements yet
             self:debug('Turn ending, lowering implements')
+            -- driveStrategy.state can be set to WORKING which is also checked if harvester header can be turned on
+            self.driveStrategy.state = self.driveStrategy.states.WORKING
             self.driveStrategy:lowerImplements()
             self.implementsLowered = true
             if self.ppc:isReversing() then

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -458,7 +458,10 @@ function TurnContext:getTurnEndNodeAndOffsets(steeringLength)
         -- implement in front of vehicle. Turn should end with the implement at the work start position, this is where
         -- the vehicle's root node is on the vehicleAtTurnEndNode
         turnEndNode = self.vehicleAtTurnEndNode
-        goalOffset = 0
+
+        -- set the turning endpoint a bit futher from the field starting point
+        -- for better aligment for front implements (e.g. potatoharvester)
+        goalOffset = -self.frontMarkerDistance
     else
         -- implement behind vehicle. Since we are turning, we want to be aligned with the next row with our vehicle
         -- on the work start node so by the time the implement reaches it, it is also aligned


### PR DESCRIPTION
Due to distance between the front implement and vehicle center, some vehicles don't have enough time to align themselves properly for a new row and the vehicle does few aligning adjustments post-turn missing some crops.

Another small improvement included is turning off the cutter when turning.

(I'm marking this as a draft for futher discussion and approval)

The cases shown were done using the Ventor 4150 potato harvester.

Fig 1. Currently generated turn.
![Farming Simulator 22 Screenshot 2023 09 20 - 22 01 00 76](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/0929c5b5-f3b5-4bf8-90ce-90d9ef51a60f)

Fig 2. After the turn, front implement is very close to field border.
![Farming Simulator 22 Screenshot 2023 09 20 - 22 01 20 01](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/3d3d2c3a-be32-4cd1-9412-cfd7633ae07c)

Fig 3. Harvester missing some crops still aligning itself post-turn.
![Farming Simulator 22 Screenshot 2023 09 20 - 22 01 28 30](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/1dbcf8be-918d-4730-8fca-32e85a4f0e93)

Fig 4. and 5. This is more noticeable when the Ventor 4150 does a K-turn when reversing is enabled.
(This case was done with 3 convoy setting and skipping one lane to avoid collision)
![Farming Simulator 22 Screenshot 2023 09 20 - 23 13 51 22](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/4746df56-1c5f-4a50-8110-42b77bdc1838)
![Farming Simulator 22 Screenshot 2023 09 20 - 23 14 13 30](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/2546a95b-d0dd-4439-abb6-af1142a5a103)

By taking into consideration the frontMarkerDistance, we can easily give the harvester more space to adjust properly.
Ventor 4150 has a very long spacing to the front implement which gives a lot of space. Maybe cap the max value?

Fig 6. Generated turn after setting goalOffSet to negative frontMarkerDistance.
![Farming Simulator 22 Screenshot 2023 09 20 - 21 59 55 40](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/2373c3c6-4d80-4b72-b5b7-79954f9e5bc2)

Fig 7. Front implement had a nice spacing to row start and harvester had time to do final adjustments.
![Farming Simulator 22 Screenshot 2023 09 20 - 21 54 07 03](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/ea2400b4-da4a-4d9c-8e56-9a05203a6e15)

Fig 8. No missed crops.
![Farming Simulator 22 Screenshot 2023 09 20 - 22 03 44 03](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/4fd8f08d-aa0f-4b0b-aa26-b03302c7a205)

Fig 9. New reverse enabled turn on 3 convoy, 1 lane skip setting
(Reversing in this case might be redundant and a bit silly looking)
![Farming Simulator 22 Screenshot 2023 09 20 - 23 22 21 29](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/2f479047-8ccb-4ccb-8f84-ad48db52915f)

Fig 10. Properly aligned
![Farming Simulator 22 Screenshot 2023 09 20 - 23 22 46 74](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/85d1ac56-530d-4d01-8966-bd06178570ed)

Fig 11. New K-turn with frontMarkerDistance considered. Single tool. No skips.
Length between the implement and vehicle makes the reversing distance quite large. Might need to check this further.
![Farming Simulator 22 Screenshot 2023 09 20 - 23 47 12 79](https://github.com/Courseplay/Courseplay_FS22/assets/12509924/359c642d-46fb-4bec-b729-08a78ed27ca4)
