### PR TITLE
fix: raising header when stop for unload

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -603,8 +603,7 @@ end
 function AIDriveStrategyCombineCourse:startWaitingForUnloadBeforeNextRow()
     self:debug('Waiting for unload before starting the next row')
     self.waitingForUnloaderAtEndOfRow:set(true, 30000)
-    self.state = self.states.UNLOADING_ON_FIELD
-    self.unloadState = self.states.WAITING_FOR_UNLOAD_BEFORE_STARTING_NEXT_ROW
+    self:stopForUnload(self.states.WAITING_FOR_UNLOAD_BEFORE_STARTING_NEXT_ROW, true)
 end
 
 --- The unloader may call this repeatedly to confirm that the rendezvous still stands, making sure the

--- a/scripts/ai/controllers/CutterController.lua
+++ b/scripts/ai/controllers/CutterController.lua
@@ -9,19 +9,30 @@ function CutterController:init(vehicle, implement)
 end
 
 function CutterController:getDriveData()
-	self:disableCutterTimer()
-	--- Turns off the cutter, while the driver is waiting for unloading.
-	if self.driveStrategy.getCanCutterBeTurnedOff and self.driveStrategy:getCanCutterBeTurnedOff() then 
-		if self.implement:getIsTurnedOn() then 
-			self.implement:setIsTurnedOn(false)
-		end
-	else 
-		--- Turns it back on, when the unloading finished and the cutter is lowered.
-		if not self.implement:getIsTurnedOn() and self.implement:getIsLowered() then 
-			self.implement:setIsTurnedOn(true)
-		end
-	end
-	return nil, nil, nil, nil
+    self:disableCutterTimer()
+    --- Turns off the cutter, while the driver is waiting for unloading.
+    if self.driveStrategy.getCanCutterBeTurnedOff and self.driveStrategy:getCanCutterBeTurnedOff() then
+        if self.implement:getIsTurnedOn() then
+            -- Do not immediately turn off the cutter. This is just a safety measure for the case when
+            -- the combine forgets to check if it is stopped before getCanCutterBeTurnedOff() returns true
+            -- also, a little bit of hysteresis won't hurt...
+            if not self.delayedTurnOff then
+                self:debug('Cutter can be turned off, wait a little bit before turning off...')
+                self.delayedTurnOff = Timer.createOneshot(2000, function()
+                    self:debug('Turning off cutter now')
+                    self.implement:setIsTurnedOn(false)
+                    self.delayedTurnOff = nil
+                end)
+            end
+        end
+    else
+        self.delayedTurnOff = nil
+        --- Turns it back on, when the unloading finished and the cutter is lowered.
+        if not self.implement:getIsTurnedOn() and self.implement:getIsLowered() then
+            self.implement:setIsTurnedOn(true)
+        end
+    end
+    return nil, nil, nil, nil
 end
 
 --- The Giants Cutter class has a timer to stop the AI job if there is no fruit being processed for 5 seconds.
@@ -29,9 +40,9 @@ end
 --- we just reset that timer here in every update cycle.
 --- Consider setting Cutter:getAllowCutterAIFruitRequirements() to false
 function CutterController:disableCutterTimer()
-	if self.cutterSpec.aiNoValidGroundTimer then 
-		self.cutterSpec.aiNoValidGroundTimer = 0
-	end
+    if self.cutterSpec.aiNoValidGroundTimer then
+        self.cutterSpec.aiNoValidGroundTimer = 0
+    end
 end
 
 function CutterController:onLowering()


### PR DESCRIPTION
Wait for stopping when waiting for unload at end of row.

Delayed header turn off by 2 seconds in all cases, just to make sure.

#2592