### PR TITLE
Fixes #2865

### DIFF
--- a/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
+++ b/scripts/ai/AIDriveStrategyDriveToFieldWorkStart.lua
@@ -84,11 +84,11 @@ function AIDriveStrategyDriveToFieldWorkStart:start(course, startIx, jobParamete
                 nVehicles > 1 and jobParameters.laneOffset:getValue() or 0,
                 course:getWorkWidth() / nVehicles)
         local implement = AIUtil.getImplementWithSpecialization(self.vehicle, Cutter)
+        if self.settings.foldImplementAtEnd:getValue() then
+            self.vehicle:prepareForAIDriving()
+        end
         if self:giantsPreFoldHeaderWithWheelsFix(implement) then 
-            self.vehicle:prepareForAIDriving()
             self:giantsPostFoldHeaderWithWheelsFix(implement)
-        else 
-            self.vehicle:prepareForAIDriving()
         end
         self:startCourseWithPathfinding(course, startIx)
     end
@@ -130,7 +130,7 @@ function AIDriveStrategyDriveToFieldWorkStart:getDriveData(dt, vX, vY, vZ)
     elseif self.state == self.states.PREPARE_TO_DRIVE then
         self:setMaxSpeed(0)
         local isReadyToDrive, blockingVehicle = self.vehicle:getIsAIReadyToDrive()
-        if isReadyToDrive then
+        if isReadyToDrive or not self.settings.foldImplementAtEnd:getValue() then
             self.state = self.states.DRIVING_TO_WORK_START
             self:debug('Ready to drive to work start')
         else

--- a/scripts/ai/jobs/CpAIJob.lua
+++ b/scripts/ai/jobs/CpAIJob.lua
@@ -96,9 +96,6 @@ end
 function CpAIJob:stop(aiMessage)
 	if self.isServer then
 		local vehicle = self.vehicleParameter:getVehicle()
-		vehicle:deleteAgent()
-		vehicle:aiJobFinished()
-
 		vehicle:resetCpAllActiveInfoTexts()
 		local driveStrategy = vehicle:getCpDriveStrategy()
 		if not aiMessage then 
@@ -116,14 +113,16 @@ function CpAIJob:stop(aiMessage)
 		if driveStrategy then
 			driveStrategy:onFinished(hasFinished)
 		end
-		if event then
-			SpecializationUtil.raiseEvent(vehicle, event)
-		end
 		if releaseMessage and not vehicle:getIsControlled() and not isOnlyShownOnPlayerStart then
 			--- Only shows the info text, if the vehicle is not entered.
 			--- TODO: Add check if passing to ad is active maybe?
 			vehicle:setCpInfoTextActive(releaseMessage)
 		end
+		if event then
+			SpecializationUtil.raiseEvent(vehicle, event)
+		end
+		vehicle:deleteAgent()
+		vehicle:aiJobFinished()
 	end
 	CpAIJob:superClass().stop(self, aiMessage)
 end

--- a/scripts/ai/jobs/CpAIJob.lua
+++ b/scripts/ai/jobs/CpAIJob.lua
@@ -94,37 +94,40 @@ function CpAIJob:start(farmId)
 end
 
 function CpAIJob:stop(aiMessage)
-	if self.isServer then
-		local vehicle = self.vehicleParameter:getVehicle()
-		vehicle:resetCpAllActiveInfoTexts()
-		local driveStrategy = vehicle:getCpDriveStrategy()
-		if not aiMessage then 
-			self:debug("No valid ai message given!")
-			if driveStrategy then
-				driveStrategy:onFinished()
-			end
-			return
-		end
-		local releaseMessage, hasFinished, event, isOnlyShownOnPlayerStart = 
-			g_infoTextManager:getInfoTextDataByAIMessage(aiMessage)
-		if releaseMessage then 
-			self:debug("Stopped with release message %s", tostring(releaseMessage))
-		end
+	if not self.isServer then 
+		CpAIJob:superClass().stop(self, aiMessage)
+		return
+	end
+	local vehicle = self.vehicleParameter:getVehicle()
+	vehicle:deleteAgent()
+	vehicle:aiJobFinished()
+	vehicle:resetCpAllActiveInfoTexts()
+	local driveStrategy = vehicle:getCpDriveStrategy()
+	if not aiMessage then 
+		self:debug("No valid ai message given!")
 		if driveStrategy then
-			driveStrategy:onFinished(hasFinished)
+			driveStrategy:onFinished()
 		end
-		if releaseMessage and not vehicle:getIsControlled() and not isOnlyShownOnPlayerStart then
-			--- Only shows the info text, if the vehicle is not entered.
-			--- TODO: Add check if passing to ad is active maybe?
-			vehicle:setCpInfoTextActive(releaseMessage)
-		end
-		if event then
-			SpecializationUtil.raiseEvent(vehicle, event)
-		end
-		vehicle:deleteAgent()
-		vehicle:aiJobFinished()
+		CpAIJob:superClass().stop(self, aiMessage)
+		return
+	end
+	local releaseMessage, hasFinished, event, isOnlyShownOnPlayerStart = 
+		g_infoTextManager:getInfoTextDataByAIMessage(aiMessage)
+	if releaseMessage then 
+		self:debug("Stopped with release message %s", tostring(releaseMessage))
+	end
+	if releaseMessage and not vehicle:getIsControlled() and not isOnlyShownOnPlayerStart then
+		--- Only shows the info text, if the vehicle is not entered.
+		--- TODO: Add check if passing to ad is active maybe?
+		vehicle:setCpInfoTextActive(releaseMessage)
 	end
 	CpAIJob:superClass().stop(self, aiMessage)
+	if event then
+		SpecializationUtil.raiseEvent(vehicle, event)
+	end
+	if driveStrategy then
+		driveStrategy:onFinished(hasFinished)
+	end
 end
 
 --- Updates the parameter values.


### PR DESCRIPTION
- Fixes info text not being cleared.
- Fixes folding timing problem.
- Drive to fieldwork only fold the implement, if the fold implement at end setting is active.