### PR TITLE
Improving how root vegetable harvesters are recognized

### DIFF
--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -382,7 +382,7 @@ end
 --
 -- Preparation marks an earth fruit since this is the only factor that diversifies them from normal fruit types
 -- SUGARCANE is an exception and ignored
-function CpUtil.getAllEarthFruits()
+function CpUtil.getAllRootVegetables()
     local earthFruits = {}
     for _, fruitTypeData in pairs(g_fruitTypeManager.fruitTypes) do
         local minPreparingGrowthState = fruitTypeData.minPreparingGrowthState

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -391,8 +391,9 @@ function CpUtil.getAllEarthFruits()
 
         -- check if fruit is needs herb removement to be harvested
         if minPreparingGrowthState ~= -1 and preparedGrowthState ~= -1 and name ~= "SUGARCANE" then
-            if g_fruitTypeManager:getFruitTypeByName(name) ~= nil then
-                table.insert(earthFruits, name)
+			local fruitType = g_fruitTypeManager:getFruitTypeByName(name)
+            if fruitType ~= nil then
+				table.insert(earthFruits, fruitType.index)
             end
         end
     end

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -377,3 +377,25 @@ function CpUtil.isStateOneOf(myState, states)
     end
     return false
 end
+
+-- Return all fruitTypeIndexes where a fruitType needs preparation. 
+--
+-- Preparation marks an earth fruit since this is the only factor that diversifies them from normal fruit types
+-- SUGARCANE is an exception and ignored
+function CpUtil.getAllEarthFruits()
+    local earthFruits = {}
+    for _, fruitTypeData in pairs(g_fruitTypeManager.fruitTypes) do
+        local minPreparingGrowthState = fruitTypeData.minPreparingGrowthState
+        local preparedGrowthState = fruitTypeData.preparedGrowthState
+        local name = fruitTypeData.name
+
+        -- check if fruit is needs herb removement to be harvested
+        if minPreparingGrowthState ~= -1 and preparedGrowthState ~= -1 and name ~= "SUGARCANE" then
+            if g_fruitTypeManager:getFruitTypeByName(name) ~= nil then
+                earthFruits:insert(name)
+            end
+        end
+    end
+
+    return earthFruits
+end

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -392,7 +392,7 @@ function CpUtil.getAllEarthFruits()
         -- check if fruit is needs herb removement to be harvested
         if minPreparingGrowthState ~= -1 and preparedGrowthState ~= -1 and name ~= "SUGARCANE" then
             if g_fruitTypeManager:getFruitTypeByName(name) ~= nil then
-                earthFruits:insert(name)
+                table.insert(earthFruits, name)
             end
         end
     end

--- a/scripts/CpUtil.lua
+++ b/scripts/CpUtil.lua
@@ -380,7 +380,7 @@ end
 
 -- Return all fruitTypeIndexes where a fruitType needs preparation. 
 --
--- Preparation marks an earth fruit since this is the only factor that diversifies them from normal fruit types
+-- Preparation marks an root vegetable since this is the only factor that diversifies them from normal fruit types
 -- SUGARCANE is an exception and ignored
 function CpUtil.getAllRootVegetables()
     local earthFruits = {}

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -1339,7 +1339,7 @@ function AIDriveStrategyCombineCourse:startTurn(ix)
         -- TODO: either make disabling combine headland turns configurable, or
         -- TODO: decide automatically based on the vehicle's properties, like turn radius, work width, etc.
         -- and disable when such a turn does not make sense for the vehicle.
-        elseif self.combineController:isPotatoOrSugarBeetHarvester() then
+        elseif self.combineController:isEarthFruitHarvester() then
             self:debug('Headland turn but this harvester uses normal turn maneuvers.')
             AIDriveStrategyCombineCourse.superClass().startTurn(self, ix)
         elseif self.course:isOnConnectingTrack(ix) then

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -129,7 +129,7 @@ function CombineController:isDroppingStrawSwath()
 end
 
 function CombineController:isEarthFruitHarvester()
-    for _, fruitTypeIndex in pairs(CpUtil.getAllEarthFruits()) do
+    for _, fruitTypeIndex in pairs(CpUtil.getAllRootVegetables()) do
         local fillUnitIndex = g_fruitTypeManager:getFillTypeIndexByFruitTypeIndex(fruitTypeIndex)
         self:debug("check if fruitType %s is supported", g_fillTypeManager:getFillTypeNameByIndex(fillUnitIndex))
         for i, _ in ipairs(self.implement:getFillUnits()) do

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -131,6 +131,7 @@ end
 function CombineController:isEarthFruitHarvester()
     for _, fruitTypeIndex in pairs(CpUtil.getAllEarthFruits()) do
         local fillUnitIndex = g_fruitTypeManager:getFillTypeIndexByFruitTypeIndex(fruitTypeIndex)
+        self:debug(string.format("check if fruitType %s is supported", g_fillTypeManager:getFillTypeNameByIndex(fillUnitIndex)))
         for i, _ in ipairs(self.implement:getFillUnits()) do
             if self.implement:getFillUnitSupportsFillType(i, fillUnitIndex) then
                 self:debug('This is a earth fruit harvester.')

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -128,12 +128,14 @@ function CombineController:isDroppingStrawSwath()
     return self.combineSpec.strawPSenabled
 end
 
-function CombineController:isPotatoOrSugarBeetHarvester()
-    for i, fillUnit in ipairs(self.implement:getFillUnits()) do
-        if self.implement:getFillUnitSupportsFillType(i, FillType.POTATO) or
-                self.implement:getFillUnitSupportsFillType(i, FillType.SUGARBEET) then
-            self:debug('This is a potato or sugar beet harvester.')
-            return true
+function CombineController:isEarthFruitHarvester()
+    for _, fruitTypeIndex in pairs(CpUtil.getAllEarthFruits()) do
+        local fillUnitIndex = g_fruitTypeManager:getFillTypeIndexByFruitTypeIndex(fruitTypeIndex)
+        for i, _ in ipairs(self.implement:getFillUnits()) do
+            if self.implement:getFillUnitSupportsFillType(i, fillUnitIndex) then
+                self:debug('This is a earth fruit harvester.')
+                return true
+            end
         end
     end
     return false

--- a/scripts/ai/controllers/CombineController.lua
+++ b/scripts/ai/controllers/CombineController.lua
@@ -131,7 +131,7 @@ end
 function CombineController:isEarthFruitHarvester()
     for _, fruitTypeIndex in pairs(CpUtil.getAllEarthFruits()) do
         local fillUnitIndex = g_fruitTypeManager:getFillTypeIndexByFruitTypeIndex(fruitTypeIndex)
-        self:debug(string.format("check if fruitType %s is supported", g_fillTypeManager:getFillTypeNameByIndex(fillUnitIndex)))
+        self:debug("check if fruitType %s is supported", g_fillTypeManager:getFillTypeNameByIndex(fillUnitIndex))
         for i, _ in ipairs(self.implement:getFillUnits()) do
             if self.implement:getFillUnitSupportsFillType(i, fillUnitIndex) then
                 self:debug('This is a earth fruit harvester.')


### PR DESCRIPTION
Removed the old implementation with hardcoded fruit type checks. how searches all earth fruits and checks if at least one of them is supported. 

A earth fruit is defined by having a preparation entry in the xml file. The only exception to this definition is Sugarcane since it needs fruit preparing but is logially no earth fruit. This condition is checked in the seach.

Improvments of this PR:
- More Future proof and dynamically recognizion of earth fruits as long as giants sticks with fruit preparation
- now the self driving harvester of dewulf does turn properly

Things that still could be improved:
- Make chopper wait before turning to unload completly. This could be done to make turning a smooth movement without the unloader driving under the pipe all the time