### PR TITLE
fix: reversing turn

### DIFF
--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -637,7 +637,9 @@ end
 --- change direction as soon as the implement is aligned.
 --- So check that here and force a direction change when possible.
 function CourseTurn:changeDirectionWhenAligned()
-    if TurnManeuver.hasTurnControl(self.turnCourse, self.turnCourse:getCurrentWaypointIx(), TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED) then
+    if self.ppc:getLastPassedWaypointIx() and
+            TurnManeuver.hasTurnControl(self.turnCourse, self.ppc:getLastPassedWaypointIx(),
+                    TurnManeuver.CHANGE_DIRECTION_WHEN_ALIGNED) then
         local aligned = self.driveStrategy:areAllImplementsAligned(self.turnContext.turnEndWpNode.node)
         self:debug('aligned: %s', tostring(aligned))
         if aligned then


### PR DESCRIPTION
When we have to reverse to reach the work start after the turn, only change direction when we actually pass those waypoints marked with CHANGE_DIRECTION_WHEN_ALIGNED instead of checking the current waypoint.

This avoids switching the direction (and thus lowering the implement) too early, when temporarily during the turn the implement is aligned with the target row.