### PR TITLE
fix: recovery turn logic

### DIFF
--- a/scripts/CpObject.lua
+++ b/scripts/CpObject.lua
@@ -125,9 +125,9 @@ end
 
 --- Set temporary value for object
 ---@param value any the temporary value
----@param expiryMs number for expiryMs milliseconds after startMs, the object will return the value set above,
+---@param expiryMs number|nil for expiryMs milliseconds after startMs, the object will return the value set above,
 --- valueWhenExpired otherwise. When nil, it'll remain value forever
----@param startMs number after starMs milliseconds from now, the object will return the value set above
+---@param startMs number|nil after starMs milliseconds from now, the object will return the value set above
 --- (for expiryMs milliseconds). When nil, the value is set immediately.
 function CpTemporaryObject:set(value, expiryMs, startMs)
 	self.value = value

--- a/scripts/ai/ProximityController.lua
+++ b/scripts/ai/ProximityController.lua
@@ -207,6 +207,7 @@ function ProximityController:getDriveData(maxSpeed, moveForwards)
                 -- have been blocked by an object long enough
                 CpUtil.debugVehicle(CpDebug.DBG_TRAFFIC, self.vehicle, 'An object has been blocking us for a while at %.1f m', d)
                 self:onBlockingObject(not moveForwards)
+                self.blockingObject:set(false, nil, nil)
             elseif not self.blockingObject:isPending() then
                 -- first time we are being blocked
                 CpUtil.debugVehicle(CpDebug.DBG_TRAFFIC, self.vehicle, 'An object blocking us at %.1f m', d)


### PR DESCRIPTION
Also, proximity controller calls the blocked object listener once only, then restarts the timer.

#3512