### PR TITLE
Combine pre call option

### DIFF
--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -831,11 +831,11 @@
 		</Translation>
 			<Translation name="CP_vehicle_setting_callUnloaderPercent_title">
 			<Text language="de"><![CDATA[Brief vor dem Anruf]]></Text>
-			<Text language="en"><![CDATA[Pre call level]]></Text>
+			<Text language="en"><![CDATA[Unloader call level]]></Text>
 		</Translation>
 		<Translation name="CP_vehicle_setting_callUnloaderPercent_tooltip">
 			<Text language="de"><![CDATA[Loader-Aufruf oberhalb des eingestellten Levels.]]></Text>
-			<Text language="en"><![CDATA[Loader call above set level.]]></Text>
+			<Text language="en"><![CDATA[Call unloader when the harvester fill level is above this limit.]]></Text>
 		</Translation>
 		<Translation name="CP_vehicle_setting_strawSwath_onlyCenter">
 			<Text language="de"><![CDATA[Vorgewende deaktiviert]]></Text>

--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -829,6 +829,14 @@
 			<Text language="de"><![CDATA[Strohablage an, aus oder nur im Vorgewende aus.]]></Text>
 			<Text language="en"><![CDATA[Enables/disables straw swath or only disables it on headlands.]]></Text>
 		</Translation>
+			<Translation name="CP_vehicle_setting_callUnloaderPercent_title">
+			<Text language="de"><![CDATA[Brief vor dem Anruf]]></Text>
+			<Text language="en"><![CDATA[Pre call level]]></Text>
+		</Translation>
+		<Translation name="CP_vehicle_setting_callUnloaderPercent_tooltip">
+			<Text language="de"><![CDATA[Loader-Aufruf oberhalb des eingestellten Levels.]]></Text>
+			<Text language="en"><![CDATA[Loader call above set level.]]></Text>
+		</Translation>
 		<Translation name="CP_vehicle_setting_strawSwath_onlyCenter">
 			<Text language="de"><![CDATA[Vorgewende deaktiviert]]></Text>
 			<Text language="en"><![CDATA[Headlands disabled]]></Text>

--- a/config/MasterTranslations.xml
+++ b/config/MasterTranslations.xml
@@ -830,12 +830,12 @@
 			<Text language="en"><![CDATA[Enables/disables straw swath or only disables it on headlands.]]></Text>
 		</Translation>
 			<Translation name="CP_vehicle_setting_callUnloaderPercent_title">
-			<Text language="de"><![CDATA[Brief vor dem Anruf]]></Text>
-			<Text language="en"><![CDATA[Unloader call level]]></Text>
+			<Text language="de"><![CDATA[Abfahrer rufen ab]]></Text>
+			<Text language="en"><![CDATA[Call unloader at]]></Text>
 		</Translation>
 		<Translation name="CP_vehicle_setting_callUnloaderPercent_tooltip">
-			<Text language="de"><![CDATA[Loader-Aufruf oberhalb des eingestellten Levels.]]></Text>
-			<Text language="en"><![CDATA[Call unloader when the harvester fill level is above this limit.]]></Text>
+			<Text language="de"><![CDATA[Ruft einen Abfahrer wenn der Füllstand des Ernters über diesen Wert liegt.]]></Text>
+			<Text language="en"><![CDATA[Call unloader when the harvester fill level is above this value.]]></Text>
 		</Translation>
 		<Translation name="CP_vehicle_setting_strawSwath_onlyCenter">
 			<Text language="de"><![CDATA[Vorgewende deaktiviert]]></Text>

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -95,6 +95,8 @@
 		<Setting classType="AIParameterBooleanSetting" name="selfUnload"/>
 		<!--Unload on first Headland-->
 		<Setting classType="AIParameterBooleanSetting" name="unloadOnFirstHeadland" defaultBool="false" isExpertModeOnly="true"/>
+		<!--UnloadLevel-->
+		<Setting classType="AIParameterSettingList" name="callUnloaderPercent" min="0" max="100" incremental="5" default ="80" unit="4" isExpertModeOnly="false"/>
 		<!--Strawswath-->
 		<Setting classType="AIParameterSettingList" name="strawSwath" default="2">
 			<Values>

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -96,7 +96,7 @@
 		<!--Unload on first Headland-->
 		<Setting classType="AIParameterBooleanSetting" name="unloadOnFirstHeadland" defaultBool="false" isExpertModeOnly="true"/>
 		<!--UnloadLevel-->
-		<Setting classType="AIParameterSettingList" name="callUnloaderPercent" min="5" max="100" incremental="5" default ="80" unit="4" isExpertModeOnly="false"/>
+		<Setting classType="AIParameterSettingList" name="callUnloaderPercent" min="60" max="90" incremental="5" default ="80" unit="4" isExpertModeOnly="false"/>
 		<!--Strawswath-->
 		<Setting classType="AIParameterSettingList" name="strawSwath" default="2">
 			<Values>

--- a/config/VehicleSettingsSetup.xml
+++ b/config/VehicleSettingsSetup.xml
@@ -96,7 +96,7 @@
 		<!--Unload on first Headland-->
 		<Setting classType="AIParameterBooleanSetting" name="unloadOnFirstHeadland" defaultBool="false" isExpertModeOnly="true"/>
 		<!--UnloadLevel-->
-		<Setting classType="AIParameterSettingList" name="callUnloaderPercent" min="0" max="100" incremental="5" default ="80" unit="4" isExpertModeOnly="false"/>
+		<Setting classType="AIParameterSettingList" name="callUnloaderPercent" min="5" max="100" incremental="5" default ="80" unit="4" isExpertModeOnly="false"/>
 		<!--Strawswath-->
 		<Setting classType="AIParameterSettingList" name="strawSwath" default="2">
 			<Values>

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -103,7 +103,6 @@ function AIDriveStrategyCombineCourse:init(task, job)
         }
     })
 
-    -- TODO: move this to a setting
     self.callUnloaderAtFillLevelPercentage = 80
 end
 
@@ -722,6 +721,7 @@ function AIDriveStrategyCombineCourse:estimateDistanceUntilFull(ix)
     end
     local litersUntilFull = capacity - fillLevel
     local dUntilFull = litersUntilFull / self.litersPerMeter
+    self.callUnloaderAtFillLevelPercentage = self.settings.callUnloaderPercent:getValue()
     local litersUntilCallUnloader = capacity * self.callUnloaderAtFillLevelPercentage / 100 - fillLevel
     local dUntilCallUnloader = litersUntilCallUnloader / self.litersPerMeter
     self.waypointIxWhenFull = self.course:getNextWaypointIxWithinDistance(ix, dUntilFull) or self.course:getNumberOfWaypoints()

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -102,8 +102,6 @@ function AIDriveStrategyCombineCourse:init(task, job)
             [self.states.WAITING_FOR_UNLOAD_IN_POCKET] = true
         }
     })
-
-    self.callUnloaderAtFillLevelPercentage = 80
 end
 
 function AIDriveStrategyCombineCourse:getStateAsString()
@@ -721,14 +719,13 @@ function AIDriveStrategyCombineCourse:estimateDistanceUntilFull(ix)
     end
     local litersUntilFull = capacity - fillLevel
     local dUntilFull = litersUntilFull / self.litersPerMeter
-    self.callUnloaderAtFillLevelPercentage = self.settings.callUnloaderPercent:getValue()
-    local litersUntilCallUnloader = capacity * self.callUnloaderAtFillLevelPercentage / 100 - fillLevel
+    local litersUntilCallUnloader = capacity * self.settings.callUnloaderPercent:getValue() / 100 - fillLevel
     local dUntilCallUnloader = litersUntilCallUnloader / self.litersPerMeter
     self.waypointIxWhenFull = self.course:getNextWaypointIxWithinDistance(ix, dUntilFull) or self.course:getNumberOfWaypoints()
     local wpDistance
     self.waypointIxWhenCallUnloader, wpDistance = self.course:getNextWaypointIxWithinDistance(ix, dUntilCallUnloader)
     self:debug('Will be full at waypoint %d, fill level %d at waypoint %d (current waypoint %d), %.1f m and %.1f l until call (currently %.1f l), wp distance %.1f',
-            self.waypointIxWhenFull or -1, self.callUnloaderAtFillLevelPercentage, self.waypointIxWhenCallUnloader or -1,
+            self.waypointIxWhenFull or -1, self.settings.callUnloaderPercent:getValue(), self.waypointIxWhenCallUnloader or -1,
             self.course:getCurrentWaypointIx(), dUntilCallUnloader, litersUntilCallUnloader, fillLevel, wpDistance)
 end
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -255,6 +255,8 @@
     <text name="CP_vehicle_setting_unloadOnFirstHeadland_tooltip" text="A kombájn az első fordulóban hívja a kirakodót."/>
     <text name="CP_vehicle_setting_strawSwath_title" text="Szalma rendrakás"/>
     <text name="CP_vehicle_setting_strawSwath_tooltip" text="Engedélyezi/letiltja a szalma rendet, vagy csak a táblavégeken tiltja le."/>
+    <text name="CP_vehicle_setting_callUnloaderPercent_title" text="Hívás előtti szint"/>
+    <text name="CP_vehicle_setting_callUnloaderPercent_tooltip" text="Rakodó hívása a beállított szint felett."/>
     <text name="CP_vehicle_setting_strawSwath_onlyCenter" text="Tiltás a fordulósávon"/>
     <!---->
     <!--Course generator settings-->


### PR DESCRIPTION
A new vehicle setting option is the combine’s filling level, which determines when to call the unloading car. Other language files are missing, Hungarian is ready