### PR TITLE
Separated the X tool offset for combine unloader and renamed Z tool offset(only for combine unloader)

### DIFF
--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -625,11 +625,11 @@
 			<Text language="de"><![CDATA[Versatz für den Ballensammler]]></Text>
 			<Text language="en"><![CDATA[Offset for the bale collector]]></Text>
 		</Translation>
-		<Translation name="CP_vehicle_setting_toolOffsetZ_title">
+		<Translation name="CP_vehicle_setting_combineOffsetZ_title">
 			<Text language="de"><![CDATA[Geräteversatz vertikal]]></Text>
 			<Text language="en"><![CDATA[Tool offset vertical]]></Text>
 		</Translation>
-		<Translation name="CP_vehicle_setting_toolOffsetZ_tooltip">
+		<Translation name="CP_vehicle_setting_combineOffsetZ_tooltip">
 			<Text language="de"><![CDATA[Geräteversatz vertikal]]></Text>
 			<Text language="en"><![CDATA[Tool offset vertical]]></Text>
 		</Translation>

--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -625,19 +625,19 @@
 			<Text language="de"><![CDATA[Versatz für den Ballensammler]]></Text>
 			<Text language="en"><![CDATA[Offset for the bale collector]]></Text>
 		</Translation>
-		<!-- <Translation name="CP_vehicle_setting_combineOffsetZ_title">
-			<Text language="de"><![CDATA[Geräteversatz vertikal]]></Text>
-			<Text language="en"><![CDATA[Tool offset vertical]]></Text>
-		</Translation>
-		<Translation name="CP_vehicle_setting_combineOffsetZ_tooltip">
-			<Text language="de"><![CDATA[Geräteversatz vertikal]]></Text>
-			<Text language="en"><![CDATA[Tool offset vertical]]></Text>
-		</Translation> -->
 		<Translation name="CP_vehicle_setting_combineOffsetX_title">
+			<Text language="de"><![CDATA[Versatz links/rechts]]></Text>
+			<Text language="en"><![CDATA[Offset left/right]]></Text>
+		</Translation>
+		<Translation name="CP_vehicle_setting_combineOffsetX_tooltip">
+			<Text language="de"><![CDATA[Versatz zum Drescher Rohr Rechts(+) und Links(-)]]></Text>
+			<Text language="en"><![CDATA[Offset for harvester pipe right(+) and left(-)]]></Text>
+		</Translation>
+		<Translation name="CP_vehicle_setting_combineOffsetZ_title">
 			<Text language="de"><![CDATA[Versatz vorne/hinten]]></Text>
 			<Text language="en"><![CDATA[Offset forwards/backwards]]></Text>
 		</Translation>
-		<Translation name="CP_vehicle_setting_combineOffsetX_tooltip">
+		<Translation name="CP_vehicle_setting_combineOffsetZ_tooltip">
 			<Text language="de"><![CDATA[Versatz zum Drescher Rohr Vorne(+) und Hinten(-)]]></Text>
 			<Text language="en"><![CDATA[Offset for harvester pipe with forwards(+) and backwards(-)]]></Text>
 		</Translation>

--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -625,13 +625,21 @@
 			<Text language="de"><![CDATA[Versatz für den Ballensammler]]></Text>
 			<Text language="en"><![CDATA[Offset for the bale collector]]></Text>
 		</Translation>
-		<Translation name="CP_vehicle_setting_combineOffsetZ_title">
+		<!-- <Translation name="CP_vehicle_setting_combineOffsetZ_title">
 			<Text language="de"><![CDATA[Geräteversatz vertikal]]></Text>
 			<Text language="en"><![CDATA[Tool offset vertical]]></Text>
 		</Translation>
 		<Translation name="CP_vehicle_setting_combineOffsetZ_tooltip">
 			<Text language="de"><![CDATA[Geräteversatz vertikal]]></Text>
 			<Text language="en"><![CDATA[Tool offset vertical]]></Text>
+		</Translation> -->
+		<Translation name="CP_vehicle_setting_combineOffsetX_title">
+			<Text language="de"><![CDATA[Versatz vorne/hinten]]></Text>
+			<Text language="en"><![CDATA[Offset forwards/backwards]]></Text>
+		</Translation>
+		<Translation name="CP_vehicle_setting_combineOffsetX_tooltip">
+			<Text language="de"><![CDATA[Versatz zum Drescher Rohr Vorne(+) und Hinten(-)]]></Text>
+			<Text language="en"><![CDATA[Offset for harvester pipe with forwards(+) and backwards(-)]]></Text>
 		</Translation>
 		<Translation name="CP_vehicle_setting_fullThreshold_title">
 			<Text language="de"><![CDATA[Entleeren wenn über:]]></Text>

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -59,15 +59,19 @@
 		</Setting>
 		<!--Tool Offset X-->
 		<Setting classType="AIParameterSettingList" name="toolOffsetX" min="-10" max="10" incremental="0.1" default="0" unit="2"
-				 onChangeCallback="cpShowWorkWidth" setDefault="setAutomaticWorkWidthAndOffset"
+				 onChangeCallback="cpShowWorkWidth" setDefault="setAutomaticWorkWidthAndOffset" isVisible="isToolOffsetVisible"
 				 isDisabled = "isToolOffsetDisabled" vehicleConfiguration="toolOffsetX"/>
 		<!--Bale finder Offset X-->
 		<Setting classType="AIParameterSettingList" name="baleCollectorOffset" min="-10" max="10" incremental="0.1" default="0" unit="2"
 				 onChangeCallback="cpShowBaleCollectorOffset" isVisible = "isBaleCollectorOffsetVisible" 
 				 setDefault="setAutomaticBaleCollectorOffset" vehicleConfiguration="baleCollectorOffset"/>
-		<!--Tool Offset Z-->
-		<Setting classType="AIParameterSettingList" name="toolOffsetZ" min="-10" max="10" incremental="0.1" default="0" unit="2"
-				 onChangeCallback="cpShowWorkWidth" isDisabled = "isToolOffsetDisabled" isVisible="areCombineUnloaderSettingsVisible" />
+		<!--Combine Offset X-->
+		<Setting classType="AIParameterSettingList" name="combineOffsetX" min="-10" max="10" incremental="0.1" default="0" unit="2"
+				 title="CP_vehicle_setting_toolOffsetX_title" tooltip="CP_vehicle_setting_toolOffsetX_tooltip"
+				 onChangeCallback="cpShowWorkWidth" isVisible="areCombineUnloaderSettingsVisible"/>
+		<!--Combine Offset Z-->
+		<Setting classType="AIParameterSettingList" name="combineOffsetZ" min="-10" max="10" incremental="0.1" default="0" unit="2"
+				 onChangeCallback="cpShowWorkWidth" isVisible="areCombineUnloaderSettingsVisible" />
 		<!-- Full threshold -->
 		<Setting classType="AIParameterSettingList" name="fullThreshold" min="40" max="100" incremental="5" default="85" unit="4" isVisible="areCombineUnloaderSettingsVisible"/>
 		<!--Silage additives needed?-->

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -67,7 +67,6 @@
 				 setDefault="setAutomaticBaleCollectorOffset" vehicleConfiguration="baleCollectorOffset"/>
 		<!--Combine Offset X-->
 		<Setting classType="AIParameterSettingList" name="combineOffsetX" min="-10" max="10" incremental="0.1" default="0" unit="2"
-				 title="CP_vehicle_setting_toolOffsetX_title" tooltip="CP_vehicle_setting_toolOffsetX_tooltip"
 				 onChangeCallback="cpShowWorkWidth" isVisible="areCombineUnloaderSettingsVisible"/>
 		<!--Combine Offset Z-->
 		<Setting classType="AIParameterSettingList" name="combineOffsetZ" min="-10" max="10" incremental="0.1" default="0" unit="2"

--- a/config/gamePadHud/UnloaderGamePadHudPage.xml
+++ b/config/gamePadHud/UnloaderGamePadHudPage.xml
@@ -9,6 +9,6 @@
 	<Setting type="combineUnloaderJobParameters" name = "useGiantsUnload" />
 	<Setting type="combineUnloaderJobParameters" name = "unloadingStation" />
 	<Setting type="vehicleSettings" name = "fullThreshold" />
-	<Setting type="vehicleSettings" name = "toolOffsetX" />
-	<Setting type="vehicleSettings" name = "toolOffsetZ" />
+	<Setting type="vehicleSettings" name = "combineOffsetX" />
+	<Setting type="vehicleSettings" name = "combineOffsetZ" />
 </Settings>

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -664,7 +664,7 @@ end
 ---(x > 0 left, z > 0 forward) corrected with the manual offset settings
 function AIDriveStrategyUnloadCombine:getPipeOffset(combine)
     -- TODO: unloader offset
-    return combine:getCpDriveStrategy():getPipeOffset(-self.settings.toolOffsetX:getValue(), self.settings.toolOffsetZ:getValue())
+    return combine:getCpDriveStrategy():getPipeOffset(-self.settings.combineOffsetX:getValue(), self.settings.combineOffsetZ:getValue())
 end
 
 function AIDriveStrategyUnloadCombine:getCombinesMeasuredBackDistance()

--- a/scripts/gui/hud/CpCombineUnloaderHudPage.lua
+++ b/scripts/gui/hud/CpCombineUnloaderHudPage.lua
@@ -18,12 +18,12 @@ end
 function CpCombineUnloaderHudPageElement:setupElements(baseHud, vehicle, lines, wMargin, hMargin)
     
     --- Tool offset x
-	self.toolOffsetXBtn = baseHud:addLineTextButton(self, 3, CpBaseHud.defaultFontSize, 
-												vehicle:getCpSettings().toolOffsetX)
+	self.combineOffsetXBtn = baseHud:addLineTextButton(self, 3, CpBaseHud.defaultFontSize, 
+												vehicle:getCpSettings().combineOffsetX)
 
     --- Tool offset z
-    self.toolOffsetZBtn = baseHud:addLineTextButton(self, 2, CpBaseHud.defaultFontSize, 
-                                                vehicle:getCpSettings().toolOffsetZ)
+    self.combineOffsetZBtn = baseHud:addLineTextButton(self, 2, CpBaseHud.defaultFontSize, 
+                                                vehicle:getCpSettings().combineOffsetZ)
 
     --- Full threshold 
     self.fullThresholdBtn = baseHud:addLineTextButton(self, 4, CpBaseHud.defaultFontSize, 
@@ -129,14 +129,13 @@ function CpCombineUnloaderHudPageElement:updateContent(vehicle, status)
     local text = vehicle:getCpCombineUnloaderJobParameters().unloadTarget:getString()
     self.unloadModeBtn:setTextDetails(text)
 
-    local toolOffsetX = vehicle:getCpSettings().toolOffsetX
-    local text = toolOffsetX:getIsDisabled() and CpBaseHud.automaticText or toolOffsetX:getString()
-    self.toolOffsetXBtn:setTextDetails(toolOffsetX:getTitle(), text)
-    self.toolOffsetXBtn:setDisabled(toolOffsetX:getIsDisabled())
+    local combineOffsetX = vehicle:getCpSettings().combineOffsetX
+    self.combineOffsetXBtn:setTextDetails(combineOffsetX:getTitle(), combineOffsetX:getString())
+    self.combineOffsetXBtn:setDisabled(combineOffsetX:getIsDisabled())
 
-    local toolOffsetZ = vehicle:getCpSettings().toolOffsetZ
-    self.toolOffsetZBtn:setTextDetails(toolOffsetZ:getTitle(), toolOffsetZ:getString())
-    self.toolOffsetZBtn:setDisabled(toolOffsetZ:getIsDisabled())
+    local combineOffsetZ = vehicle:getCpSettings().combineOffsetZ
+    self.combineOffsetZBtn:setTextDetails(combineOffsetZ:getTitle(), combineOffsetZ:getString())
+    self.combineOffsetZBtn:setDisabled(combineOffsetZ:getIsDisabled())
 
     local fullThreshold = vehicle:getCpSettings().fullThreshold
     self.fullThresholdBtn:setTextDetails(fullThreshold:getTitle(), fullThreshold:getString())

--- a/scripts/specializations/CpHud.lua
+++ b/scripts/specializations/CpHud.lua
@@ -258,8 +258,8 @@ end
 function CpHud:showCpCombineUnloaderWorkWidth()
 	WorkWidthUtil.showWorkWidth(self,
 										self:getCourseGeneratorSettings().workWidth:getValue(),
-											self:getCpSettings().toolOffsetX:getValue(),
-											self:getCpSettings().toolOffsetZ:getValue())
+											self:getCpSettings().combineOffsetX:getValue(),
+											self:getCpSettings().combineOffsetZ:getValue())
 end
 
 function CpHud:showCpCourseWorkWidth()

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -316,6 +316,10 @@ function CpVehicleSettings:isToolOffsetDisabled()
     return AIUtil.hasChildVehicleWithSpecialization(self, Plow)
 end
 
+function CpVehicleSettings:isToolOffsetVisible()
+    return not self:getCanStartCpCombineUnloader()
+end
+
 --- Only shows the setting if a valid tool with ridge markers is attached.
 function CpVehicleSettings:isRidgeMarkerSettingVisible()
     local vehicles, found = AIUtil.getAllChildVehiclesWithSpecialization(self, RidgeMarker)

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Distância lateral para coleta de fardos"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Esvaziar quando acabar:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifique se há aditivo de silagem."/>

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Distancia horizontal do implemento"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Distância lateral para coleta de fardos"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Distância lateral para coleta de fardos"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Distancia vertical do implemento"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Distancia vertical do implemento"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Distancia vertical do implemento"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Distancia vertical do implemento"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Esvaziar quando acabar:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifique se há aditivo de silagem."/>

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Distancia horizontal do implemento"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Distância lateral para coleta de fardos"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Distância lateral para coleta de fardos"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Distancia vertical do implemento"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Distancia vertical do implemento"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Esvaziar quando acabar:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifique se há aditivo de silagem."/>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="检查青贮添加剂"/>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="工具横向调整"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="工具纵向调整"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="工具纵向调整"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="工具纵向调整"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="工具纵向调整"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="检查青贮添加剂"/>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="工具横向调整"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="工具纵向调整"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="工具纵向调整"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="检查青贮添加剂"/>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="卸載完時剩餘空間"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="檢查青貯添加劑"/>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="工具橫向調整"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="工具縱向調整"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="工具縱向調整"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="卸載完時剩餘空間"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="檢查青貯添加劑"/>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="工具橫向調整"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="工具縱向調整"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="工具縱向調整"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="工具縱向調整"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="工具縱向調整"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="卸載完時剩餘空間"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="檢查青貯添加劑"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Nastaví horizontální odsazení nástroje."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Odsazení pro nakládání balíků"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Odsazení pro sběrač balíků."/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Vertikální odsazení nástroje"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Nastaví vertikální odsazení nástroje."/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vyprázdnit po naplnění:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="CO DĚLAT"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrola silážních aditiv"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Nastaví horizontální odsazení nástroje."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Odsazení pro nakládání balíků"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Odsazení pro sběrač balíků."/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Vertikální odsazení nástroje"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Nastaví vertikální odsazení nástroje."/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Vertikální odsazení nástroje"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Nastaví vertikální odsazení nástroje."/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vyprázdnit po naplnění:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="CO DĚLAT"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrola silážních aditiv"/>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Odsazení pro sběrač balíků."/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vyprázdnit po naplnění:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="CO DĚLAT"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrola silážních aditiv"/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Redskab forskudt vandret"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Redskab forskudt lodret"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Redskab forskudt vertikal"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Tøm, når den er færdig:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Tjek for ensilagetilsætning."/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Redskab forskudt vandret"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Redskab forskudt lodret"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Redskab forskudt vertikal"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Redskab forskudt lodret"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Redskab forskudt vertikal"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Tøm, når den er færdig:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Tjek for ensilagetilsætning."/>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Tøm, når den er færdig:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Tjek for ensilagetilsætning."/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Geräteversatz horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Ballen Aufnahme Versatz"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Versatz für den Ballensammler"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Geräteversatz vertikal"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Geräteversatz vertikal"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Geräteversatz vertikal"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Geräteversatz vertikal"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Entleeren wenn über:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Wenn der Füllstand des Abfahrers über diesem Wert liegt, wird er nicht auf den Drescher warten."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Siliermittel überwachen"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Geräteversatz horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Ballen Aufnahme Versatz"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Versatz für den Ballensammler"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Geräteversatz vertikal"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Geräteversatz vertikal"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Versatz vorne/hinten"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Versatz zum Drescher Rohr Vorne(+) und Hinten(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Entleeren wenn über:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Wenn der Füllstand des Abfahrers über diesem Wert liegt, wird er nicht auf den Drescher warten."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Siliermittel überwachen"/>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -194,8 +194,10 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Geräteversatz horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Ballen Aufnahme Versatz"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Versatz für den Ballensammler"/>
-    <text name="CP_vehicle_setting_combineOffsetX_title" text="Versatz vorne/hinten"/>
-    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Versatz zum Drescher Rohr Vorne(+) und Hinten(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Versatz links/rechts"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Versatz zum Drescher Rohr Rechts(+) und Links(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Versatz vorne/hinten"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Versatz zum Drescher Rohr Vorne(+) und Hinten(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Entleeren wenn über:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Wenn der Füllstand des Abfahrers über diesem Wert liegt, wird er nicht auf den Drescher warten."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Siliermittel überwachen"/>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="If the unloader's fill level is over this value, it won't wait for the combine."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="If the unloader's fill level is over this value, it won't wait for the combine."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive"/>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -194,8 +194,10 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
-    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset left/right"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe right(+) and left(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="If the unloader's fill level is over this value, it won't wait for the combine."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive"/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Desp. Herramienta Izq/Der"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Compensación de recogida de pacas"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Compensación para el recogedor de pacas"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Desp. Herramienta Del/Tra"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Desp. Herramienta Del/Tra"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vaciar al estar al:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Comprobar Aditivo de Ensilaje."/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Desp. Herramienta Izq/Der"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Compensación de recogida de pacas"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Compensación para el recogedor de pacas"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Desp. Herramienta Del/Tra"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Desp. Herramienta Del/Tra"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Desp. Herramienta Del/Tra"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Desp. Herramienta Del/Tra"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vaciar al estar al:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Comprobar Aditivo de Ensilaje."/>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Compensación para el recogedor de pacas"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vaciar al estar al:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Comprobar Aditivo de Ensilaje."/>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Décalage horizontal de l'outil."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Décalage du pickup de balle"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Décalage pour le collecteur de balles."/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Décalage vertical de l'outil"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Décalage vertical de l'outil."/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Décalage vertical de l'outil"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Décalage vertical de l'outil."/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vider si supérieur à"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Permet de tenir compte d'un seuil de remplissage plus faible pour considéder le contenant comme rempli."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Arrêt si additif d'ensilage vide"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Décalage pour le collecteur de balles."/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vider si supérieur à"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Permet de tenir compte d'un seuil de remplissage plus faible pour considéder le contenant comme rempli."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Arrêt si additif d'ensilage vide"/>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Décalage horizontal de l'outil."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Décalage du pickup de balle"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Décalage pour le collecteur de balles."/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Décalage vertical de l'outil"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Décalage vertical de l'outil."/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vider si supérieur à"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Permet de tenir compte d'un seuil de remplissage plus faible pour considéder le contenant comme rempli."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Arrêt si additif d'ensilage vide"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Eltolás a bálagyűjtőkhöz"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Kiürítési határérték:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="A segítő kiüríti a pótkocsit, ha a töltési szint meghaladja a beállított értéket"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Szilázsadalék ellenőrzés"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Szerszámeltolás balra/jobbra"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bála felszedés eltolása"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Eltolás a bálagyűjtőkhöz"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Szerszámeltolás hosszirányban"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Szerszámeltolás előre/hátra"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Szerszámeltolás hosszirányban"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Szerszámeltolás előre/hátra"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Kiürítési határérték:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="A segítő kiüríti a pótkocsit, ha a töltési szint meghaladja a beállított értéket"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Szilázsadalék ellenőrzés"/>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Szerszámeltolás balra/jobbra"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bála felszedés eltolása"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Eltolás a bálagyűjtőkhöz"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Szerszámeltolás hosszirányban"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Szerszámeltolás előre/hátra"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Kiürítési határérték:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="A segítő kiüríti a pótkocsit, ha a töltési szint meghaladja a beállított értéket"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Szilázsadalék ellenőrzés"/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Correzione oriz."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Compensazione raccolta balle"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Compensazione per il raccoglitore di balle"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Correzione vert."/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Correzione vert."/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Correzione vert."/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Correzione vert."/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vuota quando è al:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Se il livello di riempimento dello scaricatore è superiore a questo valore, non attenderà la mietitrebbia"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Controllare l'additivo per insilato."/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Compensazione per il raccoglitore di balle"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vuota quando è al:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Se il livello di riempimento dello scaricatore è superiore a questo valore, non attenderà la mietitrebbia"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Controllare l'additivo per insilato."/>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Correzione oriz."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Compensazione raccolta balle"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Compensazione per il raccoglitore di balle"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Correzione vert."/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Correzione vert."/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Vuota quando è al:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Se il livello di riempimento dello scaricatore è superiore a questo valore, non attenderà la mietitrebbia"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Controllare l'additivo per insilato."/>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="作業機の位置を水平方向にオフセットします"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="ツールオフセット（垂直）"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="作業機の位置を垂直方向にオフセットします"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="ツールオフセット（垂直）"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="作業機の位置を垂直方向にオフセットします"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="作業機の位置を水平方向にオフセットします"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="ツールオフセット（垂直）"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="作業機の位置を垂直方向にオフセットします"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Werktuig horizontale offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Werktuig verticale offset"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Werktuig verticale offset"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Werktuig verticale offset"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Werktuig verticale offset"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Werktuig horizontale offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Werktuig verticale offset"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Werktuig verticale offset"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Przesunięcie dla podbieracza bel."/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Opróżnij, gdy ponad:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Ustala po osiągnięciu jakiego poziomu wypełnienia pomocnik ma rozładować przyczepę."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Sprawdź dodatek do kiszenia"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Przesunięcie horyzontalne (poziome) dla narzędzi."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Przes. podbieracza bel"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Przesunięcie dla podbieracza bel."/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Przes. pionowe dla narzędzi"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Przesunięcie wertykalne (pionowe) dla narzędzi."/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Opróżnij, gdy ponad:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Ustala po osiągnięciu jakiego poziomu wypełnienia pomocnik ma rozładować przyczepę."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Sprawdź dodatek do kiszenia"/>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Przesunięcie horyzontalne (poziome) dla narzędzi."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Przes. podbieracza bel"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Przesunięcie dla podbieracza bel."/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Przes. pionowe dla narzędzi"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Przesunięcie wertykalne (pionowe) dla narzędzi."/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Przes. pionowe dla narzędzi"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Przesunięcie wertykalne (pionowe) dla narzędzi."/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Opróżnij, gdy ponad:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Ustala po osiągnięciu jakiego poziomu wypełnienia pomocnik ma rozładować przyczepę."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Sprawdź dodatek do kiszenia"/>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Ajuste da alfaia horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Ajuste do juntador de fardos"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Ajuste do juntador de fardos"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Ajuste da alfaia vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Ajuste da alfaia vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Ajuste da alfaia vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Ajuste da alfaia vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Despeja quando termina:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifica o aditivo de silagem."/>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Ajuste da alfaia horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Ajuste do juntador de fardos"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Ajuste do juntador de fardos"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Ajuste da alfaia vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Ajuste da alfaia vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Despeja quando termina:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifica o aditivo de silagem."/>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Ajuste do juntador de fardos"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Despeja quando termina:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Verifica o aditivo de silagem."/>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Tool offset horizontal"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Tool offset vertical"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Tool offset vertical"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Tool offset vertical"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Empty when over:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="TODO"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Check for silage additive."/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Поперечное смещение инструмента."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Смещение подборщика тюков"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Смещение подборщика тюков"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Продольное смещение"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Продольное смещение инструмента."/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Разгружаться при:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Если уровень заполнения разгрузчика уже превышает это значение, то он не будет ждать следующего вызова комбайна, а сразу поедет разгружаться."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Контроль силосной добавки."/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Поперечное смещение инструмента."/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Смещение подборщика тюков"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Смещение подборщика тюков"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Продольное смещение"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Продольное смещение инструмента."/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Продольное смещение"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Продольное смещение инструмента."/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Разгружаться при:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Если уровень заполнения разгрузчика уже превышает это значение, то он не будет ждать следующего вызова комбайна, а сразу поедет разгружаться."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Контроль силосной добавки."/>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Смещение подборщика тюков"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Разгружаться при:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="Если уровень заполнения разгрузчика уже превышает это значение, то он не будет ждать следующего вызова комбайна, а сразу поедет разгружаться."/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Контроль силосной добавки."/>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Redskapsskjutning horisontellt"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Baluppsamlare sidledsförskjutning"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Sidledsförskjutning för Baluppsamlare"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Redskapsskjutning vertikalt"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Redskapsskjutning vertikalt"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Redskapsskjutning vertikalt"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Redskapsskjutning vertikalt"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Tom när den är över:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="ATTGÖRA"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrollerar om där finns ensilage tillsatts."/>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Redskapsskjutning horisontellt"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Baluppsamlare sidledsförskjutning"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Sidledsförskjutning för Baluppsamlare"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Redskapsskjutning vertikalt"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Redskapsskjutning vertikalt"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Tom när den är över:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="ATTGÖRA"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrollerar om där finns ensilage tillsatts."/>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Sidledsförskjutning för Baluppsamlare"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Tom när den är över:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="ATTGÖRA"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Kontrollerar om där finns ensilage tillsatts."/>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Takım ofseti yatay"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_title" text="Takım ofseti dikey"/>
-    <text name="CP_vehicle_setting_toolOffsetZ_tooltip" text="Takım ofseti dikey"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Takım ofseti dikey"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Takım ofseti dikey"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Bittiğinde boş:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="YAPILACAKLAR"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Silaj katkısı olup olmadığını kontrol edin."/>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -194,8 +194,8 @@
     <text name="CP_vehicle_setting_toolOffsetX_tooltip" text="Takım ofseti yatay"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_title" text="Bale pickup offset"/>
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Takım ofseti dikey"/>
-    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Takım ofseti dikey"/>
+    <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Bittiğinde boş:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="YAPILACAKLAR"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Silaj katkısı olup olmadığını kontrol edin."/>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -196,6 +196,8 @@
     <text name="CP_vehicle_setting_baleCollectorOffset_tooltip" text="Offset for the bale collector"/>
     <text name="CP_vehicle_setting_combineOffsetX_title" text="Offset forwards/backwards"/>
     <text name="CP_vehicle_setting_combineOffsetX_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_title" text="Offset forwards/backwards"/>
+    <text name="CP_vehicle_setting_combineOffsetZ_tooltip" text="Offset for harvester pipe with forwards(+) and backwards(-)"/>
     <text name="CP_vehicle_setting_fullThreshold_title" text="Bittiğinde boş:"/>
     <text name="CP_vehicle_setting_fullThreshold_tooltip" text="YAPILACAKLAR"/>
     <text name="CP_vehicle_setting_useAdditiveFillUnit_title" text="Silaj katkısı olup olmadığını kontrol edin."/>


### PR DESCRIPTION
- Saves the combine unloader x offset separate from any X tool offset
- Offset gets no longer reset between implement changes
- Might be a good idea to change the translations of combineOffsetX and combineOffsetZ as the current tooltips dosen't describe the functions of both. 