### PR TITLE
fix: pathfinder return value on failure

### DIFF
--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1522,12 +1522,18 @@ function AIDriveStrategyUnloadCombine:onPathfindingObstacleAtStart(controller, l
 end
 
 function AIDriveStrategyUnloadCombine:onPathfindingFailed(giveUpFunc, controller, lastContext, wasLastRetry,
-                                                          currentRetryAttempt)
+                                                          currentRetryAttempt, trailerCollisionsOnly,
+                                                          fruitPenaltyNodePercent, offFieldPenaltyNodePercent)
     if wasLastRetry then
         giveUpFunc()
     elseif currentRetryAttempt == 1 then
-        self:debug('First attempt to find path failed, trying with reduced off-field penalty')
-        lastContext:offFieldPenalty(PathfinderContext.defaultOffFieldPenalty / 2)
+        if fruitPenaltyNodePercent > offFieldPenaltyNodePercent then
+            self:debug('First attempt to find path failed, trying with reduced fruit percent')
+            lastContext:maxFruitPercent(self:getMaxFruitPercent() / 2)
+        else
+            self:debug('First attempt to find path failed, trying with reduced off-field penalty')
+            lastContext:offFieldPenalty(PathfinderContext.defaultOffFieldPenalty / 2)
+        end
         controller:retry(lastContext)
     elseif currentRetryAttempt == 2 then
         self:debug('Second attempt to find path failed, trying with reduced off-field penalty and fruit percent')

--- a/scripts/ai/PathfinderController.lua
+++ b/scripts/ai/PathfinderController.lua
@@ -207,10 +207,11 @@ function PathfinderController:handleFailedPathfinding(result)
         --- Retry is allowed, so check if any tries are leftover
         if self.failCount < self.numRetries then
             self:debug("Failed with try %d of %d.", self.failCount, self.numRetries)
-            --- Retrying the path finding
+            local wasLastRetry = self.failCount == self.numRetries
             self.failCount = self.failCount + 1
+            --- Let the callback decide what next: retry or give up
             self:callCallback(self.callbackFailedFunction,
-                    self.currentContext, self.failCount == self.numRetries, self.failCount, false,
+                    self.currentContext, wasLastRetry, self.failCount, false,
                     result.fruitPenaltyNodePercent, result.offFieldPenaltyNodePercent)
             return
         elseif self.numRetries > 0 then

--- a/scripts/ai/PathfinderController.lua
+++ b/scripts/ai/PathfinderController.lua
@@ -210,7 +210,8 @@ function PathfinderController:handleFailedPathfinding(result)
             --- Retrying the path finding
             self.failCount = self.failCount + 1
             self:callCallback(self.callbackFailedFunction,
-                    self.currentContext, self.failCount == self.numRetries, self.failCount, false)
+                    self.currentContext, self.failCount == self.numRetries, self.failCount, false,
+                    result.fruitPenaltyNodePercent, result.offFieldPenaltyNodePercent)
             return
         elseif self.numRetries > 0 then
             self:debug("Max number of retries already reached!")

--- a/scripts/ai/PathfinderController.lua
+++ b/scripts/ai/PathfinderController.lua
@@ -62,9 +62,10 @@ function Strategy:onPathfindingFinished(controller : PathfinderController, succe
 end
 
 function Strategy:onPathfindingFailed(controller : PathfinderController, currentContext : PathfinderContext,
-	wasLastRetry : boolean, currentRetryAttempt : number)
+	wasLastRetry : boolean, currentRetryAttempt : number, trailerCollisionsOnly : boolean,
+	fruitPenaltyNodePercent : number, offFieldPenaltyNodePercent : number)
 	if currentRetryAttempt == 1 then 
-		// Reduced fruit impact:
+		// try whatever has better chances:
 		currentContext:ignoreFruit()
 		self.pathfinderController:findPathToNode(currentContext, ...)
 	else 
@@ -72,6 +73,20 @@ function Strategy:onPathfindingFailed(controller : PathfinderController, current
 		self.pathfinderController:findPathToNode(currentContext, ...)
 	end
 end
+
+
+function onPathfindingObstacleAtStart(controller, lastContext, maxDistance,
+                                      trailerCollisionsOnly, fruitPenaltyNodePercent, offFieldPenaltyNodePercent)
+    if trailerCollisionsOnly then
+        self:debug('Pathfinding detected obstacle at start, trailer collisions only, retry with ignoring the trailer')
+        lastContext:ignoreTrailerAtStartRange(1.5 * self.turningRadius)
+        controller:retry(lastContext)
+    else
+        self:debug('Pathfinding detected obstacle at start, back up and retry')
+        self:startMovingBackBeforePathfinding(controller, lastContext)
+    end
+end
+
 ]]
 
 ---@class DefaultFieldPathfinderControllerContext : PathfinderContext
@@ -141,12 +156,18 @@ end
 --- TODO: Decide if multiple registered listeners are needed or not?
 ---@param object table
 ---@param successFunc function func(PathfinderController, success, Course, goalNodeInvalid)
----@param failedFunc function func(PathfinderController, last context, was last retry, retry attempt number)
----@param obstacleAtStartFunc function|nil func(PathfinderController, last context, maxDistance, trailerCollisionsOnly),
+---@param failedFunc function
+---func(PathfinderController, last context, was last retry, retry attempt number, trailerCollisionsOnly, fruitPenaltyNodePercent, offFieldPenaltyNodePercent)
+---@param obstacleAtStartFunc function|nil
+--- func(PathfinderController, last context, maxDistance, trailerCollisionsOnly, fruitPenaltyNodePercent, offFieldPenaltyNodePercent),
 --- called when the pathfinding failed within maxDistance (there is an obstacle ahead of the vehicle) so it can't even
 --- start driving anywhere forward. In this case pathfinding makes no sense. No check if no callback is registered.
+---
 --- trailerCollisionsOnly will be set to true if there were no other collisions other then between the trailer and
 --- some other obstacle.
+---
+--- fruitPenaltyNodePercent and offFieldPenaltyNodePercent can be used to determine the most likely reason the pathfinding
+--- failed, returning the percent of nodes with fruit/off-field penalty (of total nodes searched)
 function PathfinderController:registerListeners(object, successFunc, failedFunc, obstacleAtStartFunc)
     self.callbackObject = object
     self.callbackSuccessFunction = successFunc

--- a/scripts/pathfinder/HybridAStar.lua
+++ b/scripts/pathfinder/HybridAStar.lua
@@ -800,7 +800,8 @@ function HybridAStarWithAStarInTheMiddle:resume(...)
         elseif self.phase == self.MIDDLE then
             self.constraints:resetStrictMode()
             if not path then
-                return PathfinderResult(true, nil, goalNodeInvalid)
+                return PathfinderResult(true, nil, goalNodeInvalid,
+                        self.currentPathfinder.nodes.highestDistance, self.constraints:trailerCollisionsOnly())
             end
             local lMiddlePath = HybridAStar.length(path)
             self:debug('Direct path is %d m', lMiddlePath)
@@ -813,7 +814,8 @@ function HybridAStarWithAStarInTheMiddle:resume(...)
             HybridAStar.shortenStart(self.middlePath, self.hybridRange)
             HybridAStar.shortenEnd(self.middlePath, self.hybridRange)
             if #self.middlePath < 2 then
-                return PathfinderResult(true, nil)
+                return PathfinderResult(true, nil, goalNodeInvalid,
+                        self.currentPathfinder.nodes.highestDistance, self.constraints:trailerCollisionsOnly())
             end
             State3D.smooth(self.middlePath)
             State3D.setAllHeadings(self.middlePath)
@@ -850,13 +852,13 @@ function HybridAStarWithAStarInTheMiddle:resume(...)
                     table.insert(self.path, path[i])
                 end
                 State3D.smooth(self.path)
+                self.constraints:showStatistics()
+                return PathfinderResult(true, self.path)
             else
                 self:debug('middle to end: no path found')
                 return PathfinderResult(true, nil, goalNodeInvalid,
                         self.currentPathfinder.nodes.highestDistance, self.constraints:trailerCollisionsOnly())
             end
-            self.constraints:showStatistics()
-            return PathfinderResult(true, self.path)
         end
     end
     return PathfinderResult(false)

--- a/scripts/pathfinder/PathfinderConstraints.lua
+++ b/scripts/pathfinder/PathfinderConstraints.lua
@@ -216,6 +216,14 @@ function PathfinderConstraints:trailerCollisionsOnly()
     return self.trailerCollisionNodeCount > 0 and self.collisionNodeCount == self.trailerCollisionNodeCount
 end
 
+function PathfinderConstraints:getFruitPenaltyNodePercent()
+    return self.totalNodeCount > 0 and (self.fruitPenaltyNodeCount / self.totalNodeCount) or 0
+end
+
+function PathfinderConstraints:getOffFieldPenaltyNodePercent()
+    return self.totalNodeCount > 0 and (self.offFieldPenaltyNodeCount / self.totalNodeCount) or 0
+end
+
 function PathfinderConstraints:debug(...)
     self.vehicleData:debug(...)
 end


### PR DESCRIPTION
Always fill in all fields of PathfinderReturn on failure to avoid false positives for object in front (and thus reversing)

#3242