### PR TITLE
fix: bale finder retry logic

### DIFF
--- a/scripts/ai/AIDriveStrategyBunkerSilo.lua
+++ b/scripts/ai/AIDriveStrategyBunkerSilo.lua
@@ -573,7 +573,7 @@ end
 ---@param lastContext PathfinderContext
 ---@param wasLastRetry boolean
 ---@param currentRetryAttempt number
-function AIDriveStrategyBunkerSilo:onPathfindingRetry(controller, 
+function AIDriveStrategyBunkerSilo:onPathfindingFailed(controller,
     lastContext, wasLastRetry, currentRetryAttempt)
     --- TODO: Think of possible points of failures, that could be adjusted here.
     ---       Maybe a small reverse course might help to avoid a deadlock

--- a/scripts/ai/AIDriveStrategyCourse.lua
+++ b/scripts/ai/AIDriveStrategyCourse.lua
@@ -124,7 +124,7 @@ function AIDriveStrategyCourse:setAIVehicle(vehicle, jobParameters)
     self.turningRadius = AIUtil.getTurningRadius(vehicle)
 
     self.pathfinderController = PathfinderController(vehicle, self.turningRadius)
-    self.pathfinderController:registerListeners(self, self.onPathfindingFinished, self.onPathfindingRetry)
+    self.pathfinderController:registerListeners(self, self.onPathfindingFinished, self.onPathfindingFailed)
 
     self:setAllStaticParameters()
 
@@ -611,7 +611,7 @@ end
 ---@param lastContext PathfinderContext
 ---@param wasLastRetry boolean
 ---@param currentRetryAttempt number
-function AIDriveStrategyCourse:onPathfindingRetry(controller, lastContext, wasLastRetry, currentRetryAttempt)
+function AIDriveStrategyCourse:onPathfindingFailed(controller, lastContext, wasLastRetry, currentRetryAttempt)
     -- override
 end
 

--- a/scripts/ai/AIDriveStrategyFindBales.lua
+++ b/scripts/ai/AIDriveStrategyFindBales.lua
@@ -393,8 +393,8 @@ function AIDriveStrategyFindBales:startPathfindingToBale(bale)
     self.state = self.states.DRIVING_TO_NEXT_BALE
     g_baleToCollectManager:lockBale(bale:getBaleObject(), self)
     local context = PathfinderContext(self.vehicle):objectsToIgnore(self:getBalesToIgnore()):allowReverse(false)
-    self.pathfinderController:findPathToGoal(context, self:getPathfinderBaleTargetAsGoalNode(bale), 3)
     self.lastPathfinderBaleTarget = bale
+    self.pathfinderController:findPathToGoal(context, self:getPathfinderBaleTargetAsGoalNode(bale), 3)
 end
 
 function AIDriveStrategyFindBales:startReversing()
@@ -407,7 +407,7 @@ function AIDriveStrategyFindBales:isObstacleAhead()
     -- then a more thorough check, we want to ignore the last bale we worked on as that may lay around too close
     -- to the baler. This happens for example to the Andersen bale wrapper.
     self:debug('Check obstacles ahead, ignoring %d bale object, first is %s', #objectsToIgnore, objectsToIgnore[1] or 'nil')
-    AIDriveStrategyCourse.isObstacleAhead(self, objectsToIgnore)
+    return AIDriveStrategyCourse.isObstacleAhead(self, objectsToIgnore)
 end
 
 function AIDriveStrategyFindBales:isNearFieldEdge()

--- a/scripts/ai/AIDriveStrategyFindBales.lua
+++ b/scripts/ai/AIDriveStrategyFindBales.lua
@@ -241,7 +241,7 @@ function AIDriveStrategyFindBales:findClosestBale(bales, baleToIgnore)
     local closestBale, minDistance, ix = nil, math.huge, 1
     local invalidBales = 0
     for i, bale in ipairs(bales) do
-        if bale:isStillValid() and bale ~= baleToIgnore then
+        if bale:isStillValid() then
             local _, _, _, d = bale:getPositionInfoFromNode(self.vehicle:getAIDirectionNode())
             self:debug('%d. bale (%d, %s) in %.1f m', i, bale:getId(), bale:getBaleObject(), d)
             if d < self.turningRadius * 4 then
@@ -251,9 +251,13 @@ function AIDriveStrategyFindBales:findClosestBale(bales, baleToIgnore)
                 self:debug('    Dubins length is %.1f m', d)
             end
             if d < minDistance then
-                closestBale = bale
-                minDistance = d
-                ix = i
+                if bale ~= baleToIgnore then
+                    closestBale = bale
+                    minDistance = d
+                    ix = i
+                else
+                    self:debug('    IGNORED')
+                end
             end
         else
             --- When a bale gets wrapped it changes its identity and the node becomes invalid. This can happen

--- a/scripts/ai/AIDriveStrategyFindBales.lua
+++ b/scripts/ai/AIDriveStrategyFindBales.lua
@@ -323,12 +323,12 @@ function AIDriveStrategyFindBales:onPathfindingFinished(controller,
     success, course, goalNodeInvalid)
     if self.state == self.states.DRIVING_TO_NEXT_BALE then
         if success then
-            self.triedReversing = false
+            self.triedReversingAfterPathfinderFailure = false
             self.balesTried = {}
             self:startCourse(course, 1)
         else
             g_baleToCollectManager:unlockBalesByDriver(self)
-            if #self.balesTried < 3 then
+            if #self.balesTried < 3 and #self.bales > #self.balesTried then
                 if goalNodeInvalid then
                     -- there may be another bale too close to the previous one
                     self:debug('Finding path to next bale failed, goal node invalid.')
@@ -341,9 +341,9 @@ function AIDriveStrategyFindBales:onPathfindingFinished(controller,
                     self:debug('Finding path to next bale failed, but we are not too close to the field edge')
                     self:retryPathfindingWithAnotherBale()
                 end
-            elseif not self.triedReversing then
-                self:info('Pathfinding failed three times, back up a bit and try again')
-                self.triedReversing = true
+            elseif not self.triedReversingAfterPathfinderFailure then
+                self:info('Pathfinding failed three times or no more bales to try, back up a bit and try again')
+                self.triedReversingAfterPathfinderFailure = true
                 self.balesTried = {}
                 self:startReversing()
             else

--- a/scripts/ai/AIDriveStrategyShovelSiloLoader.lua
+++ b/scripts/ai/AIDriveStrategyShovelSiloLoader.lua
@@ -578,7 +578,7 @@ end
 ---@param lastContext PathfinderContext
 ---@param wasLastRetry boolean
 ---@param currentRetryAttempt number
-function AIDriveStrategyShovelSiloLoader:onPathfindingRetry(controller, 
+function AIDriveStrategyShovelSiloLoader:onPathfindingFailed(controller,
     lastContext, wasLastRetry, currentRetryAttempt)
     --- TODO: Think of possible points of failures, that could be adjusted here.
     ---       Maybe a small reverse course might help to avoid a deadlock

--- a/scripts/ai/AIDriveStrategySiloLoader.lua
+++ b/scripts/ai/AIDriveStrategySiloLoader.lua
@@ -282,7 +282,7 @@ end
 ---@param lastContext PathfinderContext
 ---@param wasLastRetry boolean
 ---@param currentRetryAttempt number
-function AIDriveStrategySiloLoader:onPathfindingRetry(controller, 
+function AIDriveStrategySiloLoader:onPathfindingFailed(controller,
     lastContext, wasLastRetry, currentRetryAttempt)
     --- TODO: Think of possible points of failures, that could be adjusted here.
     ---       Maybe a small reverse course might help to avoid a deadlock

--- a/scripts/ai/BaleToCollect.lua
+++ b/scripts/ai/BaleToCollect.lua
@@ -69,7 +69,7 @@ function BaleToCollect.isValidBale(object, baleWrapper, baleLoader, baleWrapType
 end
 
 function BaleToCollect:isStillValid()
-	return BaleToCollect.isValidBale(self.bale)
+	return BaleToCollect.isValidBale(self.bale) and not self:isLocked()
 end
 
 function BaleToCollect:isLoaded()
@@ -104,6 +104,10 @@ end
 
 function BaleToCollect:getBaleObject()
 	return self.bale
+end
+
+function BaleToCollect:isLocked()
+	return not g_baleToCollectManager:isValidBale(self.bale)
 end
 
 function BaleToCollect:getPosition()


### PR DESCRIPTION
Retry with another bale if the pathfinding fails with invalid goal, meaning there is likely another bale near the target.