### PR TITLE
Pathfinder goal node fix

### DIFF
--- a/scripts/ai/AIDriveStrategyFindBales.lua
+++ b/scripts/ai/AIDriveStrategyFindBales.lua
@@ -335,7 +335,7 @@ function AIDriveStrategyFindBales:onPathfindingFinished(controller,
             self:startCourse(course, 1)
         else
             g_baleToCollectManager:unlockBalesByDriver(self)
-            if #self.balesTried < 3 and #self.bales > #self.balesTried then
+            if #self.balesTried < 5 and #self.bales > #self.balesTried then
                 if goalNodeInvalid then
                     -- there may be another bale too close to the previous one
                     self:debug('Finding path to next bale failed, goal node invalid.')
@@ -348,11 +348,6 @@ function AIDriveStrategyFindBales:onPathfindingFinished(controller,
                     self:debug('Finding path to next bale failed, but we are not too close to the field edge')
                     self:retryPathfindingWithAnotherBale()
                 end
-            elseif not self.triedReversingAfterPathfinderFailure then
-                self:info('Pathfinding failed three times or no more bales to try, back up a bit and try again')
-                self.triedReversingAfterPathfinderFailure = true
-                self.balesTried = {}
-                self:startReversing(self.states.REVERSING_AFTER_PATHFINDER_FAILURE)
             else
                 self:info('Pathfinding failed three times, giving up')
                 self.vehicle:stopCurrentAIJob(AIMessageCpErrorNoPathFound.new())

--- a/scripts/ai/AIDriveStrategyFindBales.lua
+++ b/scripts/ai/AIDriveStrategyFindBales.lua
@@ -186,7 +186,6 @@ function AIDriveStrategyFindBales:setAllStaticParameters()
     self.balesTried = {}
     -- when everything fails, reverse and try again. This is reset only when a pathfinding succeeds to avoid
     -- backing up forever
-    self.triedReversingAfterPathfinderFailure = false
     self.numBalesLeftOver = 0
 end
 
@@ -330,7 +329,6 @@ function AIDriveStrategyFindBales:onPathfindingFinished(controller,
     success, course, goalNodeInvalid)
     if self.state == self.states.DRIVING_TO_NEXT_BALE then
         if success then
-            self.triedReversingAfterPathfinderFailure = false
             self.balesTried = {}
             self:startCourse(course, 1)
         else
@@ -349,7 +347,8 @@ function AIDriveStrategyFindBales:onPathfindingFinished(controller,
                     self:retryPathfindingWithAnotherBale()
                 end
             else
-                self:info('Pathfinding failed three times, giving up')
+                self.balesTried = {}
+                self:info('Pathfinding failed five times, giving up')
                 self.vehicle:stopCurrentAIJob(AIMessageCpErrorNoPathFound.new())
             end
         end
@@ -396,6 +395,7 @@ end
 
 function AIDriveStrategyFindBales:onPathfindingObstacleAtStart(controller, lastContext, maxDistance, trailerCollisionsOnly)
     g_baleToCollectManager:unlockBalesByDriver(self)
+    self.balesTried = {}
     self:debug('Pathfinding detected obstacle at start, back up and retry')
     self:startReversing(self.states.REVERSING_DUE_TO_OBSTACLE_AHEAD)
 end

--- a/scripts/ai/PathfinderController.lua
+++ b/scripts/ai/PathfinderController.lua
@@ -174,7 +174,7 @@ function PathfinderController:start(context, numRetries, pathfinderCall)
 end
 
 function PathfinderController:handleFailedPathfinding(result)
-    if self.callbackObstacleAtStartFunction and
+    if self.callbackObstacleAtStartFunction and not result.goalNodeInvalid and
             result.maxDistance < (self.currentContext._obstacleAtStartRange or (1.5 * self.turningRadius)) then
         -- pathfinder failed before getting further than the range in the context, or, if not given,
         -- further than the default of 1.5 radius, which is approximately the length of a quarter circle.


### PR DESCRIPTION
Different bale loader fixes.
PathfinderController calls obstacle at start callback only if the goal node is not invalid (since an invalid goal node is not an obstacle at start).
Only reverse if there is an obstacle ahead, if pathfinding fails due to an invalid goal node, try again up to 5 times with different bales.