### PR TITLE
fix: reverse at turn end

### DIFF
--- a/config/VehicleConfigurations.xml
+++ b/config/VehicleConfigurations.xml
@@ -554,6 +554,8 @@ You can define the following custom settings:
              turnRadius = "7.5"
              implementWheelAlwaysOnGround = "true"
 			 workingWidth = "10.5"
+             raiseLate = "true"
+             lowerEarly = "true"
     />
     <!--Mod: KOECKERLING Vector 460-->
 	<Vehicle name="vector460.xml"

--- a/scripts/Course.lua
+++ b/scripts/Course.lua
@@ -1324,9 +1324,10 @@ function Course:getSectionAsNewCourse(startIx, endIx, reverse, allAttributes)
 end
 
 --- @param node number the node around we are looking for waypoints
+--- @param startIx number|nil start looking for waypoints at this index
 --- @return number, number, number, number the waypoint closest to node, its distance, the waypoint closest to the node
 --- pointing approximately (+-45) in the same direction as the node and its distance
-function Course:getNearestWaypoints(node)
+function Course:getNearestWaypoints(node, startIx)
     local nx, _, nz = getWorldTranslation(node)
     local lx, _, lz = localDirectionToWorld(node, 0, 0, 1)
     local nodeAngle = math.atan2(lx, lz)
@@ -1334,7 +1335,8 @@ function Course:getNearestWaypoints(node)
     local dClosest, dClosestRightDirection = math.huge, math.huge
     local ixClosest, ixClosestRightDirection = 1, 1
 
-    for i, p in ipairs(self.waypoints) do
+    for i = startIx or 1, #self.waypoints do
+        local p = self.waypoints[i]
         local x, _, z = self:getWaypointPosition(i)
         local d = MathUtil.getPointPointDistance(x, z, nx, nz)
         if d < dClosest then

--- a/scripts/ai/turns/AITurn.lua
+++ b/scripts/ai/turns/AITurn.lua
@@ -663,7 +663,11 @@ function CourseTurn:changeDirectionWhenAligned()
             local nextDirectionChangeIx = self.turnCourse:getNextDirectionChangeFromIx(self.turnCourse:getCurrentWaypointIx())
             if nextDirectionChangeIx then
                 self:debug('skipping to next direction change at %d', nextDirectionChangeIx + 1)
-                self.ppc:initialize(nextDirectionChangeIx + 1)
+                if self.turnCourse:isReverseAt(nextDirectionChangeIx + 1) then
+                    self.ppc:initializeForReversing(nextDirectionChangeIx + 1)
+                else
+                    self.ppc:initialize(nextDirectionChangeIx + 1)
+                end
             end
         end
     end


### PR DESCRIPTION
When a turn needs to be moved back to fit on the field, it ends with a straight reversing section to back the implement up to the work start point. The actual start of this section depends on when the implement was aligned with the row.

The generated start point of this reversing section however, at this point, may lay well behind the implement's reversing node, and this will result the PPC stuck in initializing mode and the vehicle reversing forever, since it is moving further and further away from the start point.

So, when changing to reverse, do not initialize to the first reverse waypoint, instead, find the one closest to the implement's reverser node.