### PR TITLE
fix: multitool headland turn

### DIFF
--- a/scripts/ai/turns/TurnContext.lua
+++ b/scripts/ai/turns/TurnContext.lua
@@ -243,6 +243,7 @@ function TurnContext:isHeadlandCorner()
 	-- both the turn start and end waypoints
     -- a turn is a headland turn only when there is minimal direction change at the turn start and the total direction
     -- change is less than 150 degrees
+    -- TODO: consider using course:isHeadlandTurnAtIx() instead as with the current generator, we know the turn type
 	return math.abs(CpMathUtil.getDeltaAngle(math.rad(self.turnStartWp.angle), math.rad(self.beforeTurnStartWp.angle))) < (math.pi / 6) and
             math.abs( self.directionChangeDeg ) < 150
 end


### PR DESCRIPTION
In Course:enrichWaypointData(), always use the non-offset position of the waypoints. This fixes issues when rerunning enrichWaypointData() on a course with offset.

Also, it wasn't correct in the first place, this is a chicken-egg problem, since the offset calculation is based on the dx/dz values which at the first run of enrichWaypointData() are not known as they are calculated by enrichWaypointData().