### PR TITLE
fix: fruit penalty reduction

### DIFF
--- a/scripts/ai/AIDriveStrategyUnloadCombine.lua
+++ b/scripts/ai/AIDriveStrategyUnloadCombine.lua
@@ -1530,22 +1530,23 @@ function AIDriveStrategyUnloadCombine:onPathfindingFailed(giveUpFunc, controller
                                                           currentRetryAttempt, trailerCollisionsOnly,
                                                           fruitPenaltyNodePercent, offFieldPenaltyNodePercent)
     -- first, apply 70% of the original penalty, second retry: 40% and last one: 10%
-    local relaxingSteps = {0.7, 0.4, 0.1}
+    local offFieldPenaltyRelaxingSteps = { 0.7, 0.4, 0.1}
+    local fruitPenaltyRelaxingSteps = { 2, 4, 8 }
     if wasLastRetry then
         giveUpFunc()
     elseif currentRetryAttempt < 3 then
         if fruitPenaltyNodePercent > offFieldPenaltyNodePercent then
-            self:debug('%d. attempt to find path failed, trying with reduced fruit percent', currentRetryAttempt)
-            lastContext:maxFruitPercent(relaxingSteps[currentRetryAttempt] * self:getMaxFruitPercent())
+            self:debug('%d. attempt to find path failed, trying with reduced fruit penalty', currentRetryAttempt)
+            lastContext:maxFruitPercent(fruitPenaltyRelaxingSteps[currentRetryAttempt] * self:getMaxFruitPercent())
         else
             self:debug('%d. attempt to find path failed, trying with reduced off-field penalty', currentRetryAttempt)
-            lastContext:offFieldPenalty(relaxingSteps[currentRetryAttempt] * PathfinderContext.defaultOffFieldPenalty)
+            lastContext:offFieldPenalty(offFieldPenaltyRelaxingSteps[currentRetryAttempt] * PathfinderContext.defaultOffFieldPenalty)
         end
         controller:retry(lastContext)
     elseif currentRetryAttempt == 3 then
         self:debug('Last attempt to find path failed, trying off-field penalty and fruit avoidance disabled')
         -- On the last try, only disable off-field penalty and keep a bit fruit penalty
-        lastContext:maxFruitPercent(relaxingSteps[currentRetryAttempt] * self:getMaxFruitPercent()):offFieldPenalty(0)
+        lastContext:maxFruitPercent(fruitPenaltyRelaxingSteps[currentRetryAttempt] * self:getMaxFruitPercent()):offFieldPenalty(0)
         controller:retry(lastContext)
     else
         giveUpFunc()

--- a/scripts/pathfinder/PathfinderUtil.lua
+++ b/scripts/pathfinder/PathfinderUtil.lua
@@ -363,7 +363,11 @@ end
 
 PathfinderUtil.collisionDetector = PathfinderUtil.CollisionDetector()
 
+--- Is there harvestable fruit at x, z?
 ---@param areaToIgnoreFruit PathfinderUtil.Area|nil
+---@return boolean true if there's fruit in the length * width area around x, z
+---@return number percentage of area covered by fruit
+---@return string name of fruit
 function PathfinderUtil.hasFruit(x, z, length, width, areaToIgnoreFruit)
     if areaToIgnoreFruit and areaToIgnoreFruit:contains(x, z) then
         return false
@@ -379,12 +383,12 @@ function PathfinderUtil.hasFruit(x, z, length, width, areaToIgnoreFruit)
         end
         if not ignoreThis then
             -- if the last boolean parameter is true then it returns fruitValue > 0 for fruits/states ready for forage also
-            local fruitValue, a, b, c = FSDensityMapUtil.getFruitArea(fruitType.index, x - width / 2, z - length / 2, x + width / 2, z, x, z + length / 2, true, true)
+            local fruitValue, numPixels, totalNumPixels, c = FSDensityMapUtil.getFruitArea(fruitType.index, x - width / 2, z - length / 2, x + width / 2, z, x, z + length / 2, true, true)
             --if g_updateLoopIndex % 200 == 0 then
             --CpUtil.debugFormat(CpDebug.DBG_PATHFINDER, '%.1f, %s, %s, %s %s', fruitValue, tostring(a), tostring(b), tostring(c), g_fruitTypeManager:getFruitTypeByIndex(fruitType.index).name)
             --end
             if fruitValue > 0 then
-                return true, fruitValue, g_fruitTypeManager:getFruitTypeByIndex(fruitType.index).name
+                return true, 100 * numPixels / totalNumPixels, g_fruitTypeManager:getFruitTypeByIndex(fruitType.index).name
             end
         end
     end


### PR DESCRIPTION
maxFruitPercent is the maximum percentage of area covered by fruit for a given tile, and thus, it must be
_increased_ to reduce the fruit penalty, not decreased.