### PR TITLE
Config open pipe early

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -629,6 +629,7 @@ You can define the following custom settings:
     <Vehicle name="premos5000.xml"
 			 disablePipeMovingToolCorrection = "true"
 			 unloadOffsetX = "-3.56"
+             openPipeEarly = "true"
     />
 
 	<!--Mod: FS22_lizardHTB6000-->

--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -149,6 +149,10 @@ You can define the following custom settings:
     shorter for some implements, especially big plows turn on the spot and align
     better with the next row without tight turn offset.
 
+- openPipeEalry: boolean
+    This will open the pipe of a combine before reaching the trailer.
+    This is useful for combines with a pipe that folds up from below.
+
 -->
 <VehicleConfigurations>
 	<Configurations>
@@ -178,6 +182,7 @@ You can define the following custom settings:
 		<Configuration type="INT">childPipeMovingToolIndex</Configuration>
 		<Configuration type="FLOAT">unloadOffsetX</Configuration>
         <Configuration type="FLOAT">tightTurnOffsetDistanceInTurns</Configuration>
+        <Configuration type="BOOL">openPipeEalry</Configuration>
 	</Configurations>
     <!--[GIANTS]-->
 
@@ -205,7 +210,7 @@ You can define the following custom settings:
 
     <!-- Implements -->
 
-    <!--\vehicles\<bednar-->
+    <!--\vehicles\bednar-->
     <Vehicle name="terraland"
              noReverse = "true"
     />
@@ -253,6 +258,7 @@ You can define the following custom settings:
     <!--\vehicles\grimme-->
     <Vehicle name="rootster604.xml"
              noReverse = "true"
+             openPipeEarly = "true"
     />
     <Vehicle name="SE260.xml"
              toolOffsetX = "-1.8"

--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -149,9 +149,10 @@ You can define the following custom settings:
     shorter for some implements, especially big plows turn on the spot and align
     better with the next row without tight turn offset.
 
-- openPipeEalry: boolean
-    This will open the pipe of a combine before reaching the trailer.
-    This is useful for combines with a pipe that folds up from below.
+- openPipeEarly: boolean
+    This will open the pipe of a harvester early while approaching a trailer for self unloading.
+    This is useful for combines with a pipe that folds up from below, making sure by the time the harvester
+    reaches the trailer, the pipe is already open.
 
 -->
 <VehicleConfigurations>
@@ -182,7 +183,7 @@ You can define the following custom settings:
 		<Configuration type="INT">childPipeMovingToolIndex</Configuration>
 		<Configuration type="FLOAT">unloadOffsetX</Configuration>
         <Configuration type="FLOAT">tightTurnOffsetDistanceInTurns</Configuration>
-        <Configuration type="BOOL">openPipeEalry</Configuration>
+        <Configuration type="BOOL">openPipeEarly</Configuration>
 	</Configurations>
     <!--[GIANTS]-->
 

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -90,6 +90,8 @@ function AIDriveStrategyCombineCourse:init(task, job)
     -- periodically check if we need to call an unloader
     self.timeToCallUnloader = CpTemporaryObject(true)
     self.unloaderRequestedToIgnoreProximity = CpTemporaryObject()
+    -- we want to keep to pipe open, even if there is no trailer under it
+    self.forcePipeOpen = CpTemporaryObject()
 
     --- Register info texts
     self:registerInfoTextForStates(self:getFillLevelInfoText(), {
@@ -393,14 +395,19 @@ function AIDriveStrategyCombineCourse:driveUnloadOnField()
                 self:changeToFieldWork()
             end
         end
-    elseif self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED or
-            self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD or
-            self.unloadState == self.states.DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW then
+    elseif self:isUnloadStateOneOf(self.drivingToSelfUnloadStates) then
         if self:isCloseToCourseEnd(25) then
             -- slow down towards the end of the course, near the trailer
-            self:setMaxSpeed(0.5 * self.settings.fieldSpeed:getValue())
+            self:setMaxSpeed(math.max(10, 0.5 * self.settings.fieldSpeed:getValue()))
             -- we'll be very close to the tractor/trailer, don't stop too soon
             self.proximityController:setTemporaryStopThreshold(self.proximityStopThresholdSelfUnload, 3000)
+            if g_vehicleConfigurations:getRecursively(self.vehicle, 'openPipeEarly') then
+                if not self.pipeController:isPipeOpen() then
+                    self:debug('Opening pipe early to not crash it into the trailer')
+                    self.pipeController:openPipe()
+                end
+                self.forcePipeOpen:set(true, 1000)
+            end
         else
             self:setMaxSpeed(self.settings.fieldSpeed:getValue())
         end
@@ -1470,7 +1477,12 @@ function AIDriveStrategyCombineCourse:handleCombinePipe(dt)
     if self:isAGoodTrailerInRange() or self:isAutoDriveWaitingForPipe() then
         self.pipeController:openPipe()
     else
-        self.pipeController:closePipe(true)
+        if not self.forcePipeOpen:get() then
+            -- when driving to self unload, we may open the pipe well before reaching the trailer to avoid
+            -- banging it into the trailer. This is configurable, and needed for harvester opening their pipe
+            -- upwards
+            self.pipeController:closePipe(true)
+        end
     end
 end
 
@@ -1865,6 +1877,11 @@ function AIDriveStrategyCombineCourse:initUnloadStates()
         self.states.SELF_UNLOADING_AFTER_FIELDWORK_ENDED,
         self.states.SELF_UNLOADING_AFTER_FIELDWORK_ENDED_WAITING_FOR_DISCHARGE,
         self.states.RETURNING_FROM_SELF_UNLOAD
+    }
+    self.drivingToSelfUnloadStates = {
+        self.states.DRIVING_TO_SELF_UNLOAD,
+        self.states.DRIVING_TO_SELF_UNLOAD_AFTER_FIELDWORK_ENDED,
+        self.states.DRIVING_TO_SELF_UNLOAD_BEFORE_NEXT_ROW,
     }
 end
 

--- a/scripts/ai/AIDriveStrategyCombineCourse.lua
+++ b/scripts/ai/AIDriveStrategyCombineCourse.lua
@@ -398,7 +398,7 @@ function AIDriveStrategyCombineCourse:driveUnloadOnField()
     elseif self:isUnloadStateOneOf(self.drivingToSelfUnloadStates) then
         if self:isCloseToCourseEnd(25) then
             -- slow down towards the end of the course, near the trailer
-            self:setMaxSpeed(math.max(10, 0.5 * self.settings.fieldSpeed:getValue()))
+            self:setMaxSpeed(math.min(10, 0.5 * self.settings.fieldSpeed:getValue()))
             -- we'll be very close to the tractor/trailer, don't stop too soon
             self.proximityController:setTemporaryStopThreshold(self.proximityStopThresholdSelfUnload, 3000)
             if g_vehicleConfigurations:getRecursively(self.vehicle, 'openPipeEarly') then


### PR DESCRIPTION
Harvesters driving to self unload can be configured to open the pipe before the trailer is in range to avoid bumping the pipe into the trailer.