### PR TITLE
Fixes loaded settings values, like the x tool offset.

### DIFF
--- a/scripts/ai/parameters/AIParameterBooleanSetting.lua
+++ b/scripts/ai/parameters/AIParameterBooleanSetting.lua
@@ -33,9 +33,17 @@ end
 function AIParameterBooleanSetting:loadFromXMLFile(xmlFile, key)
 	local rawValue = xmlFile:getString(key .. "#currentValue")
 	if rawValue ~= nil then 
+		self.loadedValue = rawValue
 		self:setValue(rawValue == "true" or false)
 	else 
 		self:loadFromXMLFileLegacy(xmlFile, key)
+	end
+end
+
+function AIParameterBooleanSetting:resetToLoadedValue()
+	if self.loadedValue ~= nil then 
+		self:setValue(self.loadedValue)
+		self:raiseDirtyFlag()
 	end
 end
 

--- a/scripts/ai/parameters/AIParameterSettingList.lua
+++ b/scripts/ai/parameters/AIParameterSettingList.lua
@@ -263,6 +263,7 @@ function AIParameterSettingList:loadFromXMLFile(xmlFile, key)
 	local value = rawValue and tonumber(rawValue) 
 	if value then 
 		self:debug("loaded value: %.2f", value)
+		self.loadedValue = value
 		--- Applies a small epsilon, as otherwise floating point problems might happen.
 		self:setFloatValue(value, 0.001)
 	else 
@@ -376,7 +377,7 @@ end
 
 --- Sets a float value relative to the incremental.
 ---@param value number
----@param epsilon number optional
+---@param epsilon number|nil optional
 ---@return boolean value is not valid and could not be set.
 function AIParameterSettingList:setFloatValue(value, epsilon)
 	return setValueInternal(self, value, function(a, b)
@@ -450,6 +451,14 @@ function AIParameterSettingList:setDefault(noEventSend)
 	end
 	self:setToIx(1)
 	if (noEventSend == nil or noEventSend==false) and current ~= self.current then
+		self:raiseDirtyFlag()
+	end
+end
+
+--- Resets the setting value back to the loaded value, if it's possible.
+function AIParameterSettingList:resetToLoadedValue()
+	if self.loadedValue ~= nil then 
+		self:setFloatValue(self.loadedValue)
 		self:raiseDirtyFlag()
 	end
 end

--- a/scripts/specializations/CpCourseGeneratorSettings.lua
+++ b/scripts/specializations/CpCourseGeneratorSettings.lua
@@ -46,6 +46,7 @@ end
 
 function CpCourseGeneratorSettings.registerEventListeners(vehicleType)	
 	SpecializationUtil.registerEventListener(vehicleType, "onLoad", CpCourseGeneratorSettings)
+    SpecializationUtil.registerEventListener(vehicleType, "onUpdate", CpCourseGeneratorSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onLoadFinished",CpCourseGeneratorSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onCpUnitChanged", CpCourseGeneratorSettings)
 end
@@ -100,11 +101,16 @@ function CpCourseGeneratorSettings:onLoad(savegame)
     CpCourseGeneratorSettings.loadSettings(self,savegame)
 end
 
---- Apply auto work width after everything is loaded and no settings are saved in the save game. 
-function CpCourseGeneratorSettings:onLoadFinished(savegame)
-    local spec = self.spec_cpCourseGeneratorSettings
-    if not spec.wasLoaded then
-        CpCourseGeneratorSettings.setAutomaticWorkWidthAndOffset(self)
+--- Apply auto work width after everything is loaded.
+function CpCourseGeneratorSettings:onLoadFinished()
+    CpCourseGeneratorSettings.setAutomaticWorkWidthAndOffset(self)
+end
+
+--- Resets the work width to a saved value after all implements are loaded and attached.
+function CpCourseGeneratorSettings:onUpdate(savegame)
+    if not self.finishedFirstUpdate then
+        local spec = self.spec_cpCourseGeneratorSettings
+        spec.workWidth:resetToLoadedValue()
     end
 end
 
@@ -160,7 +166,6 @@ function CpCourseGeneratorSettings:loadSettings(savegame)
             setting:loadFromXMLFile(savegame.xmlFile, key)
             CpUtil.debugVehicle(CpUtil.DBG_HUD,self,"Loaded setting: %s, value:%s, key: %s",setting:getName(),setting:getValue(),key)
         end
-        spec.wasLoaded = true
     end)
 
     --- Loads the normal course generator settings.

--- a/scripts/specializations/CpCourseGeneratorSettings.lua
+++ b/scripts/specializations/CpCourseGeneratorSettings.lua
@@ -108,10 +108,11 @@ end
 
 --- Resets the work width to a saved value after all implements are loaded and attached.
 function CpCourseGeneratorSettings:onUpdate(savegame)
-    if not self.finishedFirstUpdate then
-        local spec = self.spec_cpCourseGeneratorSettings
+    local spec = self.spec_cpCourseGeneratorSettings
+    if not spec.finishedFirstUpdate then
         spec.workWidth:resetToLoadedValue()
     end
+    spec.finishedFirstUpdate = true
 end
 
 --- Makes sure the automatic work width gets recalculated after the variable work width was changed by the user.

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -94,9 +94,9 @@ end
 
 --- Resets the tool offset to a saved value after all implements are loaded and attached.
 function CpVehicleSettings:onUpdate()
-    if not self.finishedFirstUpdate then
+    local spec = self.spec_cpVehicleSettings
+    if not spec.finishedFirstUpdate then
         --- TODO: Maybe consider a more generic approach in the future.
-        local spec = self.spec_cpVehicleSettings
         spec.toolOffsetX:resetToLoadedValue()
         spec.bunkerSiloWorkWidth:resetToLoadedValue()
         spec.baleCollectorOffset:resetToLoadedValue()
@@ -105,6 +105,7 @@ function CpVehicleSettings:onUpdate()
         spec.bunkerSiloWorkWidth:resetToLoadedValue()
         spec.loadingShovelHeightOffset:resetToLoadedValue()
     end
+    spec.finishedFirstUpdate = true
 end
 
 --- Changes the sprayer work width on fill type change, as it might depend on the loaded fill type.

--- a/scripts/specializations/CpVehicleSettings.lua
+++ b/scripts/specializations/CpVehicleSettings.lua
@@ -52,7 +52,7 @@ end
 function CpVehicleSettings.registerEventListeners(vehicleType)	
 --	SpecializationUtil.registerEventListener(vehicleType, "onRegisterActionEvents", CpVehicleSettings)
 	SpecializationUtil.registerEventListener(vehicleType, "onLoad", CpVehicleSettings)
-    SpecializationUtil.registerEventListener(vehicleType, "onLoadFinished", CpVehicleSettings)
+    SpecializationUtil.registerEventListener(vehicleType, "onUpdate", CpVehicleSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onCpUnitChanged", CpVehicleSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onReadStream", CpVehicleSettings)
     SpecializationUtil.registerEventListener(vehicleType, "onWriteStream", CpVehicleSettings)
@@ -92,11 +92,20 @@ function CpVehicleSettings:onLoad(savegame)
     CpVehicleSettings.loadSettings(self, savegame)
 end
 
-function CpVehicleSettings:onLoadFinished()
-    local spec = self.spec_cpVehicleSettings
-    spec.wasLoaded = nil
+--- Resets the tool offset to a saved value after all implements are loaded and attached.
+function CpVehicleSettings:onUpdate()
+    if not self.finishedFirstUpdate then
+        --- TODO: Maybe consider a more generic approach in the future.
+        local spec = self.spec_cpVehicleSettings
+        spec.toolOffsetX:resetToLoadedValue()
+        spec.bunkerSiloWorkWidth:resetToLoadedValue()
+        spec.baleCollectorOffset:resetToLoadedValue()
+        spec.raiseImplementLate:resetToLoadedValue()
+        spec.lowerImplementEarly:resetToLoadedValue()
+        spec.bunkerSiloWorkWidth:resetToLoadedValue()
+        spec.loadingShovelHeightOffset:resetToLoadedValue()
+    end
 end
-
 
 --- Changes the sprayer work width on fill type change, as it might depend on the loaded fill type.
 --- For example Lime and Fertilizer might have a different work width.


### PR DESCRIPTION
#1548 
Vehicle settings, that are changed based on attached implements, might change their loaded values automatically after loading. So we reset these settings on the first update tick back to the correct saved values.