### PR TITLE
fix: headland transition

### DIFF
--- a/scripts/courseGenerator/Headland.lua
+++ b/scripts/courseGenerator/Headland.lua
@@ -194,7 +194,13 @@ function Headland:connectTo(other, ix, workingWidth, turningRadius, headlandFirs
                 self.logger:warning('Generated path to next headland too long (%.1f > %.1f), try %d.',
                         length, maxPlausiblePathLength, i)
             end
-            transitionEndIx = transitionEndIx + 1
+            if 0.8 * radius > turningRadius then
+                radius = 0.8 * radius
+                self.logger:debug('Transition radius %.1f > turning radius %.1f, reducing transition radius.', radius, turningRadius)
+            else
+                transitionEndIx = transitionEndIx + 1
+                self.logger:debug('Can\'t generate a proper transition, try a little further.')
+            end
         end
         self.logger:error('Could not connect to next headland after %d tries, giving up', tries)
     else


### PR DESCRIPTION
When the transition can't be made with the high radius derived from the transition angle, but the radius is greater than the vehicle's turn radius, try first reducing the radius to fit in a nice Dubins curve.