### PR TITLE
fix: plow rotation at work start

### DIFF
--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -632,10 +632,18 @@ function Course:getRidgeMarkerState(ix)
     end
 end
 
----@return boolean true if the plow should be rotated to the left side of the course (as the right side was already
---- worked on)
-function Course:getPlowOnLeft(ix)
+function Course:isLeftSideWorked(ix)
     return self.waypoints[ix].attributes:isLeftSideWorked()
+end
+
+---@return boolean true if the next 180 turn is to the left, false if to the right, nil if we don't know
+function Course:isNextTurnLeft(ix)
+    if self.waypoints[ix].nextRowStartIx == nil then
+        return nil
+    else
+        local turnStartWaypointIx = self.waypoints[ix].nextRowStartIx - 1
+        return CpMathUtil.getDeltaAngle(self.waypoints[turnStartWaypointIx].yRot, self.waypoints[turnStartWaypointIx - 1].yRot) < 0
+    end
 end
 
 function Course:getIxRollover(ix)

--- a/scripts/ai/AIDriveStrategyPlowCourse.lua
+++ b/scripts/ai/AIDriveStrategyPlowCourse.lua
@@ -150,7 +150,21 @@ end
 --- Initial plow rotation based on the ridge marker side selection by the course generator.
 function AIDriveStrategyPlowCourse:rotatePlows()
     self:debug('Starting work: check if plow needs to be turned.')
-    local plowShouldBeOnTheLeft = self.course:getPlowOnLeft(self.ppc:getCurrentWaypointIx())
+    -- on the headland just check which side was worked last, on the center, check the direction of the next turn
+    -- as at the first pass both sides are unworked and need some other indication on which side the plow should be
+    local ix = self.ppc:getCurrentWaypointIx()
+    local plowShouldBeOnTheLeft
+    if self.course:isOnHeadland(ix) then
+        plowShouldBeOnTheLeft = self.course:isLeftSideWorked(ix)
+    else
+        local isNextTurnLeft = self.course:isNextTurnLeft(ix)
+        if isNextTurnLeft == nil then
+            -- don't know if left or right, so just use the last worked side
+            plowShouldBeOnTheLeft = self.course:isLeftSideWorked(ix)
+        else
+            plowShouldBeOnTheLeft = not isNextTurnLeft
+        end
+    end
     self:debug('Plow should be on the left %s', tostring(plowShouldBeOnTheLeft))
     for _, controller in pairs(self.controllers) do 
         if controller.rotate then 

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -1016,6 +1016,8 @@ function StartRowOnly:getDriveData()
                 TurnManeuver.LOWER_IMPLEMENT_AT_TURN_END) then
             self.state = self.states.APPROACHING_ROW
             self:debug('Approaching row')
+            self.driveStrategy:raiseControllerEvent(AIDriveStrategyCourse.onTurnEndProgressEvent,
+                    self.turnContext.workStartNode, self.ppc:isReversing(), true, not self.turnContext:isNextTurnLeft())
         end
     elseif self.state == self.states.APPROACHING_ROW then
         local shouldLower, _ = self.driveStrategy:shouldLowerImplements(self.turnContext.workStartNode,

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -276,6 +276,11 @@ function TurnContext:isLeftTurn()
     end
 end
 
+---@return number offset of the turn end in meters forward (>0) or back (<0)
+function TurnContext:getTurnEndForwardOffset()
+    return self.dz
+end
+
 function TurnContext:setTargetNode(node)
     self.targetNode = node
 end

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -331,13 +331,6 @@ function TurnContext:isDirectionPerpendicularToTurnEndDirection(node, thresholdD
     return math.abs(math.atan2(lx, lz)) < math.rad(thresholdDeg or 5)
 end
 
---- An angle of 0 means the headland is perpendicular to the up/down rows
-function TurnContext:getHeadlandAngle()
-    local lx, _, lz = localDirectionToLocal(self.turnEndWpNode.node, self.turnStartWpNode.node, self:isLeftTurn() and -1 or 1, 0, 0)
-    return math.abs(math.atan2(lx, lz))
-end
-
-
 function TurnContext:getAverageEndAngleDeg()
     -- use the average angle of the turn end and the next wp as there is often a bend there
     return math.deg(CpMathUtil.getAverageAngle(math.rad(self.turnEndWp.angle), math.rad(self.afterTurnEndWp.angle)))

--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -89,6 +89,7 @@ function TurnContext:init(vehicle, course, turnStartIx, turnEndIx, turnNodes, wo
 
     self.dx, _, self.dz = localToLocal(self.turnEndWpNode.node, self.workEndNode, 0, 0, 0)
     self.leftTurn = self.dx > 0
+    self.nextTurnLeft = course:isNextTurnLeft(turnEndIx)
     self:debug('start ix = %d, back marker = %.1f, front marker = %.1f',
             turnStartIx, self.backMarkerDistance, self.frontMarkerDistance)
 end
@@ -232,6 +233,10 @@ function TurnContext:getHeadlandAngle()
     return  math.abs(CpMathUtil.getDeltaAngle(math.rad(self.turnEndWp.angle), math.rad(self.turnStartWp.angle)))
 end
 
+function TurnContext:isNextTurnLeft()
+    return self.nextTurnLeft
+end
+
 function TurnContext:isHeadlandCorner()
 	-- in headland turns there's no significant direction change at the turn start waypoint, as the turn end waypoint
 	-- marks the actual corner. In a non-headland turn (usually 180) there is about 90 degrees direction change at
@@ -269,11 +274,6 @@ function TurnContext:isLeftTurn()
     else
         return self.leftTurn
     end
-end
-
----@return number offset of the turn end in meters forward (>0) or back (<0)
-function TurnContext:getTurnEndForwardOffset()
-    return self.dz
 end
 
 function TurnContext:setTargetNode(node)
@@ -325,6 +325,13 @@ function TurnContext:isDirectionPerpendicularToTurnEndDirection(node, thresholdD
     local lx, _, lz = localDirectionToLocal(self.turnEndWpNode.node, node, self:isLeftTurn() and -1 or 1, 0, 0)
     return math.abs(math.atan2(lx, lz)) < math.rad(thresholdDeg or 5)
 end
+
+--- An angle of 0 means the headland is perpendicular to the up/down rows
+function TurnContext:getHeadlandAngle()
+    local lx, _, lz = localDirectionToLocal(self.turnEndWpNode.node, self.turnStartWpNode.node, self:isLeftTurn() and -1 or 1, 0, 0)
+    return math.abs(math.atan2(lx, lz))
+end
+
 
 function TurnContext:getAverageEndAngleDeg()
     -- use the average angle of the turn end and the next wp as there is often a bend there


### PR DESCRIPTION
Rotate the plow to the left if:
- on a headland pass and the left side is already worked
- on a center pass and the next 180 turn is to the right