### PR TITLE
Fix for #2801 stops cotton harvesters during rain

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -164,8 +164,9 @@ end
 function AIDriveStrategyCombineCourse:initializeImplementControllers(vehicle)
     AIDriveStrategyCombineCourse:superClass().initializeImplementControllers(self, vehicle)
     local _
-    _, self.pipeController = self:addImplementController(vehicle, PipeController, Pipe, {}, nil)
-    self.combine, self.combineController = self:addImplementController(vehicle, CombineController, Combine, {}, nil)
+    _, self.pipeController = self:addImplementController(vehicle, 
+        PipeController, Pipe, {}, nil)
+    self.combineController, self.combine = self:getFirstRegisteredImplementControllerByClass(CombineController)
 end
 
 function AIDriveStrategyCombineCourse:getProximitySensorWidth()

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -222,16 +222,46 @@ function AIDriveStrategyCourse:addImplementController(vehicle, class, spec, stat
     local lastImplement, lastController
     for _, childVehicle in pairs(AIUtil.getAllChildVehiclesWithSpecialization(vehicle, spec, specReference)) do
         local controller = class(vehicle, childVehicle)
-        controller:setDisabledStates(states)
-        controller:setDriveStrategy(self)
-        table.insert(self.controllers, controller)
+        self:appendImplementController(controller, states)
         lastImplement, lastController = childVehicle, controller
     end
     return lastImplement, lastController
 end
 
-function AIDriveStrategyCourse:appendImplementController(controller)
+--- Appends an implement controller
+---@param controller ImplementController
+---@param disabledStates table|nil
+function AIDriveStrategyCourse:appendImplementController(controller, disabledStates)
+    if disabledStates then
+        controller:setDisabledStates(disabledStates)
+    end
+    controller:setDriveStrategy(self)
     table.insert(self.controllers, controller)
+end
+
+--- Gets all registered implement controller of a given type.
+---@param controllerClass ImplementController
+---@return boolean found?
+---@return table all found implement controllers
+function AIDriveStrategyCourse:getRegisteredImplementControllersByClass(controllerClass)
+    local foundControllers = {}
+    for _, controller in pairs(self.controllers) do 
+        if controller:is_a(controllerClass) then 
+            table.insert(foundControllers, controller)
+        end
+    end
+    return #foundControllers > 0, foundControllers
+end
+
+--- Gets the first found registered implement controller and it's implement.
+---@param controllerClass ImplementController
+---@return ImplementController|nil found implement controller
+---@return table|nil found implement
+function AIDriveStrategyCourse:getFirstRegisteredImplementControllerByClass(controllerClass)
+    local found, controllers = self:getRegisteredImplementControllersByClass(controllerClass)
+    if found then 
+        return controllers[1], controllers[1]:getImplement()
+    end
 end
 
 --- Checks if any controller disables fuel save, for example a round baler that is dropping a bale.
@@ -250,6 +280,7 @@ function AIDriveStrategyCourse:isFuelSaveAllowed()
 end
 
 function AIDriveStrategyCourse:initializeImplementControllers(vehicle)
+    --- override
 end
 
 --- Normal update function called every frame.

--- a/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
+++ b/scripts/ai/AIDriveStrategyFieldWorkCourse.lua
@@ -247,6 +247,7 @@ function AIDriveStrategyFieldWorkCourse:initializeImplementControllers(vehicle)
     self:addImplementController(vehicle, APalletAutoLoaderController, nil, {}, "spec_aPalletAutoLoader")
     self:addImplementController(vehicle, UniversalAutoloadController, nil, {}, "spec_universalAutoload")
 
+    self:addImplementController(vehicle, CombineController, Combine, defaultDisabledStates)
     self:addImplementController(vehicle, FertilizingSowingMachineController, FertilizingSowingMachine, defaultDisabledStates)
     self:addImplementController(vehicle, ForageWagonController, ForageWagon, defaultDisabledStates)
     self:addImplementController(vehicle, SowingMachineController, SowingMachine, defaultDisabledStates)
@@ -268,6 +269,7 @@ function AIDriveStrategyFieldWorkCourse:initializeImplementControllers(vehicle)
 
     self:addImplementController(vehicle, SoilSamplerController, nil, defaultDisabledStates, "spec_soilSampler")
     self:addImplementController(vehicle, StumpCutterController, StumpCutter, defaultDisabledStates)
+
 
 end
 

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -8,7 +8,9 @@ function CombineController:init(vehicle, combine)
     self.settings = vehicle:getCpSettings()
     self.beaconLightsActive = false
     self.hasPipe = SpecializationUtil.hasSpecialization(Pipe, combine.specializations)
-    self:fixDischargeDistanceForChopper()
+    if self.hasPipe then
+        self:fixDischargeDistanceForChopper()
+    end
 end
 
 function CombineController:update()


### PR DESCRIPTION
Cotton harvester have the combine spec but don't use the combine strategy. To use the combine controller, it has to be initialized in the fieldwork strategy.
