### PR TITLE
Small shovel position fixes and added missing high dump shovels to vehicle config

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -365,6 +365,9 @@ You can define the following custom settings:
 	<Vehicle name="wheelLoaderShovel.xml"
              shovelMovingToolIx = "1"
     />
+	<Vehicle name="overtippingBucket.xml"
+             shovelMovingToolIx = "1"
+    />
 
     <!--[DLC]-->
 
@@ -549,4 +552,30 @@ You can define the following custom settings:
 			 disablePipeMovingToolCorrection = "true"
 			 unloadOffsetX = "-3.56"
     />
+
+	<!--Mod: FS22_lizardHTB6000-->
+	<Vehicle name="HTB6000.xml"
+			shovelMovingToolIx = "1"
+	/>
+
+	<!--Mod: FS22_Liebherr_Xpower-->
+	<Vehicle name="highTipShovel.xml"
+			shovelMovingToolIx = "1"
+	/>
+
+	<!--Mod: FS22_bresselUndLadeHighTipShovelPack-->
+	<Vehicle name="bresselUndLadeL67.xml"
+			shovelMovingToolIx = "1"
+	/>
+
+	<!--Mod: FS22_bresselUndLadeHighTipShovelPack-->
+	<Vehicle name="bresselUndLadeL71.xml"
+			shovelMovingToolIx = "1"
+	/>
+
+	<!--Mod: FS22_bresselUndLadeHighTipShovelPack-->
+	<Vehicle name="bresselUndLadeL71.xml"
+			shovelMovingToolIx = "1"
+	/>
+
 </VehicleConfigurations>

--- a/scripts/ai/ImplementUtil.lua
+++ b/scripts/ai/ImplementUtil.lua
@@ -401,6 +401,25 @@ function ImplementUtil.stopMovingTool(implement, tool)
     local spec = implement.spec_cylindered
     implement:raiseDirtyFlags(tool.dirtyFlag)
     implement:raiseDirtyFlags(spec.cylinderedDirtyFlag)
+    local detachLock = spec.detachLockNodes and spec.detachLockNodes[tool]
+    if detachLock then
+        --- Fix shovel detach, as shovel might have angle requirements for detaching.
+        --- These limits are implemented without a hysteresis ...
+        --- So we need to force set the limit, if a difference of less than 1 degree was found.
+        local node = tool.node
+        local rot = {
+            getRotation(node)
+        }
+        if detachLock.detachingRotMinLimit ~=nil and 
+            math.abs(MathUtil.getAngleDifference(detachLock.detachingRotMinLimit, rot[tool.rotationAxis])) < math.pi/180 then 
+            Cylindered.setAbsoluteToolRotation(implement, tool, detachLock.detachingRotMinLimit)
+        end
+        if detachLock.detachingRotMaxLimit ~= nil and 
+            math.abs(MathUtil.getAngleDifference(detachLock.detachingRotMaxLimit, rot[tool.rotationAxis])) < math.pi/180 then 
+            Cylindered.setAbsoluteToolRotation(implement, tool, detachLock.detachingRotMaxLimit)
+        end
+    end
+
 end
 
 function ImplementUtil.getLevelerNode(object)

--- a/scripts/specializations/CpShovelPositions.lua
+++ b/scripts/specializations/CpShovelPositions.lua
@@ -78,6 +78,7 @@ function CpShovelPositions.registerEventListeners(vehicleType)
 	SpecializationUtil.registerEventListener(vehicleType, "onDraw", CpShovelPositions)	
 	SpecializationUtil.registerEventListener(vehicleType, "onUpdateTick", CpShovelPositions)
 	SpecializationUtil.registerEventListener(vehicleType, "onPostAttach", CpShovelPositions)
+	SpecializationUtil.registerEventListener(vehicleType, "onPreDetach", CpShovelPositions)
 end
 
 function CpShovelPositions.registerFunctions(vehicleType)
@@ -110,6 +111,10 @@ function CpShovelPositions:onPostAttach()
 	if self.spec_cpShovelPositions then
 		CpShovelPositions.cpSetupShovelPositions(self)
 	end
+end
+
+function CpShovelPositions:onPreDetach()
+	self:cpResetShovelState()
 end
 
 function CpShovelPositions:onDraw()


### PR DESCRIPTION
- Force stops the shovel position movement on detach.
- Makes sure detach requirements are met. 
- Added missing high dump shovels to config. (#2783 )