### PR TITLE
Ai improvements 2023 12

### DIFF
--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -146,7 +146,7 @@ function AIDriveStrategyCombineCourse:setAllStaticParameters()
     self.pullBackDistanceEnd = self.pullBackDistanceStart + 5
     -- when making a pocket, how far to back up before changing to forward
     -- for very long vehicles, like potato/sugar beet harvesters the 20 meters may not be enough
-    self.pocketReverseDistance = math.max(1.8 * AIUtil.getVehicleAndImplementsTotalLength(self.vehicle), 20)
+    self.pocketReverseDistance = math.max(1.9 * AIUtil.getVehicleAndImplementsTotalLength(self.vehicle), 20)
     -- register ourselves at our boss
     -- TODO_22 g_combineUnloadManager:addCombineToList(self.vehicle, self)
     self.waitingForUnloaderAtEndOfRow = CpTemporaryObject()

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1332,7 +1332,10 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
 
     -- Combines drive special headland corner maneuvers, except potato and sugarbeet harvesters
     if self.turnContext:isHeadlandCorner() then
-        if self.combineController:isPotatoOrSugarBeetHarvester() then
+        if self.combineController:isTowed() then
+            self:debug('Headland turn but this is a towed harvester using normal turn maneuvers.')
+            AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)
+        elseif self.combineController:isPotatoOrSugarBeetHarvester() then
             self:debug('Headland turn but this harvester uses normal turn maneuvers.')
             AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)
         elseif self.course:isOnConnectingTrack(ix) then

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1335,6 +1335,10 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
         if self.combineController:isTowed() then
             self:debug('Headland turn but this is a towed harvester using normal turn maneuvers.')
             AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)
+        -- The type of fruit being harvested isn't really the indicator if we can make a headland turn
+        -- TODO: either make disabling combine headland turns configurable, or
+        -- TODO: decide automatically based on the vehicle's properties, like turn radius, work width, etc.
+        -- and disable when such a turn does not make sense for the vehicle.
         elseif self.combineController:isPotatoOrSugarBeetHarvester() then
             self:debug('Headland turn but this harvester uses normal turn maneuvers.')
             AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -145,7 +145,8 @@ function AIDriveStrategyCombineCourse:setAllStaticParameters()
     -- and back up another bit
     self.pullBackDistanceEnd = self.pullBackDistanceStart + 5
     -- when making a pocket, how far to back up before changing to forward
-    self.pocketReverseDistance = 20
+    -- for very long vehicles, like potato/sugar beet harvesters the 20 meters may not be enough
+    self.pocketReverseDistance = math.max(1.8 * AIUtil.getVehicleAndImplementsTotalLength(self.vehicle), 20)
     -- register ourselves at our boss
     -- TODO_22 g_combineUnloadManager:addCombineToList(self.vehicle, self)
     self.waitingForUnloaderAtEndOfRow = CpTemporaryObject()

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1603,20 +1603,6 @@ function AIDriveStrategyUnloadCombine:createMoveAwayCourse(blockingVehicle, isAh
 end
 
 ------------------------------------------------------------------------------------------------------------------------
--- Is the blocking vehicle in front of us?
-------------------------------------------------------------------------------------------------------------------------
-function AIDriveStrategyUnloadCombine:isBlockingVehicleAheadOfUs(blockingVehicle)
-    -- if we look straight left or right out of the window, is blockingVehicle in front of us or behind us?
-    -- if in front, move back, if behind, move forward
-    -- but since we have a trailer, don't use the tractor's direction node directly, instead, a point behind it
-    -- about the half length of the rig.
-    local _, frontMarkerOffset = Markers.getFrontMarkerNode(self.vehicle)
-    local _, backMarkerOffset = Markers.getBackMarkerNode(self.vehicle)
-    local _, _, dz = localToLocal(blockingVehicle.rootNode, self.vehicle:getAIDirectionNode(), 0, 0, 0)
-    return dz > (frontMarkerOffset + backMarkerOffset) / 2
-end
-
-------------------------------------------------------------------------------------------------------------------------
 -- Is there another vehicle blocking us?
 ------------------------------------------------------------------------------------------------------------------------
 --- If the other vehicle is a combine driven by CP, we will try get out of its way. Otherwise, if we are not being
@@ -1636,7 +1622,7 @@ function AIDriveStrategyUnloadCombine:onBlockingVehicle(blockingVehicle, isBack)
             not self:isBeingHeld() then
         self:debug('%s has been blocking us for a while, move a bit', CpUtil.getName(blockingVehicle))
         local course
-        local isBlockingVehicleAheadOfUs = self:isBlockingVehicleAheadOfUs(blockingVehicle)
+        local isBlockingVehicleAheadOfUs = AIUtil.isOtherVehicleAhead(self.vehicle, blockingVehicle)
         local trailer = AIUtil.getImplementOrVehicleWithSpecialization(self.vehicle, Trailer)
         if AIDriveStrategyCombineCourse.isActiveCpCombine(blockingVehicle) then
             -- except we are blocking our buddy, so set up a course parallel to the combine's direction,

--- a/scripts/ai/AIUtil.lua
+++ b/scripts/ai/AIUtil.lua
@@ -712,3 +712,18 @@ end
 function AIUtil.hasArticulatedAxis(vehicle)
 	return vehicle.spec_articulatedAxis and vehicle.spec_articulatedAxis.componentJoint
 end
+
+------------------------------------------------------------------------------------------------------------------------
+-- Is the other vehicle in front of us?
+------------------------------------------------------------------------------------------------------------------------
+function AIUtil.isOtherVehicleAhead(vehicle, otherVehicle)
+	-- if we look straight left or right out of the window, is blockingVehicle in front of us or behind us?
+	-- but since we may have a trailer or other implement, don't use the tractor's direction node directly, instead,
+	-- a point behind it about the half length of the rig.
+	-- (using the front and back markers are probably better than getVehicleAndImplementsTotalLength() as that
+	-- assumes that there is no overlap between the vehicle and the implements)
+	local _, frontMarkerOffset = Markers.getFrontMarkerNode(vehicle)
+	local _, backMarkerOffset = Markers.getBackMarkerNode(vehicle)
+	local _, _, dz = localToLocal(otherVehicle.rootNode, vehicle:getAIDirectionNode(), 0, 0, 0)
+	return dz > (frontMarkerOffset + backMarkerOffset) / 2
+end

--- a/scripts/ai/ImplementUtil.lua
+++ b/scripts/ai/ImplementUtil.lua
@@ -114,7 +114,7 @@ function ImplementUtil.isWheeledImplement(implement)
         end
     end
 
-    local activeInputAttacherJoint = implement:getActiveInputAttacherJoint()
+    local activeInputAttacherJoint = implement.getActiveInputAttacherJoint and implement:getActiveInputAttacherJoint()
     if activeInputAttacherJoint and allowedJointTypes[activeInputAttacherJoint.jointType] and
             implement.spec_wheels and implement.spec_wheels.wheels and #implement.spec_wheels.wheels > 0 then
         -- Attempt to find the pivot node.

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -11,6 +11,7 @@ function CombineController:init(vehicle, combine)
     if self.hasPipe then
         self:fixDischargeDistanceForChopper()
     end
+    self.isWheeledImplement = ImplementUtil.isWheeledImplement(combine)
 end
 
 function CombineController:update()
@@ -136,6 +137,11 @@ function CombineController:isPotatoOrSugarBeetHarvester()
         end
     end
     return false
+end
+
+--- Is this a towed harvester? We don't want these to make combine headland turns (or make pockets?)
+function CombineController:isTowed()
+    return self.isWheeledImplement
 end
 
 -------------------------------------------------------------


### PR DESCRIPTION
fix: harvester pocket creation

Back up further with longer vehicles before starting
the pocket, so they have room to drive fully into the
pocket.

fix: combine unloader stuck behind combine

When checking if we are in a good position behind
the combine to start unloading, allow for more
sideways error proportional to the distance from
the pipe, assuming we'll line up better as we
get closer.

fix: combine unloader moving out of combine's way

Fixed head-on and in-front/same direction check so
unloader will now reverse when behind the combine
(but has the same heading) to make way.

fix: towed harvester don't use combine headland turns