### PR TITLE
fix: starting at first waypoint

### DIFF
--- a/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -210,8 +210,6 @@ function AIDriveStrategyDriveToFieldWorkStart:onPathfindingDoneToCourseStart(pat
         self:debug('Pathfinding to start fieldwork finished with %d waypoints (%d ms)',
                 #path, g_currentMission.time - (self.pathfindingStartedAt or 0))
         courseToStart = Course(self.vehicle, CourseGenerator.pointsToXzInPlace(path), true)
-        -- make sure the course extends to the first waypoint
-        courseToStart:appendWaypoints({fieldWorkCourse:getWaypoint(ix)})
         courseToStart:adjustForTowedImplements(2)
     else
         self:debug('Pathfinding to start fieldwork failed, using alignment course instead')


### PR DESCRIPTION
Do not add the first waypoint of the fieldwork course to the alignment course as it is generated to reach it anyway, no idea why I did that, but it was a problem when the alignment course ends in reverse.

#2788