### PR TITLE
Might help with #3098

### DIFF
--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1509,7 +1509,7 @@ function AIDriveStrategyUnloadCombine:onPathfindingFailed(giveUpFunc, controller
         controller:retry(lastContext)
     elseif currentRetryAttempt == 2 then
         self:debug('Second attempt to find path failed, trying with reduced off-field penalty and fruit percent')
-        lastContext:maxFruitPercent(self:getMaxFruitPercent() / 2):offFieldPenalty(PathfinderContext.defaultOffFieldPenalty / 2)
+        lastContext:maxFruitPercent(self:getMaxFruitPercent() / 2):offFieldPenalty(PathfinderContext.defaultOffFieldPenalty / 2):ignoreFruitHeaps()
         controller:retry(lastContext)
     elseif currentRetryAttempt == 3 then
         self:debug('Third attempt to find path failed, trying with reduced off-field penalty and no fruit avoidance')

--- a/scripts/ai/controllers/PipeController.lua
+++ b/scripts/ai/controllers/PipeController.lua
@@ -9,6 +9,7 @@ PipeController.PIPE_STATE_MOVING = 0
 PipeController.PIPE_STATE_CLOSED = 1
 PipeController.PIPE_STATE_OPEN = 2
 PipeController.moveablePipeHeightOffset = 1 --- Offset to the calculated pipe height.
+PipeController.unloadingToGroundSpeed = 3
 
 function PipeController:init(vehicle, implement, isConsoleCommand)
     self.isConsoleCommand = isConsoleCommand
@@ -35,9 +36,8 @@ function PipeController:getDriveData()
     local maxSpeed
     if self.isDischargingToGround then
         if self.isDischargingTimer:get() then
-            --- Waiting until the discharging stopped or 
-            --- the trailer is empty and the folding animation is playing.
-            maxSpeed = 0
+            --- Slows down the driver while unloading
+            maxSpeed = self.unloadingToGroundSpeed
             self:debugSparse("Waiting for unloading!")
         end
         if self.implement:getIsAIPreparingToDrive() or self:isPipeMoving() then


### PR DESCRIPTION
Disables the pathfinder fruit on the ground constraint after the second fail. #3098 