### PR TITLE
fix: combine unloader end of row

### DIFF
--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1505,8 +1505,13 @@ function AIDriveStrategyUnloadCombine:unloadMovingCombine()
         -- when the combine is turning just don't move
         self:setMaxSpeed(0)
     elseif self.followCourse:isTurnStartAtIx(self.followCourse:getCurrentWaypointIx()) then
-        -- big rigs may reach the turn before the combine, do not attempt to follow the turn, just wait.
-        self:setMaxSpeed(0)
+        -- big rigs may reach the turn before the combine, add a small straight course here so we have
+        -- something to follow until the combine reaches the turn (so we don't try to make the turn
+        -- also apply an offset as the followCourse is assumed to be the combine's course
+        -- TODO: #3029
+        self.followCourse = Course.createStraightForwardCourse(self.vehicle, 20, -self.combineOffset)
+        self.followCourse:setOffset(-self.combineOffset, 0)
+        self:startCourse(self.followCourse, 1)
     elseif not self:isBehindAndAlignedToCombine() and not self:isInFrontAndAlignedToMovingCombine() then
         -- call these again just to log the reason
         self:isBehindAndAlignedToCombine(true)

--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1501,8 +1501,11 @@ function AIDriveStrategyUnloadCombine:unloadMovingCombine()
         return
     end
 
-    -- when the combine is turning just don't move
     if self.combineToUnload:getCpDriveStrategy():isManeuvering() then
+        -- when the combine is turning just don't move
+        self:setMaxSpeed(0)
+    elseif self.followCourse:isTurnStartAtIx(self.followCourse:getCurrentWaypointIx()) then
+        -- big rigs may reach the turn before the combine, do not attempt to follow the turn, just wait.
         self:setMaxSpeed(0)
     elseif not self:isBehindAndAlignedToCombine() and not self:isInFrontAndAlignedToMovingCombine() then
         -- call these again just to log the reason


### PR DESCRIPTION
Big rigs may reach the turn before the combine,
do not attempt to follow the turn, just stop.

#3052